### PR TITLE
Fix release ordering of the doc site deploy.

### DIFF
--- a/.github/workflows/doc-site.yml
+++ b/.github/workflows/doc-site.yml
@@ -1,8 +1,7 @@
 name: Deploy Doc Site
 on:
-  push:
-    tags:
-      - v[0-9]+.[0-9]+.[0-9]+
+  repository_dispatch:
+    types: [release-docs]
   workflow_dispatch:
 
 permissions:
@@ -21,8 +20,14 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout Pex
-        uses: actions/checkout@v3
+      - name: Checkout Pex (for release-docs event)
+        uses: actions/checkout@v4
+        if: github.event_name == 'repository_dispatch'
+        with:
+          ref: ${{ github.event.client_payload.ref }}
+      - name: Checkout Pex (for manual workflow dispatch)
+        uses: actions/checkout@v4
+        if: github.event_name == 'workflow_dispatch'
       - name: Setup Python 3.11
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,3 +109,19 @@ jobs:
             dist/docs/pdf/pex.pdf
           fail_on_unmatched_files: true
           discussion_category_name: Announcements
+  deploy-docsite:
+    name: Trigger Deploy Doc Site
+    needs:
+      - determine-tag
+      - pypi
+      - github-release
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Dispatch `release-docs` Event
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          event-type: release-docs
+          client-payload: |-
+            {
+              "ref": "${{ github.ref }}"
+            }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## 2.2.1
+
+This release trims down the size of the Pex wheel on PyPI and the
+released Pex PEX by about 20KB by consolidating image resources.
+
+This release also fixes the release process to remove a window of time
+when several links would be dead on at https://docs.pex-tool.org that
+pointed to release artifacts that were not yet fully deployed.
+
+* Fix release ordering of the doc site deploy. (#2369)
+* Trim embedded doc image assets. (#2368)
+
 ## 2.2.0
 
 This release adds tools to interact with Pex's new embedded offline

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"


### PR DESCRIPTION
This keeps the workflow separate to allow for manual doc site deployment
in PR forks and adds a gather step to the release that triggers that
workflow by dispatching an event at the tail of the release process.