### PR TITLE
Fix PyPI deploy.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Check Packaging
         uses: pantsbuild/actions/run-tox@b16b9cf47cd566acfe217b1dafc5b452e27e6fd7
         with:
-          tox-env: package -- --additional-format sdist --additional-format wheel --embed-docs
+          tox-env: package -- --additional-format sdist --additional-format wheel --embed-docs --clean-docs
       - name: Check Docs
         uses: pantsbuild/actions/run-tox@b16b9cf47cd566acfe217b1dafc5b452e27e6fd7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Build sdist and wheel
         uses: pantsbuild/actions/run-tox@b16b9cf47cd566acfe217b1dafc5b452e27e6fd7
         with:
-          tox-env: package -- --no-pex --additional-format sdist --additional-format wheel --embed-docs
+          tox-env: package -- --no-pex --additional-format sdist --additional-format wheel --embed-docs --clean-docs
       - name: Publish Pex ${{ needs.determine-tag.outputs.release-tag }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/scripts/package.py
+++ b/scripts/package.py
@@ -126,6 +126,7 @@ def main(
     *additional_dist_formats: Format,
     verbosity: int = 0,
     embed_docs: bool = False,
+    clean_docs: bool = False,
     pex_output_file: Optional[Path] = DIST_DIR / "pex",
     serve: bool = False
 ) -> None:
@@ -160,6 +161,9 @@ def main(
         for dist_path in built:
             print(f"  {dist_path}")
 
+    if clean_docs:
+        shutil.rmtree(DIST_DIR / "docs", ignore_errors=True)
+
     if serve:
         server = HTTPServer(("", 0), SimpleHTTPRequestHandler)
         host, port = server.server_address
@@ -183,6 +187,12 @@ if __name__ == "__main__":
         default=False,
         action="store_true",
         help="Embed offline docs in the built binary distributions.",
+    )
+    parser.add_argument(
+        "--clean-docs",
+        default=False,
+        action="store_true",
+        help="Clean up loose generated docs after they have embedded in binary distributions.",
     )
     parser.add_argument(
         "--additional-format",
@@ -216,6 +226,7 @@ if __name__ == "__main__":
         *(args.additional_formats or ()),
         verbosity=args.verbosity,
         embed_docs=args.embed_docs,
+        clean_docs=args.clean_docs,
         pex_output_file=None if args.no_pex else args.pex_output_file,
         serve=args.serve
     )


### PR DESCRIPTION
The v2.1.164 release went smoothly except for the PyPI deploy. I had to
build and deploy manually from the v2.1.164 tag with:
```
$ rm -rf dist/
$ tox -epackage -- \
--additional-format sdist \
--additional-format wheel \
--embed-docs
$ pex twine -c twine -- upload -s dist/*
```

The action wants the dist/ dir to just contain the artifacts to deploy;
no more and no less.