### PR TITLE
Fix tmp dir cleanup.

### DIFF
--- a/scripts/package.py
+++ b/scripts/package.py
@@ -96,8 +96,8 @@ def build_pex_dists(
 ) -> Iterator[PurePath]:
     tmp_dir = DIST_DIR / ".tmp"
     tmp_dir.mkdir(parents=True, exist_ok=True)
+    atexit.register(shutil.rmtree, tmp_dir, ignore_errors=True)
     out_dir = tempfile.mkdtemp(dir=tmp_dir)
-    atexit.register(shutil.rmtree, out_dir, ignore_errors=True)
 
     output = None if verbose else subprocess.DEVNULL
 


### PR DESCRIPTION
The deploy of v2.2.0 failed, much like v2.1.164, due to
`tox -epackage ...` leaving non-PyPI artifacts in the `dist/` dir. This
time the issue was `dist/.tmp`. Fix cleanup of this tmp dir and,
finally, fix the PyPI deploy in the release process.