### PR TITLE
Fix Pex to handle venvs with multiple site-packages dirs.

### DIFF
--- a/pex/finders.py
+++ b/pex/finders.py
@@ -9,9 +9,9 @@ import os
 from pex.common import is_python_script, open_zip, safe_mkdtemp
 from pex.dist_metadata import Distribution, DistributionType, EntryPoint
 from pex.pep_376 import InstalledWheel
-from pex.pep_427 import Wheel
 from pex.pep_503 import ProjectName
 from pex.typing import TYPE_CHECKING, cast
+from pex.wheel import Wheel
 
 if TYPE_CHECKING:
     from typing import Dict, Iterable, Optional

--- a/pex/pep_427.py
+++ b/pex/pep_427.py
@@ -10,27 +10,19 @@ import shutil
 import subprocess
 import sys
 from contextlib import closing
-from email.message import Message
 from fileinput import FileInput
 from textwrap import dedent
 
 from pex import pex_warnings
 from pex.common import chmod_plus_x, is_pyc_file, iter_copytree, open_zip, safe_open, touch
 from pex.compatibility import commonpath, get_stdout_bytes_buffer
-from pex.dist_metadata import (
-    DistMetadata,
-    Distribution,
-    MetadataFiles,
-    MetadataType,
-    ProjectNameAndVersion,
-    load_metadata,
-    parse_message,
-)
+from pex.dist_metadata import DistMetadata, Distribution, MetadataFiles, ProjectNameAndVersion
 from pex.enum import Enum
 from pex.interpreter import PythonInterpreter
 from pex.pep_376 import InstalledFile, InstalledWheel, Record
 from pex.pep_503 import ProjectName
 from pex.typing import TYPE_CHECKING, cast
