### PR TITLE
Upgrade to PyPy 7.3.16 release.

### DIFF
--- a/docker/base/install_pythons.sh
+++ b/docker/base/install_pythons.sh
@@ -18,13 +18,13 @@ PYENV_VERSIONS=(
   3.10.14
   3.12.3
   3.13.0a6
-  pypy2.7-7.3.15
+  pypy2.7-7.3.16
   pypy3.5-7.0.0
   pypy3.6-7.3.3
   pypy3.7-7.3.9
   pypy3.8-7.3.11
-  pypy3.9-7.3.15
-  pypy3.10-7.3.15
+  pypy3.9-7.3.16
+  pypy3.10-7.3.16
 )
 git clone "${PYENV_REPO:-https://github.com/pyenv/pyenv.git}" "${PYENV_ROOT}" && (
   cd "${PYENV_ROOT}" && git checkout "${PYENV_SHA:-HEAD}" && src/configure && make -C src

--- a/docker/user/Dockerfile
+++ b/docker/user/Dockerfile
@@ -25,17 +25,6 @@ ENV _PEX_TEST_DEV_ROOT=/development/pex_dev
 # ~/.pex cache.
 VOLUME "/home/${USER}/.pex"
 
-RUN mkdir -p  \
-    /development/pex \
-    /development/pex/.tox \
-    /development/pex_dev \
-    "/home/${USER}/.pex" && \
-  chown -R "${UID}:${GID}" \
-    /development/pex \
-    /development/pex/.tox \
-    /development/pex_dev \
-    "/home/${USER}/.pex"
-
 # This will be a named volume used to persist the pytest tmp tree (/tmp/pytest-of-$USER/) for use \
 # in `./dtox inspect` sessions.
 VOLUME /tmp


### PR DESCRIPTION
See the release announcement here:
  https://www.pypy.org/posts/2024/04/pypy-v7316-release.html

Also fix and simplify dtox volume mount permissions adjustment in the
face of docker behavior changes. This new method should be robust to
subtle semantic shifts since it operates after a `docker build` and
fully in `docker run` context taking its cue from the `CACHE_MODE=pull`
method of doing this.