### PR TITLE
Improve test_gevent_monkeypatch robustness.

### DIFF
--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -120,10 +120,13 @@ else:
 
 
 if PY3:
+    from http.client import HTTPConnection as HTTPConnection
+    from http.client import HTTPResponse as HTTPResponse
     from urllib import parse as _url_parse
     from urllib.error import HTTPError as HTTPError
     from urllib.parse import quote as _url_quote
     from urllib.parse import unquote as _url_unquote
+    from urllib.request import AbstractHTTPHandler as AbstractHTTPHandler
     from urllib.request import FileHandler as FileHandler
     from urllib.request import HTTPBasicAuthHandler as HTTPBasicAuthHandler
     from urllib.request import HTTPDigestAuthHandler as HTTPDigestAuthHandler
@@ -137,6 +140,9 @@ else:
     from urllib import unquote as _url_unquote
 
     import urlparse as _url_parse
+    from httplib import HTTPConnection as HTTPConnection
+    from httplib import HTTPResponse as HTTPResponse
+    from urllib2 import AbstractHTTPHandler as AbstractHTTPHandler
     from urllib2 import FileHandler as FileHandler
     from urllib2 import HTTPBasicAuthHandler as HTTPBasicAuthHandler
     from urllib2 import HTTPDigestAuthHandler as HTTPDigestAuthHandler

--- a/pex/fetcher.py
+++ b/pex/fetcher.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import contextlib
 import os
+import socket
 import sys
 import threading
 import time
@@ -13,16 +14,21 @@ from contextlib import closing, contextmanager
 from pex import asserts
 from pex.auth import PasswordDatabase, PasswordEntry
 from pex.compatibility import (
+    PY2,
+    AbstractHTTPHandler,
     FileHandler,
     HTTPBasicAuthHandler,
+    HTTPConnection,
     HTTPDigestAuthHandler,
     HTTPError,
     HTTPPasswordMgrWithDefaultRealm,
+    HTTPResponse,
     HTTPSHandler,
     ProxyHandler,
     Request,
     build_opener,
     in_main_thread,
+    urlparse,
 )
 from pex.network_configuration import NetworkConfiguration
 from pex.typing import TYPE_CHECKING, cast
@@ -30,7 +36,7 @@ from pex.version import __version__
 
 if TYPE_CHECKING:
     from ssl import SSLContext
-    from typing import BinaryIO, Dict, Iterable, Iterator, Mapping, Optional, Text
+    from typing import Any, BinaryIO, Dict, Iterable, Iterator, Mapping, Optional, Text
 
     import attr  # vendor:skip
 else:
@@ -148,6 +154,68 @@ def initialize_ssl_context(network_configuration=None):
 initialize_ssl_context()
 
 
+class UnixHTTPConnection(HTTPConnection):
+    def __init__(
+        self,
+        *args,  # type: Any
+        **kwargs  # type: Any
+    ):
+        # type: (...) -> None
+        path = kwargs.pop("path")
+        super(UnixHTTPConnection, self).__init__(*args, **kwargs)
+        self.path = path
+
+    def connect(self):
+        # type: () -> None
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(self.path)
+        self.sock = sock
+
+
+class UnixHTTPHandler(AbstractHTTPHandler):
+    # N.B.: The naming scheme here is <protocol>_<action>; thus `unix` captures unix:// URLs and
+    # `open` captures the open event for unix:// URLs.
+    def unix_open(self, req):
+        # type: (Request) -> HTTPResponse
+        url_info = urlparse.urlparse(req.get_full_url())
+
+        path = ""
+        unix_socket_path = url_info.path
+        while not os.path.basename(unix_socket_path).endswith(".sock"):
+            path = os.path.join(path, os.path.basename(unix_socket_path))
+            new_unix_socket_path = os.path.dirname(unix_socket_path)
+            if new_unix_socket_path == unix_socket_path:
+                # There was no *.sock component, so just use the full path.
+                path = ""
+                unix_socket_path = url_info.path
+                break
+            unix_socket_path = new_unix_socket_path
+
+        # <scheme>://<netloc>/<path>;<params>?<query>#<fragment>
+        url = urlparse.urlunparse(
+            ("unix", "localhost", path, url_info.params, url_info.query, url_info.fragment)
+        )
+        kwargs = {} if PY2 else {"method": req.method}
+        modified_req = Request(
+            url,
+            data=req.data,
+            headers=req.headers,
+            # N.B.: MyPy for Python 2.7 needs the cast.
+            origin_req_host=cast(str, req.origin_req_host),
+            unverifiable=req.unverifiable,
+            **kwargs
+        )
+
+        # The stdlib actually sets timeout this way - it is not a constructor argument in any
+        # Python version.
+        modified_req.timeout = req.timeout
+
+        # N.B.: MyPy for Python 2.7 needs the cast.
+        return cast(
+            HTTPResponse, self.do_open(UnixHTTPConnection, modified_req, path=unix_socket_path)
+        )
+
+
 class URLFetcher(object):
     USER_AGENT = "pex/{version}".format(version=__version__)
 
