### PR TITLE
Fix CI bitrot breaks.

### DIFF
--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -120,7 +120,7 @@ else:
 
 
 if PY3:
-    from urllib import parse as urlparse
+    from urllib import parse as _url_parse
     from urllib.error import HTTPError as HTTPError
     from urllib.parse import quote as _url_quote
     from urllib.parse import unquote as _url_unquote
@@ -136,7 +136,7 @@ else:
     from urllib import quote as _url_quote
     from urllib import unquote as _url_unquote
 
-    import urlparse as urlparse
+    import urlparse as _url_parse
     from urllib2 import FileHandler as FileHandler
     from urllib2 import HTTPBasicAuthHandler as HTTPBasicAuthHandler
     from urllib2 import HTTPDigestAuthHandler as HTTPDigestAuthHandler
@@ -147,8 +147,10 @@ else:
     from urllib2 import Request as Request
     from urllib2 import build_opener as build_opener
 
+urlparse = _url_parse
 url_unquote = _url_unquote
 url_quote = _url_quote
+del _url_parse, _url_unquote, _url_quote
 
 if PY3:
     from queue import Queue as Queue

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -106,15 +106,18 @@ def test_no_duplicate_constraints_pex_warnings(
     )
 
 
-def package_index_configuration(pip_version):
-    # type: (PipVersionValue) -> Optional[PackageIndexConfiguration]
+def package_index_configuration(
+    pip_version,  # type: PipVersionValue
+    use_pip_config=False,  # type: bool
+):
+    # type: (...) -> Optional[PackageIndexConfiguration]
     if pip_version is PipVersion.v23_2:
         # N.B.: Pip 23.2 has a bug handling PEP-658 metadata with the legacy resolver; so we use the
         # 2020 resolver to work around. See: https://github.com/pypa/pip/issues/12156
         return PackageIndexConfiguration.create(
-            pip_version, resolver_version=ResolverVersion.PIP_2020
+            pip_version, resolver_version=ResolverVersion.PIP_2020, use_pip_config=use_pip_config
         )
-    return None
+    return PackageIndexConfiguration.create(use_pip_config=use_pip_config)
 
 
 @pytest.mark.skipif(
@@ -293,7 +296,9 @@ def test_create_confounding_env_vars_issue_1668(
 
     download_dir = os.path.join(str(tmpdir), "downloads")
     create_pip(None, version=version, PEX_SCRIPT="pex3").spawn_download_distributions(
-        requirements=["ansicolors==1.1.8"], download_dir=download_dir
+        requirements=["ansicolors==1.1.8"],
+        download_dir=download_dir,
+        package_index_configuration=package_index_configuration(version),
     ).wait()
     assert ["ansicolors-1.1.8-py2.py3-none-any.whl"] == os.listdir(download_dir)
 
@@ -353,18 +358,19 @@ def test_use_pip_config(
     with ENV.patch(PIP_PYTHON_VERSION="invalid") as env, environment_as(**env):
         assert "invalid" == os.environ["PIP_PYTHON_VERSION"]
         job = pip.spawn_download_distributions(
-            download_dir=download_dir, requirements=["ansicolors==1.1.8"]
+            download_dir=download_dir,
+            requirements=["ansicolors==1.1.8"],
+            package_index_configuration=package_index_configuration(version),
         )
         assert "--isolated" in job._command
         job.wait()
         assert ["ansicolors-1.1.8-py2.py3-none-any.whl"] == os.listdir(download_dir)
 
         shutil.rmtree(download_dir)
-        package_index_configuration = PackageIndexConfiguration.create(use_pip_config=True)
         job = pip.spawn_download_distributions(
             download_dir=download_dir,
             requirements=["ansicolors==1.1.8"],
-            package_index_configuration=package_index_configuration,
+            package_index_configuration=package_index_configuration(version, use_pip_config=True),
         )
         assert "--isolated" not in job._command
         with pytest.raises(Job.Error) as exc:

--- a/tox.ini
+++ b/tox.ini
@@ -123,20 +123,28 @@ commands =
 deps =
     # This version should track the version in pex/vendor/__init__.py.
     attrs @ git+https://github.com/python-attrs/attrs@947bfb542104209a587280701d8cb389c813459d
+    httpx==0.23.0
+
+    # We pin at 0.971 since this is the last version of mypy that supports `--python-version 2.7`.
+    mypy[python2]==0.971
     packaging==20.9  # This version should track the lowest version in pex/vendor/__init__.py.
-    toml==0.10.2  # This version should track the version in pex/vendor/__init__.py.
     pip==20.3.4  # This version should track the version in pex/vendor/__init__.py.
     setuptools==44.0.0  # This version should track the version in pex/vendor/__init__.py.
-    mypy[python2]==0.931
-    typing-extensions
-    types-mock
-    types-pexpect
-    types-PyYAML
-    types-setuptools
-    types-toml==0.10.5
-    httpx==0.23.0
     sphinx
-    types-docutils
+    toml==0.10.2  # This version should track the version in pex/vendor/__init__.py.
+
+    # The following stubs are pinned at the last version that does not use positional-only parameter
+    # syntax (/) not available to `--python-version 2.7` type checks.
+    types-PyYAML==6.0.12.12
+    types-docutils==0.20.0.20240310
+    types-mock==5.1.0.20240106
+    types-pexpect==4.9.0.20240207
+    types-setuptools==69.1.0.20240302
+
+    # 0.10.6 stubs are not compatible with Python 2.7
+    types-toml==0.10.5
+
+    typing-extensions
 commands =
     python scripts/typecheck.py
 


### PR DESCRIPTION
Two bitrot breaks are fixed:

+ Fix typing errors due to updates in type stubs.
  A recent spate of type-stub updates express positional-only arguments
  (the `/` marker), which is not valid syntax for the MyPy
  `--python-version 2.7` checks.

+ Work around pypa/pip#12156.  
  It seems to be the case that PEP-658 metadata is backfilling which
  triggers bugs in the legacy resolver under Pip 23.2.