### PR TITLE
colocate __main__.py with the central directory record of the zipapp

### DIFF
--- a/pex/common.py
+++ b/pex/common.py
@@ -627,11 +627,13 @@ class Chroot(object):
                     # If labels are provided, respect the given ordering, but still sort the files
                     # within each label to get deterministic output.
                     sorted(self.filesets.get(label, ()))
+                    # NB: An iterable of labels with non-deterministic order is not reproducible!
                     for label in labels
                 )
             )
         else:
-            selected_files = OrderedSet(self.files())
+            # Otherwise, sort the files to get reproducible output by default.
+            selected_files = OrderedSet(sorted(self.files()))
 
         compression = zipfile.ZIP_DEFLATED if compress else zipfile.ZIP_STORED
         with open_zip(filename, mode, compression) as zf:

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -719,7 +719,7 @@ class PEXBuilder(object):
     def iter_metadata_labels(cls):
         # type: () -> Iterator[str]
         """``Chroot`` labels covering metadata files."""
-        # PEX-INFO: This is accessed after unpacking the zip.
+        # PEX-INFO
         yield "manifest"
 
     @classmethod
@@ -733,8 +733,8 @@ class PEXBuilder(object):
     def iter_deps_libs_labels(cls, pex_info):
         # type: (PexInfo) -> Iterator[str]
         """``Chroot`` labels covering the third-party code that was resolved into dists."""
-        # Subdirectories of .deps:
-        for dist_label in pex_info.distributions.keys():
+        # Subdirectories of .deps/: Keys need to be sorted for deterministic output.
+        for dist_label in sorted(pex_info.distributions.keys()):
             yield dist_label
 
     @classmethod

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -840,7 +840,7 @@ class PEXBuilder(object):
 
     @classmethod
     def iter_zipapp_labels(cls, pex_info):
-        # type: (PexInof) -> Iterator[str]
+        # type: (PexInfo) -> Iterator[str]
         """User sources, bootstrap sources, metadata, and dependencies, optimized for tail access.
 
         This method returns all the ``Chroot`` labels used by this ``PEXBuilder``. For zipapp

--- a/tests/integration/test_reproducible.py
+++ b/tests/integration/test_reproducible.py
@@ -97,6 +97,9 @@ def assert_reproducible_build(
                     ), "{} and {} have different content.".format(member1, member2)
                 # Check that the entire file is equal, including metadata.
                 assert filecmp.cmp(member1, member2, shallow=False)
+            # Check that the file list is identical.
+            with ZipFile(pex1) as zfp1, ZipFile(pex2) as zfp2:
+                assert zfp1.namelist() == zfp2.namelist()
             # Finally, check that the .pex files are byte-for-byte identical.
             assert filecmp.cmp(pex1, pex2, shallow=False)
 


### PR DESCRIPTION
When the Python interpreter executes a zipapp, it will import `__main__.py`, while `__pex__/__init__.py` will be loaded if the pex file is on the `PYTHONPATH`. This file is loaded from the zip file handle with `zipimport`, and the PEX bootstrap script at that location will then import some of the code in `.bootstrap/` before the zipapp is unpacked and compiled. Because a zip file's central directory records are located at the end of the file, placing this code at the end of the zip file list will reduce the amount of seeking the Python interpreter needs to perform in order to execute the bootstrap script. This was previously discussed in https://github.com/pantsbuild/pex/pull/2175#issuecomment-1665710187 and https://github.com/pantsbuild/pex/pull/2175#issuecomment-1665800458.

Changes involved:
1. Make `Chroot#zip()` respect the relative ordering of labels when collecting from `self.filesets`.
2. Put `"main"` and `"importhook"` labels at the end of the zipapp.