### PR TITLE
Guard against mismatched `--requirements-pex`.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -892,28 +892,9 @@ def build_pex(
         "Adding distributions from pexes: {}".format(" ".join(options.requirements_pexes))
     ):
         for requirements_pex in options.requirements_pexes:
-            if (
-                pex_info.deps_are_wheel_files
-                != PexInfo.from_pex(requirements_pex).deps_are_wheel_files
-            ):
-                die(
-                    "The {option} option was selected but the --requirements-pex "
-                    "{requirements_pex} is built with {opposite_option}. Any --requirements-pex "
-                    "you want to merge into the main PEX must be built with {option}.".format(
-                        option=(
-                            "--no-pre-install-wheels"
-                            if pex_info.deps_are_wheel_files
-                            else "--pre-install-wheels"
-                        ),
-                        requirements_pex=requirements_pex,
-                        opposite_option=(
-                            "--pre-install-wheels"
-                            if pex_info.deps_are_wheel_files
-                            else "--no-pre-install-wheels"
-                        ),
-                    )
-                )
-            requirements_pex_info = dependency_manager.add_from_pex(requirements_pex)
+            requirements_pex_info = dependency_manager.add_from_pex(
+                requirements_pex, result_type_wheel_file=pex_info.deps_are_wheel_files
+            )
             excluded.extend(requirements_pex_info.excluded)
 
     with TRACER.timed(

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -892,6 +892,27 @@ def build_pex(
         "Adding distributions from pexes: {}".format(" ".join(options.requirements_pexes))
     ):
         for requirements_pex in options.requirements_pexes:
+            if (
+                pex_info.deps_are_wheel_files
+                != PexInfo.from_pex(requirements_pex).deps_are_wheel_files
+            ):
+                die(
+                    "The {option} option was selected but the --requirements-pex "
+                    "{requirements_pex} is built with {opposite_option}. Any --requirements-pex "
+                    "you want to merge into the main PEX must be built with {option}.".format(
+                        option=(
+                            "--no-pre-install-wheels"
+                            if pex_info.deps_are_wheel_files
+                            else "--pre-install-wheels"
+                        ),
+                        requirements_pex=requirements_pex,
+                        opposite_option=(
+                            "--pre-install-wheels"
+                            if pex_info.deps_are_wheel_files
+                            else "--no-pre-install-wheels"
+                        ),
+                    )
+                )
             requirements_pex_info = dependency_manager.add_from_pex(requirements_pex)
             excluded.extend(requirements_pex_info.excluded)
 

--- a/pex/dependency_manager.py
+++ b/pex/dependency_manager.py
@@ -31,14 +31,20 @@ class DependencyManager(object):
     _requirements = attr.ib(factory=OrderedSet)  # type: OrderedSet[Requirement]
     _distributions = attr.ib(factory=OrderedSet)  # type: OrderedSet[FingerprintedDistribution]
 
-    def add_from_pex(self, pex):
-        # type: (str) -> PexInfo
+    def add_from_pex(
+        self,
+        pex,  # type: str
+        result_type_wheel_file=False,  # type: bool
+    ):
+        # type: (...) -> PexInfo
 
         pex_info = PexInfo.from_pex(pex)
         self._requirements.update(Requirement.parse(req) for req in pex_info.requirements)
 
         pex_environment = PEXEnvironment.mount(pex, pex_info=pex_info)
-        self._distributions.update(pex_environment.iter_distributions())
+        self._distributions.update(
+            pex_environment.iter_distributions(result_type_wheel_file=result_type_wheel_file)
+        )
 
         return pex_info
 

--- a/tests/integration/test_issue_2391.py
+++ b/tests/integration/test_issue_2391.py
@@ -1,0 +1,68 @@
+# Copyright 2014 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+import re
+import subprocess
+
+from pex.typing import TYPE_CHECKING
+from testing import run_pex_command
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_requirements_pex_wheel_type_mismatch(tmpdir):
+    # type: (Any)-> None
+
+    pre_installed_reqs_pex = os.path.join(str(tmpdir), "pre_installed_reqs.pex")
+    run_pex_command(args=["cowsay==5.0", "-o", pre_installed_reqs_pex]).assert_success()
+
+    wheel_file_reqs_pex = os.path.join(str(tmpdir), "wheel_file_reqs.pex")
+    run_pex_command(
+        args=["cowsay==5.0", "--no-pre-install-wheels", "-o", wheel_file_reqs_pex]
+    ).assert_success()
+
+    pex = os.path.join(str(tmpdir), "pex")
+
+    def assert_pex():
+        # type: () -> None
+        assert "5.0" == subprocess.check_output(args=[pex, "--version"]).decode("utf-8").strip()
+
+    run_pex_command(
+        args=["--requirements-pex", pre_installed_reqs_pex, "-c" "cowsay", "-o", pex]
+    ).assert_success()
+    assert_pex()
+
+    run_pex_command(
+        args=[
+            "--requirements-pex",
+            wheel_file_reqs_pex,
+            "--no-pre-install-wheels",
+            "-c",
+            "cowsay",
+            "-o",
+            pex,
+        ]
+    ).assert_success()
+    assert_pex()
+
+    run_pex_command(
+        args=["--no-pre-install-wheels", "--requirements-pex", pre_installed_reqs_pex], quiet=True
+    ).assert_failure(
+        expected_error_re=re.escape(
+            "The --no-pre-install-wheels option was selected but the --requirements-pex {reqs_pex} "
+            "is built with --pre-install-wheels. Any --requirements-pex you want to merge into the "
+            "main PEX must be built with --no-pre-install-wheels.".format(
+                reqs_pex=pre_installed_reqs_pex
+            )
+        )
+    )
+
+    run_pex_command(args=["--requirements-pex", wheel_file_reqs_pex], quiet=True).assert_failure(
+        expected_error_re=re.escape(
+            "The --pre-install-wheels option was selected but the --requirements-pex {reqs_pex} is "
+            "built with --no-pre-install-wheels. Any --requirements-pex you want to merge into the "
+            "main PEX must be built with --pre-install-wheels.".format(reqs_pex=wheel_file_reqs_pex)
+        )
+    )

--- a/tests/integration/test_issue_2391.py
+++ b/tests/integration/test_issue_2391.py
@@ -85,22 +85,16 @@ def test_requirements_pex_wheel_type_mismatch(
     ).assert_success()
     assert_pex()
 
+    # N.B.: We cannot currently re-materialize wheel files from pre-installed wheel chroots.
+    # See: https://github.com/pex-tool/pex/issues/2299
     run_pex_command(
         args=["--no-pre-install-wheels", "--requirements-pex", pre_installed_reqs_pex], quiet=True
     ).assert_failure(
         expected_error_re=re.escape(
-            "The --no-pre-install-wheels option was selected but the --requirements-pex {reqs_pex} "
-            "is built with --pre-install-wheels. Any --requirements-pex you want to merge into the "
-            "main PEX must be built with --no-pre-install-wheels.".format(
-                reqs_pex=pre_installed_reqs_pex
-            )
+            "Cannot resolve .whl files from PEX at {reqs_pex}; its dependencies are in the form of "
+            "pre-installed wheel chroots.".format(reqs_pex=pre_installed_reqs_pex)
         )
     )
 
-    run_pex_command(args=["--requirements-pex", wheel_file_reqs_pex], quiet=True).assert_failure(
-        expected_error_re=re.escape(
-            "The --pre-install-wheels option was selected but the --requirements-pex {reqs_pex} is "
-            "built with --no-pre-install-wheels. Any --requirements-pex you want to merge into the "
-            "main PEX must be built with --pre-install-wheels.".format(reqs_pex=wheel_file_reqs_pex)
-        )
-    )
+    # But we can go the other way around and turn wheel files into pre-installed wheel chroots.
+    run_pex_command(args=["--requirements-pex", wheel_file_reqs_pex], quiet=True).assert_success()


### PR DESCRIPTION
Pex cannot yet handle turning installed wheel chroots back into wheel
files (see #2299). As such, until that time, it must reject attempts
to combine PEXes with different wheel packaging.

Clarifies #2391