### PR TITLE
Fix `pex3 lock export` handling of exotic reqs.

### DIFF
--- a/tests/integration/cli/commands/test_export.py
+++ b/tests/integration/cli/commands/test_export.py
@@ -384,11 +384,11 @@ def test_export_vcs_and_local_project_requirements_issue_2416(
         The requirements exported from {lockfile} include the following requirements
         that tools likely won't support --hash for:
         + VCS requirement 'cowsay @ git+https://github.com/VaasuDevanS/cowsay-python@3db622ce'
-        + local project requirement 'pex @ file:///home/jsirois/dev/pex-tool/pex'
+        + local project requirement 'pex @ file://{pex_project_dir}'
 
         If you can accept a lack of hash checking you can specify `--format pip-no-hashes`.
         """
-    ).format(lockfile=lockfile_path)
+    ).format(lockfile=lockfile_path, pex_project_dir=pex_project_dir)
     exported = export(
         tmpdir,
         ansicolors_plus_vcs_plus_local_project,


### PR DESCRIPTION
Although Pex supports locking VCS requirements and local project
requirements, it does so with a be-spoke system for fingerprinting
each; as such, the `--hash`es emitted when exporting lock files
containing these types of requirements are not actually useable in
practice. Continue to support exporting this class of lock file, but
warn of the potential problems and offer a new `--format pip-no-hash`
mode for the daring. In addition, change the requirements output for
this class of lock file to match the input requirement for best
fidelity when actually attempting to use the resulting exported
requirement file without `--hash`es.

Fixes #2416