### PR TITLE
consume packed wheel cache in zipapp creation

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -164,8 +164,23 @@ def configure_clp_pex_options(parser):
         ),
     )
 
-    # TODO: avoid caching at all for --no-compress, since the cache entries are so large and the
-    # performance improvement is so slim.
+    group.add_argument(
+        "--cache-dists",
+        "--no-cache-dists",
+        dest="cache_dists",
+        default=None,
+        action=HandleBoolAction,
+        help=(
+            "Whether to zip up each dist contained in the output PEX file into a fingerprinted "
+            "cache directory to speed up later PEX file builds. For `--layout packed`, this "
+            "behavior is enabled by default. "
+            "For `--layout zipapp`, this synthesizes the zip file from those cached zips with an "
+            "experimental zip merging technique, so this flag is disabled by default when building "
+            "a zipapp. This will re-use the same caches as `--layout packed`, so creating a "
+            "zipapp or packed PEX file from the same inputs will only populate the cache once. "
+            "This flag and behavior do not apply to other layouts."
+        ),
+    )
     group.add_argument(
         "--compress",
         "--compressed",
@@ -961,6 +976,7 @@ def do_main(
             deterministic_timestamp=not options.use_system_time,
             layout=options.layout,
             compress=options.compress,
+            cache_dists=options.cache_dists,
         )
         if options.seed != Seed.NONE:
             seed_info = seed_cache(

--- a/pex/common.py
+++ b/pex/common.py
@@ -219,7 +219,7 @@ class PermPreservingZipFile(zipfile.ZipFile, object):
             arcname += "/"
         if date_time is None:
             date_time = time.localtime(st.st_mtime)
-        zinfo = zipfile.ZipInfo(filename=arcname, date_time=cast(_DateTime, date_time[:6]))
+        zinfo = zipfile.ZipInfo(filename=arcname, date_time=cast("_DateTime", date_time[:6]))
         zinfo.external_attr = (st.st_mode & 0xFFFF) << 16  # Unix attributes
         if isdir:
             zinfo.file_size = 0
@@ -659,7 +659,7 @@ class Chroot(object):
     # https://github.com/pantsbuild/pex/issues/2158 and https://github.com/pantsbuild/pex/pull/2175.
     def zip(
         self,
-        output_file,  # type: Union[str, io.IOBase]
+        output_file,  # type: Union[str, io.IOBase, io.BufferedRandom]
         mode="w",  # type: str
         deterministic_timestamp=False,  # type: bool
         exclude_file=lambda _: False,  # type: Callable[[str], bool]

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -869,10 +869,10 @@ class PEXBuilder(object):
                 #     computation, because the compressed entries are simply copied over as-is.
                 #
                 #     Note that these cached zips are created in the --layout packed format, without
-                #     the .bootstrap/ or .deps/ prefixes we need to form a proper zipapp. Our zip
-                #     file merging solution edits each entry's .filename with the appropriate
-                #     prefix, but we will still need to generate intermediate directory entries
-                #     before adding the prefixed files in order to unzip correctly.
+                #     the .bootstrap/ or .deps/ prefixes we need to form a proper Pex zipapp
+                #     layout. Our zip file merging solution edits each entry's .filename with the
+                #     appropriate prefix, but we will still need to generate intermediate directory
+                #     entries before adding the prefixed files in order to unzip correctly.
 
                 # Reuse the file handle to zip into. This isn't necessary (we could close and reopen
                 # it), but it avoids unnecessarily flushing to disk. The ZipFile class will re-parse
@@ -927,6 +927,5 @@ class PEXBuilder(object):
                         compress=compress,
                         labels=self._DIRECT_SOURCE_LABELS,
                     )
-
 
         chmod_plus_x(filename)


### PR DESCRIPTION
*Closes #2158.*

# Problem
*#1675 has another repro.*

Generating a `--compress --layout zipapp` (the default) regularly exhibits pathologically slow performance **(46s zip / 1m1s total)** on many real-world inputs (especially tensorflow). This occurs even when all dists are already downloaded from pypi:
```bash
; time pex -vvvvvvvvv --layout zipapp --resolver-version=pip-2020-resolver 'numpy>=1.19.5' 'keras==2.4.3' 'mtcnn' 'pillow>=7.0.0' 'bleach>=2.1.0' 'tensorflow-gpu==2.5.3' -o test.pex
# ...
# Saving PEX file to test.pex
# pex: Zipping PEX file.: 45659.1ms
# 57.18s user 3.02s system 97% cpu 1:01.57 total
; ls -lAvFh test.pex
# -rwxrwxr-x 1 cosmicexplorer cosmicexplorer 617M Jul 26 09:17 test.pex*
; du -b test.pex
# 616754775       test.pex
```

## Alternatives

#1705 introduced `--no-compress`, which drastically improves the zip performance **(2.2s zip => 20.6x speedup / 19.3s total = 2.4x speedup)**:
```bash
; time pex -vvvvvvvvv --layout zipapp --no-compress --resolver-version=pip-2020-resolver 'numpy>=1.19.5' 'keras==2.4.3' 'mtcnn' 'pillow>=7.0.0' 'bleach>=2.1.0' 'tensorflow-gpu==2.5.3' -o test.pex
# ...
# Saving PEX file to test.pex
# pex: Zipping PEX file.: 2209.7ms
# pex  14.11s user 3.06s system 89% cpu 19.285 total
```

but as #1686 describes, it also introduces a significant tradeoff in file size **(1.6G => 2.5x blowup)**:
```bash
; ls -lAvFh test.pex
# -rwxrwxr-x 1 cosmicexplorer cosmicexplorer 1.6G Jul 26 09:20 test.pex*
; du -b test.pex
# 1541737605      test.pex
```

The cache entries are also many times larger:
```bash
; ls $(find ~/.pex/packed_wheels -name '*tensorflow_gpu*whl')
# -rw-rw-r-- 1 cosmicexplorer cosmicexplorer 468M Aug  1 09:10 /home/cosmicexplorer/.pex/packed_wheels/7a4763a35d0824ebb172b00f8d0241ff231404c4b7d97dd5ea870d5afca336a4/tensorflow_gpu-2.5.3-cp38-cp38-manylinux2010_x86_64.whl
# -rw-rw-r-- 1 cosmicexplorer cosmicexplorer 1.2G Aug  1 09:16 /home/cosmicexplorer/.pex/packed_wheels/7a4763a35d0824ebb172b00f8d0241ff231404c4b7d97dd5ea870d5afca336a4/un-compressed/tensorflow_gpu-2.5.3-cp38-cp38-manylinux2010_x86_64.whl
```

# Solution
1. Introduce `pex.ziputils.MergeableZipFile` to incorporate the contents of other zip files without decompressing them.
    - Introduce `pex.common.copy_file_range()` to copy over a limited range of the contents of another file handle.
2. Introduce the `--cache-dists` option to toggle the use (and/or creation) of the packed wheel caches for `.bootstrap/` and `.deps/` subdirectories.
3. Consume the existing `--layout packed` caches for `--layout zipapp` when `--cache-dists` is provided.