@@ -171,6 +239,7 @@ class URLFetcher(object):
         handlers = [
             ProxyHandler(proxies),
             HTTPSHandler(context=get_ssl_context(network_configuration=network_configuration)),
+            UnixHTTPHandler(),
         ]
         if handle_file_urls:
             handlers.append(FileHandler())

--- a/pex/fetcher.py
+++ b/pex/fetcher.py
@@ -195,7 +195,7 @@ class UnixHTTPHandler(AbstractHTTPHandler):
         url = urlparse.urlunparse(
             ("unix", "localhost", path, url_info.params, url_info.query, url_info.fragment)
         )
-        kwargs = {} if PY2 else {"method": req.method}
+        kwargs = {} if PY2 else {"method": req.get_method()}
         modified_req = Request(
             url,
             data=req.data,

--- a/testing/data/locks/issue-2415.lock.json
+++ b/testing/data/locks/issue-2415.lock.json
@@ -1491,7 +1491,7 @@
   "requirements": [
     "flask",
     "gevent>=1.3.4",
-    "gunicorn"
+    "gunicorn[gevent]"
   ],
   "requires_python": [
     "<3.13,>=3.8"

--- a/tests/integration/test_issue_2415.py
+++ b/tests/integration/test_issue_2415.py
@@ -9,10 +9,10 @@ from textwrap import dedent
 
 import pytest
 
-from pex.common import safe_open
+from pex.common import safe_mkdtemp, safe_open
 from pex.fetcher import URLFetcher
 from pex.typing import TYPE_CHECKING
-from testing import IS_PYPY, PY_VER, data, run_pex_command
+from testing import IS_MAC, IS_PYPY, PY_VER, data, run_pex_command
 
 if TYPE_CHECKING:
     from typing import Any
@@ -84,7 +84,18 @@ def test_gevent_monkeypatch(tmpdir):
         cwd=str(tmpdir),
     ).assert_success()
 
-    socket = os.path.join(str(tmpdir), "socket.sock")
+    # N.B.: Simply using a path under tmpdir does not work on Mac; so we jump through some extra
+    # hoops here and use the proper directory for socket files for the operating system we're
+    # running under.
+    socket_dir = safe_mkdtemp(
+        dir=os.environ.get(
+            "XDG_RUNTIME_DIR",
+            os.path.expanduser("~/Library/Caches/TemporaryItems")
+            if IS_MAC
+            else os.path.join("/run/user", str(os.getuid())),
+        )
+    )
+    socket = os.path.join(socket_dir, "gunicorn.sock")
     with open(os.path.join(str(tmpdir), "stderr"), "wb+") as stderr_fp:
         gunicorn = subprocess.Popen(
             args=[pex, "--bind", "unix:{socket}".format(socket=socket)], stderr=stderr_fp


### PR DESCRIPTION
Previously the test could hang when the log fifo was closed by the
gunicorn server before the port was written to the log; now it fails
when this happens.

Follow up to #2417 which introduced the test and led to observed hangs
in CI.