### PR TITLE
Add Windows support to file locking

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -424,9 +424,12 @@ def atomic_directory(target_dir, exclusive, source=None):
                 # a blocking lock, but it only tries 10 times, once per second before rasing an
                 # OSError.
                 try:
-                    msvcrt.locking(lock_fd, msvcrt.LK_NBLCK, 1)
+                    msvcrt.locking(lock_fd, msvcrt.LK_LOCK, 1)
                     break
-                except OSError:
+                except OSError as ex:
+                    # Deadlock error is raised after failing to lock the file
+                    if ex.errno != errno.EDEADLOCK:
+                        raise
                     safe_sleep(1)
         else:
             fcntl.lockf(lock_fd, fcntl.LOCK_EX)  # A blocking write lock.


### PR DESCRIPTION
While this project does not officially support Windows, it was compatible with `1.x.x` versions of this package, and there's minimal changes necessary to restore that functionality in future `2.x.x` versions as well. The only noticeable incompatibility at the moment is  around the use of `fcntl` for file locking, which is not available in Windows (`msvcrt` is the alternative), which was discussed in https://github.com/pantsbuild/pex/issues/1155. This PR adds logic to choose the correct package for file locking based on what platform is being used.

I was able to successfully build and test a `.pex` file on Windows 10 after making this change. As noted [here](https://docs.python.org/3/library/os.html#os.symlink), a user will need to build the `.pex` as an Administrator, Developer Mode, or enable the `SeCreateSymbolicLinkPrivilege` privilege in order for symlinking to occur correctly.