### PR TITLE
Handle `.tar.bz2` & `.tgz` sdists when locking.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 2.2.2
+
+This release fixes `pex3 lock create` to handle `.tar.bz2` and `.tgz`
+sdists in addition to the officially sanctioned `.tar.gz` and (less
+officially so) `.zip` sdists.
+
+# Handle `.tar.bz2` & `.tgz` sdists when locking. (#2380)
+
 ## 2.2.1
 
 This release trims down the size of the Pex wheel on PyPI and the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ This release fixes `pex3 lock create` to handle `.tar.bz2` and `.tgz`
 sdists in addition to the officially sanctioned `.tar.gz` and (less
 officially so) `.zip` sdists.
 
-# Handle `.tar.bz2` & `.tgz` sdists when locking. (#2380)
+* Handle `.tar.bz2` & `.tgz` sdists when locking. (#2380)
 
 ## 2.2.1
 

--- a/pex/pip/tool.py
+++ b/pex/pip/tool.py
@@ -259,22 +259,27 @@ class Pip(object):
             else ResolverVersion.default()
         )
 
-    @classmethod
     def _calculate_resolver_version_args(
-        cls,
+        self,
         interpreter,  # type: PythonInterpreter
         package_index_configuration=None,  # type: Optional[PackageIndexConfiguration]
     ):
         # type: (...) -> Iterator[str]
-        resolver_version = cls._calculate_resolver_version(
+        resolver_version = self._calculate_resolver_version(
             package_index_configuration=package_index_configuration
         )
         # N.B.: The pip default resolver depends on the python it is invoked with. For Python 2.7
         # Pip defaults to the legacy resolver and for Python 3 Pip defaults to the 2020 resolver.
         # Further, Pip warns when you do not use the default resolver version for the interpreter
         # in play. To both avoid warnings and set the correct resolver version, we need
-        # to only set the resolver version when it's not the default for the interpreter in play:
-        if resolver_version == ResolverVersion.PIP_2020 and interpreter.version[0] == 2:
+        # to only set the resolver version when it's not the default for the interpreter in play.
+        # As an added constraint, the 2020-resolver feature was removed and made default in the
+        # Pip 22.3 release.
+        if (
+            resolver_version == ResolverVersion.PIP_2020
+            and interpreter.version[0] == 2
+            and self.version.version < PipVersion.v22_3.version
+        ):
             yield "--use-feature"
             yield "2020-resolver"
         elif resolver_version == ResolverVersion.PIP_LEGACY and interpreter.version[0] == 3:

--- a/pex/pip/tool.py
+++ b/pex/pip/tool.py
@@ -247,7 +247,7 @@ class Pip(object):
     _PATCHES_PACKAGE_NAME = "_pex_pip_patches"
 
     _pip = attr.ib()  # type: PipVenv
-    _version = attr.ib()  # type: PipVersionValue
+    version = attr.ib()  # type: PipVersionValue
     _pip_cache = attr.ib()  # type: str
 
     @staticmethod
@@ -599,7 +599,7 @@ class Pip(object):
             if not atomic_dir.is_finalized():
                 self.spawn_download_distributions(
                     download_dir=atomic_dir.work_dir,
-                    requirements=[self._version.wheel_requirement],
+                    requirements=[self.version.wheel_requirement],
                     package_index_configuration=package_index_configuration,
                     build_configuration=BuildConfiguration.create(allow_builds=False),
                 ).wait()
@@ -617,7 +617,7 @@ class Pip(object):
     ):
         # type: (...) -> Job
 
-        if self._version is PipVersion.VENDORED:
+        if self.version is PipVersion.VENDORED:
             self._ensure_wheel_installed(package_index_configuration=package_index_configuration)
 
         wheel_cmd = ["wheel", "--no-deps", "--wheel-dir", wheel_dir]

--- a/pex/resolve/lockfile/create.py
+++ b/pex/resolve/lockfile/create.py
@@ -154,10 +154,10 @@ def _prepare_project_directory(build_request):
         return target, project
 
     extract_dir = os.path.join(safe_mkdtemp(), "project")
-    if project.endswith(".zip"):
+    if FileArtifact.is_zip_sdist(project):
         with open_zip(project) as zf:
             zf.extractall(extract_dir)
-    elif project.endswith(".tar.gz"):
+    elif FileArtifact.is_tar_sdist(project):
         with tarfile.open(project) as tf:
             tf.extractall(extract_dir)
     else:

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.2.1"
+__version__ = "2.2.2"

--- a/tests/integration/test_issue_2739.py
+++ b/tests/integration/test_issue_2739.py
@@ -1,0 +1,60 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+import subprocess
+
+from pex.pep_440 import Version
+from pex.pep_503 import ProjectName
+from pex.resolve.locked_resolve import FileArtifact
+from pex.resolve.lockfile import json_codec
+from pex.resolve.resolved_requirement import Pin
+from pex.typing import TYPE_CHECKING
+from testing import run_pex_command
+from testing.cli import run_pex3
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_tar_bz2(tmpdir):
+    # type: (Any) -> None
+
+    lock = os.path.join(str(tmpdir), "lock.json")
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    run_pex3(
+        "lock",
+        "create",
+        "--pex-root",
+        pex_root,
+        "python-constraint==1.4.0",
+        "-o",
+        lock,
+        "--indent",
+        "2",
+    ).assert_success()
+
+    lock_file = json_codec.load(lock)
+    assert len(lock_file.locked_resolves) == 1
+
+    locked_resolve = lock_file.locked_resolves[0]
+    assert len(locked_resolve.locked_requirements) == 1
+
+    locked_requirement = locked_resolve.locked_requirements[0]
+    assert Pin(ProjectName("python-constraint"), Version("1.4.0")) == locked_requirement.pin
+    assert isinstance(locked_requirement.artifact, FileArtifact)
+    assert locked_requirement.artifact.is_source
+    assert locked_requirement.artifact.filename.endswith(".tar.bz2")
+    assert not locked_requirement.additional_artifacts
+
+    pex = os.path.join(str(tmpdir), "pex")
+    run_pex_command(
+        args=["--pex-root", pex_root, "--runtime-pex-root", pex_root, "--lock", lock, "-o", pex]
+    ).assert_success()
+
+    assert (
+        b"1.4.0"
+        == subprocess.check_output(
+            args=[pex, "-c", "from constraint.version import __version__; print(__version__)"]
+        ).strip()
+    )

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -184,6 +184,7 @@ def assert_download_platform_markers_issue_1366(
         requirements=["typing_extensions==3.7.4.2; python_version < '3.8'"],
         download_dir=download_dir,
         transitive=False,
+        package_index_configuration=package_index_configuration(pip.version),
     ).wait()
 
     assert ["typing_extensions-3.7.4.2-py2-none-any.whl"] == os.listdir(download_dir)


### PR DESCRIPTION
More generally, investigate what is out there (on PyPI) for sdists and
explicitly admit `.zip`, `.tar.gz`, `.tar.bz2` and `.tgz` as covering
99.999% of all known cases.

Fixes #2379