+from pex.wheel import WHEEL
 
 if TYPE_CHECKING:
     from typing import (  # noqa
@@ -127,7 +119,7 @@ def install_wheel_chroot(
 ):
     # type: (...) -> InstalledWheel
 
-    metadata_files = install_wheel(
+    wheel = install_wheel(
         wheel_path,
         InstallPaths.chroot(
             destination,
@@ -137,12 +129,15 @@ def install_wheel_chroot(
         requested=requested,
     )
 
-    record_relpath = metadata_files.metadata_file_rel_path("RECORD")
+    record_relpath = wheel.metadata_files.metadata_file_rel_path("RECORD")
     assert (
         record_relpath is not None
     ), "The {module}.install_wheel function should always create a RECORD.".format(module=__name__)
     return InstalledWheel.save(
-        prefix_dir=destination, stash_dir=InstallPaths.CHROOT_STASH, record_relpath=record_relpath
+        prefix_dir=destination,
+        stash_dir=InstallPaths.CHROOT_STASH,
+        record_relpath=record_relpath,
+        root_is_purelib=wheel.root_is_purelib,
     )
 
 
@@ -152,7 +147,7 @@ def install_wheel_interpreter(
     compile=True,  # type: bool
     requested=True,  # type: bool
 ):
-    # type: (...) -> MetadataFiles
+    # type: (...) -> Wheel
 
     return install_wheel(
         wheel_path,
@@ -173,16 +168,17 @@ class Wheel(object):
     def load(cls, wheel_path):
         # type: (str) -> Wheel
 
-        metadata_files = load_metadata(wheel_path, restrict_types_to=(MetadataType.DIST_INFO,))
-        if not metadata_files:
-            raise WheelLoadError("Could not find any metadata in {wheel}.".format(wheel=wheel_path))
+        try:
+            metadata = WHEEL.load(wheel_path)
+        except WHEEL.LoadError as e:
+            raise WheelLoadError(str(e))
 
-        metadata_path = metadata_files.metadata_file_rel_path("WHEEL")
-        metadata_bytes = metadata_files.read("WHEEL")
-        if not metadata_path or not metadata_bytes:
+        metadata_path = metadata.files.metadata_file_rel_path("WHEEL")
+        if not metadata_path:
             raise WheelLoadError(
                 "Could not find WHEEL metadata in {wheel}.".format(wheel=wheel_path)
             )
+
         wheel_metadata_dir = os.path.dirname(metadata_path)
         if not wheel_metadata_dir.endswith(".dist-info"):
             raise WheelLoadError(
@@ -198,14 +194,13 @@ class Wheel(object):
         # https://peps.python.org/pep-0427/, we are safe in assuming ASCII overall for the wheel
         # metadata dir path.
         metadata_dir = str(wheel_metadata_dir)
-        metadata = parse_message(metadata_bytes)
 
         data_dir = re.sub(r"\.dist-info$", ".data", metadata_dir)
 
         return cls(
             location=wheel_path,
             metadata_dir=metadata_dir,
-            metadata_files=metadata_files,
+            metadata_files=metadata.files,
             metadata=metadata,
             data_dir=data_dir,
         )
@@ -213,13 +208,13 @@ class Wheel(object):
     location = attr.ib()  # type: str
     metadata_dir = attr.ib()  # type: str
     metadata_files = attr.ib()  # type: MetadataFiles
-    metadata = attr.ib()  # type: Message
+    metadata = attr.ib()  # type: WHEEL
     data_dir = attr.ib()  # type: str
 
     @property
-    def purelib(self):
+    def root_is_purelib(self):
         # type: () -> bool
-        return cast(bool, "true" == self.metadata.get("Root-Is-Purelib"))
+        return self.metadata.root_is_purelib
 
     def dist_metadata(self):
         return DistMetadata.from_metadata_files(self.metadata_files)
@@ -240,11 +235,11 @@ def install_wheel(
     compile=False,  # type: bool
     requested=True,  # type: bool
 ):
-    # type: (...) -> MetadataFiles
+    # type: (...) -> Wheel
 
     # See: https://packaging.python.org/en/latest/specifications/binary-distribution-format/#installing-a-wheel-distribution-1-0-py32-none-any-whl
     wheel = Wheel.load(wheel_path)
-    dest = install_paths.purelib if wheel.purelib else install_paths.platlib
+    dest = install_paths.purelib if wheel.root_is_purelib else install_paths.platlib
 
     record_relpath = wheel.metadata_path("RECORD")
     record_abspath = os.path.join(dest, record_relpath)
@@ -406,4 +401,4 @@ def install_wheel(
         installed_files.append(InstalledFile(path=record_relpath, hash=None, size=None))
         Record.write(dst=record_abspath, installed_files=installed_files)
 
-    return wheel.metadata_files
+    return wheel

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -77,7 +77,7 @@ class IsolatedSysPath(object):
         site_packages = OrderedSet()  # type: OrderedSet[str]
         for site_lib in ident.site_packages:
             TRACER.log("Discarding site packages path: {site_lib}".format(site_lib=site_lib))
-            site_packages.add(site_lib)
+            site_packages.add(site_lib.path)
 
         extras_paths = OrderedSet()  # type: OrderedSet[str]
         for extras_path in ident.extras_paths:

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -23,7 +23,7 @@ from pex.fingerprinted_distribution import FingerprintedDistribution
 from pex.jobs import Raise, SpawnedJob, execute_parallel, iter_map_parallel
 from pex.network_configuration import NetworkConfiguration
 from pex.orderedset import OrderedSet
-from pex.pep_376 import InstalledWheel, LoadError
+from pex.pep_376 import InstalledWheel
 from pex.pep_425 import CompatibilityTags
 from pex.pep_427 import InstallableType, WheelError, install_wheel_chroot
 from pex.pep_503 import ProjectName
@@ -481,7 +481,7 @@ class InstallResult(object):
         cached_fingerprint = None  # type: Optional[str]
         try:
             installed_wheel = InstalledWheel.load(self.install_chroot)
-        except LoadError:
+        except InstalledWheel.LoadError:
             # We support legacy chroots below by calculating the chroot fingerprint just in time.
             pass
         else:

--- a/pex/vendor/_vendored/attrs/.layout.json
+++ b/pex/vendor/_vendored/attrs/.layout.json
@@ -1,1 +1,1 @@
-{"fingerprint": "13e0015aa58e8f470b17936f42a5d5f874a20194156c371d2a4c695dc8c16d9e", "record_relpath": "attrs-21.5.0.dev0.dist-info/RECORD", "stash_dir": ".prefix"}
+{"fingerprint": "13e0015aa58e8f470b17936f42a5d5f874a20194156c371d2a4c695dc8c16d9e", "record_relpath": "attrs-21.5.0.dev0.dist-info/RECORD", "root_is_purelib": true, "stash_dir": ".prefix"}

--- a/pex/vendor/_vendored/packaging_20_9/.layout.json
+++ b/pex/vendor/_vendored/packaging_20_9/.layout.json
@@ -1,1 +1,1 @@
-{"fingerprint": "5a3fc5dcd563b4a4474944cd0d73ee4a51fb53132af553abfb203dc1cdf8f7c3", "record_relpath": "packaging-20.9.dist-info/RECORD", "stash_dir": ".prefix"}
+{"fingerprint": "df4c9633d3ccb0f1fe190d0539fe008e66273039e3fdaee182744d86496b1d5c", "record_relpath": "packaging-20.9.dist-info/RECORD", "root_is_purelib": true, "stash_dir": ".prefix"}

--- a/pex/vendor/_vendored/packaging_21_3/.layout.json
+++ b/pex/vendor/_vendored/packaging_21_3/.layout.json
@@ -1,1 +1,1 @@
-{"fingerprint": "2a93da49a5fc8217a0f710ff0ca3cfc56fefa35eddcf6a64786d452bfa284525", "record_relpath": "packaging-21.3.dist-info/RECORD", "stash_dir": ".prefix"}
+{"fingerprint": "fba014506f6a5a4cce9b8d83d13a573071b289e3659a0fad1f7c8b1becac57c7", "record_relpath": "packaging-21.3.dist-info/RECORD", "root_is_purelib": true, "stash_dir": ".prefix"}

--- a/pex/vendor/_vendored/packaging_23_1/.layout.json
+++ b/pex/vendor/_vendored/packaging_23_1/.layout.json
@@ -1,1 +1,1 @@
-{"fingerprint": "a98c4a74d7b6a62763df7ad330ac4c7a0779323fc36e961aeb8f20865e21a191", "record_relpath": "packaging-23.1.dist-info/RECORD", "stash_dir": ".prefix"}
+{"fingerprint": "a98c4a74d7b6a62763df7ad330ac4c7a0779323fc36e961aeb8f20865e21a191", "record_relpath": "packaging-23.1.dist-info/RECORD", "root_is_purelib": true, "stash_dir": ".prefix"}

--- a/pex/vendor/_vendored/pip/.layout.json
+++ b/pex/vendor/_vendored/pip/.layout.json
@@ -1,1 +1,1 @@
-{"fingerprint": "120267325b80f5c4b4adac019eb6617ab3319395c043d2871eedf70dd6ae2954", "record_relpath": "pip-20.3.4.dist-info/RECORD", "stash_dir": ".prefix"}
+{"fingerprint": "120267325b80f5c4b4adac019eb6617ab3319395c043d2871eedf70dd6ae2954", "record_relpath": "pip-20.3.4.dist-info/RECORD", "root_is_purelib": true, "stash_dir": ".prefix"}

--- a/pex/vendor/_vendored/setuptools/.layout.json
+++ b/pex/vendor/_vendored/setuptools/.layout.json
@@ -1,1 +1,1 @@
-{"fingerprint": "ebe3717ba6bad87ca328cbf3d3eb3f5475105bccb51dc09a69d37eff6b2e5210", "record_relpath": "setuptools-44.0.0+3acb925dd708430aeaf197ea53ac8a752f7c1863.dist-info/RECORD", "stash_dir": ".prefix"}
+{"fingerprint": "ebe3717ba6bad87ca328cbf3d3eb3f5475105bccb51dc09a69d37eff6b2e5210", "record_relpath": "setuptools-44.0.0+3acb925dd708430aeaf197ea53ac8a752f7c1863.dist-info/RECORD", "root_is_purelib": true, "stash_dir": ".prefix"}

--- a/pex/vendor/_vendored/toml/.layout.json
+++ b/pex/vendor/_vendored/toml/.layout.json
@@ -1,1 +1,1 @@
-{"fingerprint": "3d44cdc5911c31b190a0225202daafbb22f7f74e6761fb086742dadb5dff5384", "record_relpath": "toml-0.10.2.dist-info/RECORD", "stash_dir": ".prefix"}
+{"fingerprint": "3d44cdc5911c31b190a0225202daafbb22f7f74e6761fb086742dadb5dff5384", "record_relpath": "toml-0.10.2.dist-info/RECORD", "root_is_purelib": true, "stash_dir": ".prefix"}

--- a/pex/venv/installer.py
+++ b/pex/venv/installer.py
@@ -14,8 +14,7 @@ from pex.compatibility import is_valid_python_identifier
 from pex.dist_metadata import Distribution
 from pex.environment import PEXEnvironment
 from pex.orderedset import OrderedSet
-from pex.pep_376 import InstalledWheel, LoadError
-from pex.pep_427 import Wheel, WheelLoadError
+from pex.pep_376 import InstalledWheel
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.pex import PEX
@@ -26,6 +25,7 @@ from pex.util import CacheHelper
 from pex.venv.bin_path import BinPath
 from pex.venv.install_scope import InstallScope
 from pex.venv.virtualenv import PipUnavailableError, Virtualenv
+from pex.wheel import Wheel, WheelMetadataLoadError
 
 if TYPE_CHECKING:
     import typing
@@ -258,7 +258,7 @@ def _populate_flat_deps(
             installed_wheel = InstalledWheel.load(dist.location)
             for src, dst in installed_wheel.reinstall_flat(target_dir=dest_dir, symlink=symlink):
                 yield src, dst
-        except LoadError:
+        except InstalledWheel.LoadError:
             for src, dst in _populate_legacy_dist(
                 dest_dir=dest_dir, bin_dir=dest_dir, dist=dist, symlink=symlink
             ):
@@ -471,10 +471,10 @@ def _populate_venv_deps(
                 venv, symlink=symlink, rel_extra_path=rel_extra_path
             ):
                 yield src, dst
-        except LoadError:
+        except InstalledWheel.LoadError:
             try:
                 wheel = Wheel.load(dist.location)
-            except WheelLoadError:
+            except WheelMetadataLoadError:
                 site_packages_dir = venv.site_packages_dir
             else:
                 site_packages_dir = venv.purelib if wheel.root_is_purelib else venv.platlib

--- a/pex/wheel.py
+++ b/pex/wheel.py
@@ -1,0 +1,61 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from email.message import Message
+
+from pex.dist_metadata import MetadataFiles, MetadataType, load_metadata, parse_message
+from pex.typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from typing import Dict, Text
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
+
+
+@attr.s(frozen=True)
+class WHEEL(object):
+    """The .whl WHEEL metadata file.
+
+    See item 6 here for the WHEEL file contents: https://peps.python.org/pep-0427/#file-contents
+    """
+
+    class LoadError(Exception):
+        """Indicates an error loading WHEEL metadata."""
+
+    _CACHE = {}  # type: Dict[Text, WHEEL]
+
+    @classmethod
+    def load(cls, location):
+        # type: (Text) -> WHEEL
+        wheel = cls._CACHE.get(location)
+        if not wheel:
+            metadata_files = load_metadata(location, restrict_types_to=(MetadataType.DIST_INFO,))
+            if not metadata_files:
+                raise cls.LoadError(
+                    "Could not find any metadata in {wheel}.".format(wheel=location)
+                )
+
+            metadata_bytes = metadata_files.read("WHEEL")
+            if not metadata_bytes:
+                raise cls.LoadError(
+                    "Could not find WHEEL metadata in {wheel}.".format(wheel=location)
+                )
+            metadata = parse_message(metadata_bytes)
+            wheel = cls(files=metadata_files, metadata=metadata)
+            cls._CACHE[location] = wheel
+        return wheel
+
+    files = attr.ib()  # type: MetadataFiles
+    metadata = attr.ib()  # type: Message
+
+    @property
+    def root_is_purelib(self):
+        # type: () -> bool
+
+        # See:
+        #   https://peps.python.org/pep-0427/#installing-a-wheel-distribution-1-0-py32-none-any-whl
+        return cast(bool, "true" == self.metadata.get("Root-Is-Purelib"))

--- a/pex/wheel.py
+++ b/pex/wheel.py
@@ -3,9 +3,17 @@
 
 from __future__ import absolute_import
 
+import os
+import re
 from email.message import Message
 
-from pex.dist_metadata import MetadataFiles, MetadataType, load_metadata, parse_message
+from pex.dist_metadata import (
+    DistMetadata,
+    MetadataFiles,
+    MetadataType,
+    load_metadata,
+    parse_message,
+)
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
@@ -16,15 +24,16 @@ else:
     from pex.third_party import attr
 
 
+class WheelMetadataLoadError(Exception):
+    """Indicates an error loading WHEEL metadata."""
+
+
 @attr.s(frozen=True)
 class WHEEL(object):
     """The .whl WHEEL metadata file.
 
     See item 6 here for the WHEEL file contents: https://peps.python.org/pep-0427/#file-contents
     """
-
-    class LoadError(Exception):
-        """Indicates an error loading WHEEL metadata."""
 
     _CACHE = {}  # type: Dict[Text, WHEEL]
 
@@ -35,13 +44,13 @@ class WHEEL(object):
         if not wheel:
             metadata_files = load_metadata(location, restrict_types_to=(MetadataType.DIST_INFO,))
             if not metadata_files:
-                raise cls.LoadError(
+                raise WheelMetadataLoadError(
                     "Could not find any metadata in {wheel}.".format(wheel=location)
                 )
 
             metadata_bytes = metadata_files.read("WHEEL")
             if not metadata_bytes:
-                raise cls.LoadError(
+                raise WheelMetadataLoadError(
                     "Could not find WHEEL metadata in {wheel}.".format(wheel=location)
                 )
             metadata = parse_message(metadata_bytes)
@@ -59,3 +68,66 @@ class WHEEL(object):
         # See:
         #   https://peps.python.org/pep-0427/#installing-a-wheel-distribution-1-0-py32-none-any-whl
         return cast(bool, "true" == self.metadata.get("Root-Is-Purelib"))
+
+
+@attr.s(frozen=True)
+class Wheel(object):
+    @classmethod
+    def load(cls, wheel_path):
+        # type: (str) -> Wheel
+
+        metadata = WHEEL.load(wheel_path)
+
+        metadata_path = metadata.files.metadata_file_rel_path("WHEEL")
+        if not metadata_path:
+            raise WheelMetadataLoadError(
+                "Could not find WHEEL metadata in {wheel}.".format(wheel=wheel_path)
+            )
+
+        wheel_metadata_dir = os.path.dirname(metadata_path)
+        if not wheel_metadata_dir.endswith(".dist-info"):
+            raise WheelMetadataLoadError(
+                "Expected WHEEL metadata for {wheel} to be housed in a .dist-info directory, but was "
+                "found at {wheel_metadata_path}.".format(
+                    wheel=wheel_path, wheel_metadata_path=metadata_path
+                )
+            )
+        # Although not crisply defined, all PEPs lead to PEP-508 which restricts project names
+        # to ASCII: https://peps.python.org/pep-0508/#names. Likewise, version numbers are also
+        # restricted to ASCII: https://peps.python.org/pep-0440/. Since the `.dist-info` dir
+        # path is defined as `<project name>-<version>.dist-info` in
+        # https://peps.python.org/pep-0427/, we are safe in assuming ASCII overall for the wheel
+        # metadata dir path.
+        metadata_dir = str(wheel_metadata_dir)
+
+        data_dir = re.sub(r"\.dist-info$", ".data", metadata_dir)
+
+        return cls(
+            location=wheel_path,
+            metadata_dir=metadata_dir,
+            metadata_files=metadata.files,
+            metadata=metadata,
+            data_dir=data_dir,
+        )
+
+    location = attr.ib()  # type: str
+    metadata_dir = attr.ib()  # type: str
+    metadata_files = attr.ib()  # type: MetadataFiles
+    metadata = attr.ib()  # type: WHEEL
+    data_dir = attr.ib()  # type: str
+
+    @property
+    def root_is_purelib(self):
+        # type: () -> bool
+        return self.metadata.root_is_purelib
+
+    def dist_metadata(self):
+        return DistMetadata.from_metadata_files(self.metadata_files)
+
+    def metadata_path(self, *components):
+        # typ: (*str) -> str
+        return os.path.join(self.metadata_dir, *components)
+
+    def data_path(self, *components):
+        # typ: (*str) -> str
+        return os.path.join(self.data_dir, *components)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,14 @@
 # entry point metadata so the hook is discovered.
 backend-path = ["build-backend"]
 build-backend = "pex_build.hatchling.build"
-requires = ["hatchling"]
+
+# The hatchling 1.22.0 release breaks our build in several ways:
+# + Our console scripts are no longer generated.
+# + The `project.readme` pyproject.toml key now has its value hydrated before our metadata plugin
+#   runs, which foils our metadata expansion since our README.rst contains inadvertant expansion
+#   tokens.
+# This pin low buys time to work through the issues.
+requires = ["hatchling<1.22.0"]
 
 [tool.hatch.metadata.hooks.pex-adjust-metadata]
 expand = {"pex_version" = "version"}

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -65,11 +65,12 @@ IS_PYPY3 = IS_PYPY and sys.version_info[0] == 3
 NOT_CPYTHON27 = IS_PYPY or PY_VER != (2, 7)
 IS_LINUX = platform.system() == "Linux"
 IS_MAC = platform.system() == "Darwin"
-machine = platform.machine()
-IS_LINUX_X86_64 = IS_LINUX and machine == "x86_64"
-IS_LINUX_ARM64 = IS_LINUX and machine == "aarch64"
-IS_MAC_X86_64 = IS_MAC and machine == "x86_64"
-IS_MAC_ARM64 = IS_MAC and machine == "arm64"
+IS_X86_64 = platform.machine().lower() in ("amd64", "x86_64")
+IS_ARM_64 = platform.machine().lower() in ("arm64", "aarch64")
+IS_LINUX_X86_64 = IS_LINUX and IS_X86_64
+IS_LINUX_ARM64 = IS_LINUX and IS_ARM_64
+IS_MAC_X86_64 = IS_MAC and IS_X86_64
+IS_MAC_ARM64 = IS_MAC and IS_ARM_64
 NOT_CPYTHON27_OR_OSX = NOT_CPYTHON27 or not IS_LINUX
 
 

--- a/testing/docker.py
+++ b/testing/docker.py
@@ -1,0 +1,103 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os
+import subprocess
+from textwrap import dedent
+
+import pytest
+
+from pex.common import chmod_plus_x, is_exe, safe_mkdtemp
+from pex.typing import TYPE_CHECKING
+from testing import pex_project_dir
+
+if TYPE_CHECKING:
+    from typing import Optional
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
+
+
+HAVE_DOCKER = any(
+    is_exe(os.path.join(entry, "docker"))
+    for entry in os.environ.get("PATH", os.path.defpath).split(os.pathsep)
+)
+
+skip_unless_docker = pytest.mark.skipif(not HAVE_DOCKER, reason="This test needs docker to run.")
+
+
+@attr.s(frozen=True)
+class DockerVirtualenvRunner(object):
+    """Run's code in a venv created by Virtualenv at /virtualenv.venv in a docker container."""
+
+    @classmethod
+    def create(
+        cls,
+        base_image,  # type: str
+        python="python",  # type: str
+        virtualenv_version=None,  # type: Optional[str]
+        tmpdir=None,  # type: Optional[str]
+    ):
+        # type: (...) -> DockerVirtualenvRunner
+
+        test_script = os.path.join(tmpdir or safe_mkdtemp(), "test.sh")
+        with open(test_script, "w") as fp:
+            fp.write(
+                dedent(
+                    """\
+                    #!/usr/bin/env bash
+
+                    set -euo pipefail
+
+                    {python} -mvenv /setup.venv >&2
+                    /setup.venv/bin/pip install {virtualenv_requirement} >&2
+                    /setup.venv/bin/virtualenv /virtualenv.venv >&2
+                    PYTHONPATH=/code /virtualenv.venv/bin/python "$@"
+                    """
+                ).format(
+                    python=python,
+                    virtualenv_requirement=(
+                        "virtualenv=={virtualenv_version}".format(
+                            virtualenv_version=virtualenv_version
+                        )
+                        if virtualenv_version
+                        else "virtualenv"
+                    ),
+                )
+            )
+        chmod_plus_x(test_script)
+
+        return cls(base_image=base_image, test_script=test_script)
+
+    base_image = attr.ib()  # type: str
+    test_script = attr.ib()  # type: str
+
+    def run(
+        self,
+        python_code,  # type: str
+        *args  # type: str
+    ):
+        # type: (...) -> bytes
+
+        if not HAVE_DOCKER:
+            pytest.skip("This test needs docker to run.")
+
+        return subprocess.check_output(
+            args=[
+                "docker",
+                "run",
+                "--rm",
+                "-v",
+                "{pex_project_dir}:/code".format(pex_project_dir=pex_project_dir()),
+                "-v",
+                "{test_script}:/test.sh".format(test_script=self.test_script),
+                self.base_image,
+                "/test.sh",
+                "-c",
+                python_code,
+            ]
+            + list(args)
+        )

--- a/testing/docker.py
+++ b/testing/docker.py
@@ -31,7 +31,7 @@ skip_unless_docker = pytest.mark.skipif(not HAVE_DOCKER, reason="This test needs
 
 @attr.s(frozen=True)
 class DockerVirtualenvRunner(object):
-    """Run's code in a venv created by Virtualenv at /virtualenv.venv in a docker container."""
+    """Runs code in a venv created by Virtualenv at /virtualenv.venv in a docker container."""
 
     @classmethod
     def create(

--- a/tests/integration/test_excludes.py
+++ b/tests/integration/test_excludes.py
@@ -48,7 +48,10 @@ def requests_certifi_excluded_pex(tmpdir_factory):
     return pex
 
 
-REQUESTS_CMD = ["-c", "import requests, sys; print(sys.modules['certifi'].__file__)"]
+REQUESTS_CMD = [
+    "-c",
+    "import os, requests, sys; print(os.path.realpath(sys.modules['certifi'].__file__))",
+]
 EXPECTED_IMPORT_ERROR_MSG = "ModuleNotFoundError: No module named 'certifi'"
 
 

--- a/tests/integration/test_issue_1017.py
+++ b/tests/integration/test_issue_1017.py
@@ -3,10 +3,19 @@
 
 import os
 
+import pytest
+
 from pex.common import temporary_dir
-from testing import PY38, ensure_python_interpreter, run_pex_command
+from testing import IS_ARM_64, PY38, ensure_python_interpreter, run_pex_command
 
 
+@pytest.mark.skipif(
+    IS_ARM_64,
+    reason=(
+        "Pandas 1.0.5 requires Cython<3 to build from source, but its build_requires does not "
+        "constrain an upper bound and Cython 3 was released in the intervening time."
+    ),
+)
 def test_resolve_python_requires_full_version():
     # type: () -> None
     python38 = ensure_python_interpreter(PY38)

--- a/tests/integration/test_issue_1933.py
+++ b/tests/integration/test_issue_1933.py
@@ -6,23 +6,16 @@ import subprocess
 
 import pytest
 
-from pex.common import is_exe
 from pex.typing import TYPE_CHECKING
-from testing import IS_LINUX_ARM64, IS_MAC_ARM64, run_pex_command
+from testing import IS_X86_64, run_pex_command
+from testing.docker import skip_unless_docker
 
 if TYPE_CHECKING:
     from typing import Any
 
 
-@pytest.mark.skipif(
-    IS_MAC_ARM64
-    or IS_LINUX_ARM64
-    or not any(
-        is_exe(os.path.join(entry, "docker"))
-        for entry in os.environ.get("PATH", os.path.defpath).split(os.pathsep)
-    ),
-    reason="This test needs docker to run, and must run on an X86_64 platform.",
-)
+@pytest.mark.skipif(not IS_X86_64, reason="This test must run on an X86_64 platform.")
+@skip_unless_docker
 def test_musllinux_wheels_resolved(
     tmpdir,  # type: Any
     pex_project_dir,  # type: str

--- a/tests/integration/test_issue_2348.py
+++ b/tests/integration/test_issue_2348.py
@@ -9,7 +9,7 @@ import shutil
 from pex.dist_metadata import ProjectNameAndVersion
 from pex.pex_info import PexInfo
 from pex.typing import TYPE_CHECKING
-from testing import IS_MAC, PY310, ensure_python_interpreter, run_pex_command
+from testing import IS_ARM_64, IS_MAC, PY310, ensure_python_interpreter, run_pex_command
 from testing.cli import run_pex3
 
 if TYPE_CHECKING:
@@ -49,8 +49,8 @@ def test_find_links_url_escaping(tmpdir):
         "2",
     ).assert_success()
 
-    # The torch 2.0.1+cpu wheel is only published for Linux and Windows.
-    if IS_MAC:
+    # The torch 2.0.1+cpu wheel is only published for x86_64 for Linux and Windows.
+    if IS_MAC or IS_ARM_64:
         return
 
     # Force the torch 2.0.1+cpu wheel to be re-downloaded from the lock.

--- a/tests/integration/test_issue_2355.py
+++ b/tests/integration/test_issue_2355.py
@@ -5,23 +5,15 @@ import os
 import subprocess
 from textwrap import dedent
 
-import pytest
-
-from pex.common import is_exe
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import IS_X86_64, run_pex_command
+from testing.docker import skip_unless_docker
 
 if TYPE_CHECKING:
     from typing import Any
 
 
-@pytest.mark.skipif(
-    not any(
-        is_exe(os.path.join(entry, "docker"))
-        for entry in os.environ.get("PATH", os.path.defpath).split(os.pathsep)
-    ),
-    reason="This test needs docker to run.",
-)
+@skip_unless_docker
 def test_ssl_context(
     tmpdir,  # type: Any
     pex_project_dir,  # type: str
@@ -49,7 +41,9 @@ def test_ssl_context(
         )
 
     pbs_release = "https://github.com/indygreg/python-build-standalone/releases/download/20240107"
-    pbs_archive = "cpython-3.9.18+20240107-x86_64-unknown-linux-gnu-install_only.tar.gz"
+    pbs_archive = "cpython-3.9.18+20240107-{arch}-unknown-linux-gnu-install_only.tar.gz".format(
+        arch="x86_64" if IS_X86_64 else "aarch64"
+    )
     subprocess.check_call(
         args=[
             "docker",

--- a/tests/integration/test_issue_661.py
+++ b/tests/integration/test_issue_661.py
@@ -7,17 +7,20 @@ import subprocess
 import pytest
 
 from pex.common import temporary_dir
-from testing import IS_PYPY, run_pex_command
+from testing import IS_ARM_64, IS_PYPY, run_pex_command
 
 
 @pytest.mark.skipif(
-    IS_PYPY,
-    reason="On PyPy this causes this error: Failed to execute PEX file. Needed "
-    "manylinux2014_x86_64-pp-272-pypy_41 compatible dependencies for 1: "
-    "cryptography==2.5 But this pex only contains "
-    "cryptography-2.5-pp27-pypy_41-linux_x86_64.whl. "
-    "Temporarily skipping the test on PyPy allows us to get tests passing "
-    "again, until we can address this.",
+    IS_ARM_64 or IS_PYPY,
+    reason=(
+        "No wheels are published for arm and the sdist fails to compile against modern OpenSSL. "
+        "Also, on PyPy we get this error: Failed to execute PEX file. Needed "
+        "manylinux2014_x86_64-pp-272-pypy_41 compatible dependencies for 1: "
+        "cryptography==2.5 But this pex only contains "
+        "cryptography-2.5-pp27-pypy_41-linux_x86_64.whl. "
+        "Temporarily skipping the test on PyPy allows us to get tests passing again, until we can "
+        "address this."
+    ),
 )
 def test_devendoring_required():
     # type: () -> None

--- a/tests/integration/venv_ITs/__init__.py
+++ b/tests/integration/venv_ITs/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).

--- a/tests/integration/venv_ITs/conftest.py
+++ b/tests/integration/venv_ITs/conftest.py
@@ -1,0 +1,24 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import pytest
+
+from pex.typing import TYPE_CHECKING
+from testing.docker import DockerVirtualenvRunner
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+@pytest.fixture
+def fedora39_virtualenv_runner(tmpdir):
+    # type: (Any) -> DockerVirtualenvRunner
+
+    return DockerVirtualenvRunner.create(
+        base_image="fedora:39",
+        python="python3.12",
+        virtualenv_version="20.25.1",
+        tmpdir=str(tmpdir),
+    )

--- a/tests/integration/venv_ITs/test_install_wheel_multiple_site_packages_dirs.py
+++ b/tests/integration/venv_ITs/test_install_wheel_multiple_site_packages_dirs.py
@@ -1,0 +1,109 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import json
+from textwrap import dedent
+
+from testing.docker import DockerVirtualenvRunner
+
+
+def test_installed_wheels(fedora39_virtualenv_runner):
+    # type: (DockerVirtualenvRunner) -> None
+
+    assert {
+        "ansicolors==1.1.8": "/virtualenv.venv/lib/python3.12/site-packages",
+        "numpy==1.26.4": "/virtualenv.venv/lib64/python3.12/site-packages",
+    } == json.loads(
+        fedora39_virtualenv_runner.run(
+            dedent(
+                """\
+                import json
+                import subprocess
+                import sys
+
+                from pex.venv.virtualenv import Virtualenv
+
+
+                subprocess.check_call(
+                    args=[
+                        sys.executable,
+                        "-m",
+                        "pex.cli",
+                        "venv",
+                        "create",
+                        "-d",
+                        "/virtualenv.venv",
+                        "ansicolors==1.1.8",
+                        "numpy==1.26.4"
+                    ],
+                    stdout=sys.stderr
+                )
+
+                venv = Virtualenv("/virtualenv.venv")
+                json.dump(
+                    {
+                        str(dist.as_requirement()): dist.location
+                        for dist in venv.iter_distributions()
+                        if str(dist.metadata.project_name) in ("ansicolors", "numpy")
+                    },
+                    sys.stdout
+                )
+                """
+            )
+        ).decode("utf-8")
+    )
+
+
+def test_wheel_files(fedora39_virtualenv_runner):
+    # type: (DockerVirtualenvRunner) -> None
+
+    assert {
+        "ansicolors==1.1.7": "/virtualenv.venv/lib/python3.12/site-packages",
+        "numpy==1.26.3": "/virtualenv.venv/lib64/python3.12/site-packages",
+    } == json.loads(
+        fedora39_virtualenv_runner.run(
+            dedent(
+                """\
+                import glob
+                import json
+                import subprocess
+                import sys
+
+                from pex.interpreter import PythonInterpreter
+                from pex.pep_427 import install_wheel_interpreter
+                from pex.venv.virtualenv import Virtualenv
+
+
+                subprocess.check_call(
+                    args=[
+                        sys.executable,
+                        "-m",
+                        "pip",
+                        "wheel",
+                        "-w",
+                        "/wheels",
+                        "ansicolors==1.1.7",
+                        "numpy==1.26.3"
+                    ],
+                    stdout=sys.stderr
+                )
+
+                interpreter = PythonInterpreter.get()
+                for wheel_path in glob.glob("/wheels/*.whl"):
+                    install_wheel_interpreter(wheel_path=wheel_path, interpreter=interpreter)
+
+                venv = Virtualenv("/virtualenv.venv")
+                json.dump(
+                    {
+                        str(dist.as_requirement()): dist.location
+                        for dist in venv.iter_distributions()
+                        if str(dist.metadata.project_name) in ("ansicolors", "numpy")
+                    },
+                    sys.stdout
+                )
+                """
+            )
+        ).decode("utf-8")
+    )

--- a/tests/integration/venv_ITs/test_virtualenv.py
+++ b/tests/integration/venv_ITs/test_virtualenv.py
@@ -131,7 +131,7 @@ def test_multiple_site_packages_dirs(fedora39_virtualenv_runner):
                     {
                         "site_packages_dir": venv.site_packages_dir,
                         "purelib": venv.purelib,
-                        "platlib": venv.platlib,s
+                        "platlib": venv.platlib,
                     },
                     sys.stdout
                 )

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -261,7 +261,7 @@ def test_site_libs_excludes_prefix():
     with mock.patch.object(
         site, "getsitepackages"
     ) as mock_site_packages, temporary_dir() as tempdir:
-        site_packages = os.path.join(tempdir, "site-packages")
+        site_packages = os.path.realpath(os.path.join(tempdir, "site-packages"))
         os.mkdir(site_packages)
         mock_site_packages.return_value = [site_packages, sys.prefix]
         site_libs = tuple(entry.path for entry in PythonIdentity.get().site_packages)

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -221,7 +221,7 @@ def test_site_libs(tmpdir):
         site_packages = os.path.join(str(tmpdir), "site-packages")
         os.mkdir(site_packages)
         mock_site_packages.return_value = {site_packages}
-        site_libs = PythonIdentity.get().site_packages
+        site_libs = frozenset(entry.path for entry in PythonIdentity.get().site_packages)
         assert site_packages in site_libs
 
 
@@ -264,7 +264,7 @@ def test_site_libs_excludes_prefix():
         site_packages = os.path.join(tempdir, "site-packages")
         os.mkdir(site_packages)
         mock_site_packages.return_value = [site_packages, sys.prefix]
-        site_libs = PythonIdentity.get().site_packages
+        site_libs = tuple(entry.path for entry in PythonIdentity.get().site_packages)
         assert site_packages in site_libs
         assert sys.prefix not in site_libs
 


### PR DESCRIPTION
Previously the Pex venv code would blow up when it encountered a venv
with multiple distinct site-packages directories. Although this was
safe, it was unhelpful for virtualenvs created by modern Virtualenv on
Red Hat based distributions where there is a separation between
purelib (`lib/pythonX.Y/site-packages`) and
platlib (`lib64/pythonX.Y/site-packages`). Interestingly this was not a
problem for Python stdlib `-mvenv` virtualenvs since those create the
`lib64/` platlib directory as a symlink to the `lib/` purelib
directory. It's unclear who is constructing venvs correctly here, but
given the Virtualenv layout, its definitely correct to honor the
purelib / platlib distinction when installing wheels in venvs. Pex now
does this and tests are added to confirm.

Also fix up various existing tests that failed on ARM machines where
this problem was discovered.