### PR TITLE
Implement support for preserving and injecting Python args.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -513,6 +513,18 @@ def configure_clp_pex_entry_points(parser):
             self.default.extend(shlex.split(value))
 
     group.add_argument(
+        "--inject-python-args",
+        dest="inject_python_args",
+        default=[],
+        action=InjectArgAction,
+        help=(
+            "Command line arguments to the Python interpreter to freeze in. For example, `-u` to "
+            "disable buffering of `sys.stdout` and `sys.stderr` or `-W <arg>` to control Python "
+            "warnings."
+        ),
+    )
+
+    group.add_argument(
         "--inject-args",
         dest="inject_args",
         default=[],
@@ -867,6 +879,7 @@ def build_pex(
             seen.add((src, dst))
 
     pex_info = pex_builder.info
+    pex_info.inject_python_args = options.inject_python_args
     pex_info.inject_env = dict(options.inject_env)
     pex_info.inject_args = options.inject_args
     pex_info.venv = bool(options.venv)

--- a/pex/build_system/pep_517.py
+++ b/pex/build_system/pep_517.py
@@ -150,31 +150,33 @@ def _invoke_build_hook(
     build_backend_object = build_system.build_backend.replace(":", ".")
     with named_temporary_file(mode="r") as fp:
         args = build_system.venv_pex.execute_args(
-            "-c",
-            dedent(
-                """\
-                import json
-                import sys
+            additional_args=(
+                "-c",
+                dedent(
+                    """\
+                    import json
+                    import sys
 
-                import {build_backend_module}
+                    import {build_backend_module}
 
 
-                if not hasattr({build_backend_object}, {hook_method!r}):
-                    sys.exit({hook_unavailable_exit_code})
+                    if not hasattr({build_backend_object}, {hook_method!r}):
+                        sys.exit({hook_unavailable_exit_code})
 
-                result = {build_backend_object}.{hook_method}(*{hook_args!r}, **{hook_kwargs!r})
-                with open({result_file!r}, "w") as fp:
-                    json.dump(result, fp)
-                """
-            ).format(
-                build_backend_module=build_backend_module,
-                build_backend_object=build_backend_object,
-                hook_method=hook_method,
-                hook_args=tuple(hook_args),
-                hook_kwargs=dict(hook_kwargs) if hook_kwargs else {},
-                hook_unavailable_exit_code=_HOOK_UNAVAILABLE_EXIT_CODE,
-                result_file=fp.name,
-            ),
+                    result = {build_backend_object}.{hook_method}(*{hook_args!r}, **{hook_kwargs!r})
+                    with open({result_file!r}, "w") as fp:
+                        json.dump(result, fp)
+                    """
+                ).format(
+                    build_backend_module=build_backend_module,
+                    build_backend_object=build_backend_object,
+                    hook_method=hook_method,
+                    hook_args=tuple(hook_args),
+                    hook_kwargs=dict(hook_kwargs) if hook_kwargs else {},
+                    hook_unavailable_exit_code=_HOOK_UNAVAILABLE_EXIT_CODE,
+                    result_file=fp.name,
+                ),
+            )
         )
         process = subprocess.Popen(
             args=args,

--- a/pex/pex_boot.py
+++ b/pex/pex_boot.py
@@ -148,6 +148,7 @@ def boot(
     hermetic_venv_scripts,  # type: bool
     pex_path,  # type: Tuple[str, ...]
     is_venv,  # type: bool
+    inject_python_args,  # type: Tuple[str, ...]
 ):
     # type: (...) -> int
 
@@ -170,7 +171,7 @@ def boot(
         sys.stderr.write("Could not launch python executable!\\n")
         return 2
 
-    python_args = []  # type: List[str]
+    python_args = list(inject_python_args)  # type: List[str]
     orig_args = orig_argv()
     if orig_args:
         for index, arg in enumerate(orig_args[1:], start=1):

--- a/pex/pex_boot.py
+++ b/pex/pex_boot.py
@@ -1,0 +1,164 @@
+# Copyright 2014 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+import sys
+
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    from typing import NoReturn, Optional, Tuple
+
+
+def __re_exec__(
+    argv0,  # type: str
+    *extra_launch_args  # type: str
+):
+    # type: (...) -> NoReturn
+
+    os.execv(argv0, [argv0] + list(extra_launch_args) + sys.argv[1:])
+
+
+__SHOULD_EXECUTE__ = __name__ == "__main__"
+
+
+def __entry_point_from_filename__(filename):
+    # type: (str) -> str
+
+    # Either the entry point is "__main__" and we're in execute mode or "__pex__/__init__.py"
+    # and we're in import hook mode.
+    entry_point = os.path.dirname(filename)
+    if __SHOULD_EXECUTE__:
+        return entry_point
+    return os.path.dirname(entry_point)
+
+
+__INSTALLED_FROM__ = "__PEX_EXE__"
+
+
+def __ensure_pex_installed__(
+    pex,  # type: str
+    pex_root,  # type: str
+    pex_hash,  # type: str
+):
+    # type: (...) -> Optional[str]
+
+    from pex.layout import ensure_installed
+    from pex.tracer import TRACER
+
+    installed_location = ensure_installed(pex=pex, pex_root=pex_root, pex_hash=pex_hash)
+    if not __SHOULD_EXECUTE__ or pex == installed_location:
+        return installed_location
+
+    # N.B.: This is read upon re-exec below to point sys.argv[0] back to the original pex
+    # before unconditionally scrubbing the env var and handing off to user code.
+    os.environ[__INSTALLED_FROM__] = pex
+
+    TRACER.log(
+        "Executing installed PEX for {pex} at {installed_location}".format(
+            pex=pex, installed_location=installed_location
+        )
+    )
+    __re_exec__(sys.executable, installed_location)
+
+
+def __maybe_run_venv__(
+    pex,  # type: str
+    pex_root,  # type: str
+    pex_hash,  # type: str
+    has_interpreter_constraints,  # type: bool
+    hermetic_venv_scripts,  # type: bool
+    pex_path,  # type: Tuple[str, ...]
+):
+    # type: (...) -> Optional[str]
+
+    from pex.common import is_exe
+    from pex.tracer import TRACER
+    from pex.variables import venv_dir
+
+    venv_root_dir = venv_dir(
+        pex_file=pex,
+        pex_root=pex_root,
+        pex_hash=pex_hash,
+        has_interpreter_constraints=has_interpreter_constraints,
+        pex_path=pex_path,
+    )
+    venv_pex = os.path.join(venv_root_dir, "pex")
+    if not __SHOULD_EXECUTE__ or not is_exe(venv_pex):
+        # Code in bootstrap_pex will (re)create the venv after selecting the correct
+        # interpreter.
+        return venv_root_dir
+
+    TRACER.log("Executing venv PEX for {pex} at {venv_pex}".format(pex=pex, venv_pex=venv_pex))
+    venv_python = os.path.join(venv_root_dir, "bin", "python")
+    if hermetic_venv_scripts:
+        __re_exec__(venv_python, "-sE", venv_pex)
+    else:
+        __re_exec__(venv_python, venv_pex)
+
+
+def boot(
+    bootstrap_dir,  # type: str
+    pex_root,  # type: str
+    pex_hash,  # type: str
+    has_interpreter_constraints,  # type: bool
+    hermetic_venv_scripts,  # type: bool
+    pex_path,  # type: Tuple[str, ...]
+    is_venv,  # type: bool
+):
+    # type: (...) -> int
+
+    entry_point = None  # type: Optional[str]
+    __file__ = globals().get("__file__")
+    __loader__ = globals().get("__loader__")
+    if __file__ is not None and os.path.exists(__file__):
+        entry_point = __entry_point_from_filename__(__file__)
+    elif __loader__ is not None:
+        if hasattr(__loader__, "archive"):
+            entry_point = __loader__.archive
+        elif hasattr(__loader__, "get_filename"):
+            # The source of the loader interface has changed over the course of Python history
+            # from `pkgutil.ImpLoader` to `importlib.abc.Loader`, but the existence and
+            # semantics of `get_filename` has remained constant; so we just check for the
+            # method.
+            entry_point = __entry_point_from_filename__(__loader__.get_filename())
+
+    if entry_point is None:
+        sys.stderr.write("Could not launch python executable!\\n")
+        return 2
+
+    installed_from = os.environ.pop(__INSTALLED_FROM__, None)
+    sys.argv[0] = installed_from or sys.argv[0]
+
+    sys.path[0] = os.path.abspath(sys.path[0])
+    sys.path.insert(0, os.path.abspath(os.path.join(entry_point, bootstrap_dir)))
+
+    venv_dir = None  # type: Optional[str]
+    if not installed_from:
+        os.environ["PEX"] = os.path.realpath(entry_point)
+        from pex.variables import ENV, Variables
+
+        pex_root = Variables.PEX_ROOT.value_or(ENV, pex_root)
+
+        if not ENV.PEX_TOOLS and Variables.PEX_VENV.value_or(ENV, is_venv):
+            venv_dir = __maybe_run_venv__(
+                pex=entry_point,
+                pex_root=pex_root,
+                pex_hash=pex_hash,
+                has_interpreter_constraints=has_interpreter_constraints,
+                hermetic_venv_scripts=hermetic_venv_scripts,
+                pex_path=ENV.PEX_PATH or pex_path,
+            )
+        entry_point = __ensure_pex_installed__(
+            pex=entry_point, pex_root=pex_root, pex_hash=pex_hash
+        )
+        if entry_point is None:
+            # This means we re-exec'd ourselves already; so this just appeases type checking.
+            return 0
+    else:
+        os.environ["PEX"] = os.path.realpath(installed_from)
+
+    from pex.pex_bootstrapper import bootstrap_pex
+
+    bootstrap_pex(entry_point, execute=__SHOULD_EXECUTE__, venv_dir=venv_dir)
+    return 0

--- a/pex/pex_boot.py
+++ b/pex/pex_boot.py
@@ -20,7 +20,7 @@ else:
     try:
         import ctypes
 
-        # N.B.: Of the PyPy versions we support, only PyPy>=3.10 supports the pythonapi.
+        # N.B.: None of the PyPy versions we support <3.10 supports the pythonapi.
         from ctypes import pythonapi
 
         def orig_argv():

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -500,6 +500,7 @@ class PEXBuilder(object):
                 hermetic_venv_scripts={hermetic_venv_scripts!r},
                 pex_path={pex_path!r},
                 is_venv={is_venv!r},
+                inject_python_args={inject_python_args!r},
             )
             if __SHOULD_EXECUTE__:
                 sys.exit(result)
@@ -512,6 +513,7 @@ class PEXBuilder(object):
             hermetic_venv_scripts=self._pex_info.venv_hermetic_scripts,
             pex_path=self._pex_info.pex_path,
             is_venv=self._pex_info.venv,
+            inject_python_args=self._pex_info.inject_python_args,
         )
         bootstrap = pex_boot + "\n" + pex_main
 

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -171,6 +171,16 @@ class PexInfo(object):
         self._pex_info["build_properties"].update(value)
 
     @property
+    def inject_python_args(self):
+        # type: () -> Tuple[str, ...]
+        return tuple(self._pex_info.get("inject_python_args", ()))
+
+    @inject_python_args.setter
+    def inject_python_args(self, value):
+        # type: (Iterable[str]) -> None
+        self._pex_info["inject_python_args"] = tuple(value)
+
+    @property
     def inject_env(self):
         # type: () -> Dict[str, str]
         return dict(self._pex_info.get("inject_env", {}))

--- a/tests/integration/test_inject_python_args.py
+++ b/tests/integration/test_inject_python_args.py
@@ -69,10 +69,9 @@ def assert_exe_output(
     error = stderr.decode("utf-8")
     assert 0 == process.returncode, error
     assert ["--foo", "bar"] == json.loads(stdout)
-    if warning_expected:
-        assert "If you don't eat your meat, you can't have any pudding!" in error, error
-    else:
-        assert "" == error
+    assert warning_expected == (
+        "If you don't eat your meat, you can't have any pudding!" in error
+    ), error
 
 
 @pytest.mark.skipif(

--- a/tests/integration/test_inject_python_args.py
+++ b/tests/integration/test_inject_python_args.py
@@ -1,0 +1,262 @@
+# Copyright 2022 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import json
+import os.path
+import shutil
+import subprocess
+import sys
+from textwrap import dedent
+
+import pytest
+
+from pex.typing import TYPE_CHECKING
+from testing import IS_PYPY, run_pex_command
+
+if TYPE_CHECKING:
+    from typing import Any, Iterable, List
+
+parametrize_execution_mode_args = pytest.mark.parametrize(
+    "execution_mode_args",
+    [
+        pytest.param([], id="ZIPAPP"),
+        pytest.param(["--venv"], id="VENV"),
+    ],
+)
+
+
+parametrize_boot_mode_args = pytest.mark.parametrize(
+    "boot_mode_args",
+    [
+        pytest.param([], id="PYTHON"),
+        pytest.param(["--sh-boot"], id="SH_BOOT"),
+    ],
+)
+
+
+@pytest.fixture
+def exe(tmpdir):
+    # type: (Any) -> str
+    exe = os.path.join(str(tmpdir), "exe.py")
+    with open(exe, "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                import json
+                import sys
+                import warnings
+
+
+                warnings.warn("If you don't eat your meat, you can't have any pudding!")
+                json.dump(sys.argv[1:], sys.stdout)
+                """
+            )
+        )
+    return exe
+
+
+def assert_exe_output(
+    pex,  # type: str
+    warning_expected,  # type: bool
+    prefix_args=(),  # type: Iterable[str]
+):
+    process = subprocess.Popen(
+        args=list(prefix_args) + [pex, "--foo", "bar"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    stdout, stderr = process.communicate()
+    error = stderr.decode("utf-8")
+    assert 0 == process.returncode, error
+    assert ["--foo", "bar"] == json.loads(stdout)
+    if warning_expected:
+        assert "If you don't eat your meat, you can't have any pudding!" in error, error
+    else:
+        assert "" == error
+
+
+@pytest.mark.skipif(
+    IS_PYPY and sys.version_info[:2] < (3, 10),
+    reason=(
+        "Pex cannot retrieve the original argv when running under PyPy<3.10 which prevents "
+        "passthrough."
+    ),
+)
+@parametrize_execution_mode_args
+@parametrize_boot_mode_args
+def test_python_args_passthrough(
+    tmpdir,  # type: Any
+    execution_mode_args,  # type: List[str]
+    boot_mode_args,  # type: List[str]
+    exe,  # type: str
+):
+    # type: (...) -> None
+
+    default_shebang_pex = os.path.join(str(tmpdir), "default_shebang.pex")
+    custom_shebang_pex = os.path.join(str(tmpdir), "custom_shebang.pex")
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+
+    args = (
+        execution_mode_args
+        + boot_mode_args
+        + [
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "--exe",
+            exe,
+        ]
+    )
+    run_pex_command(args=args + ["-o", default_shebang_pex]).assert_success()
+    run_pex_command(
+        args=args
+        + [
+            "-o",
+            custom_shebang_pex,
+            "--python-shebang",
+            "{python} -Wignore".format(python=sys.executable),
+        ]
+    ).assert_success()
+
+    # N.B.: We execute tests in doubles after a cache nuke to exercise both cold and warm runs
+    # which take different re-exec paths through the code that all need to preserve Python args.
+
+    # The built-in python shebang args, if any, should be respected.
+    shutil.rmtree(pex_root)
+    assert_exe_output(default_shebang_pex, warning_expected=True)
+    assert_exe_output(default_shebang_pex, warning_expected=True)
+    assert_exe_output(custom_shebang_pex, warning_expected=False)
+    assert_exe_output(custom_shebang_pex, warning_expected=False)
+
+    # But they also should be able to be over-ridden.
+    shutil.rmtree(pex_root)
+    assert_exe_output(
+        default_shebang_pex, prefix_args=[sys.executable, "-Wignore"], warning_expected=False
+    )
+    assert_exe_output(
+        default_shebang_pex, prefix_args=[sys.executable, "-Wignore"], warning_expected=False
+    )
+    assert_exe_output(custom_shebang_pex, prefix_args=[sys.executable], warning_expected=True)
+    assert_exe_output(custom_shebang_pex, prefix_args=[sys.executable], warning_expected=True)
+
+
+@parametrize_execution_mode_args
+@parametrize_boot_mode_args
+def test_inject_python_args(
+    tmpdir,  # type: Any
+    execution_mode_args,  # type: List[str]
+    boot_mode_args,  # type: List[str]
+    exe,  # type: str
+):
+    # type: (...) -> None
+
+    pex = os.path.join(str(tmpdir), "pex")
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+
+    run_pex_command(
+        args=execution_mode_args
+        + boot_mode_args
+        + [
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "--exe",
+            exe,
+            "--inject-python-args=-W ignore",
+            "-o",
+            pex,
+        ]
+    ).assert_success()
+
+    assert_exe_output(pex, warning_expected=False)
+    assert_exe_output(pex, warning_expected=False)
+
+    # N.B.: The original argv cannot be detected by Pex running under PyPy<3.10; so we expect
+    # warnings to be turned off (the default sealed in by `--inject-python-args`). For all other
+    # Pythons we support, these explicit command line Python args should be detected and trump the
+    # injected args by dint of occurring later in the command line. In other words, the command line
+    # should be as follows and Python is known to pick the last occurrence of the -W option:
+    #
+    #   python -W ignore -W always ...
+    #
+    warning_expected = not IS_PYPY or sys.version_info[:2] >= (3, 10)
+    assert_exe_output(
+        pex, prefix_args=[sys.executable, "-W", "always"], warning_expected=warning_expected
+    )
+    assert_exe_output(
+        pex, prefix_args=[sys.executable, "-W", "always"], warning_expected=warning_expected
+    )
+
+
+@pytest.mark.skipif(
+    sys.version_info[:2] < (3, 10 if IS_PYPY else 9),
+    reason=(
+        "The effect of `-u` on the `sys.stdout.buffer` type used in this test is only "
+        "differentiable from a lack of `-u` for these Pythons."
+    ),
+)
+@parametrize_execution_mode_args
+@parametrize_boot_mode_args
+def test_issue_2422(
+    tmpdir,  # type: Any
+    execution_mode_args,  # type: List[str]
+    boot_mode_args,  # type: List[str]
+):
+    # type: (...) -> None
+
+    pex = os.path.join(str(tmpdir), "pex")
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+
+    exe = os.path.join(str(tmpdir), "exe.py")
+    with open(exe, "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                import sys
+
+
+                if __name__ == "__main__":
+                    print(type(sys.stdout.buffer).__name__)
+                """
+            )
+        )
+
+    args = ["--pex-root", pex_root, "--runtime-pex-root", pex_root, "--exe", exe, "-o", pex]
+    args.extend(execution_mode_args)
+    args.extend(boot_mode_args)
+
+    run_pex_command(args=args).assert_success()
+    shutil.rmtree(pex_root)
+    assert b"BufferedWriter\n" == subprocess.check_output(args=[sys.executable, exe])
+    assert b"BufferedWriter\n" == subprocess.check_output(
+        args=[pex]
+    ), "Expected cold run to use buffered io."
+    # assert b"BufferedWriter\n" == subprocess.check_output(
+    #     args=[pex]
+    # ), "Expected warm run to use buffered io."
+
+    assert b"FileIO\n" == subprocess.check_output(
+        args=[sys.executable, "-u", pex]
+    ), "Expected explicit Python arguments to be honored."
+
+    run_pex_command(args=args + ["--inject-python-args=-u"]).assert_success()
+    shutil.rmtree(pex_root)
+    assert b"FileIO\n" == subprocess.check_output(args=[sys.executable, "-u", exe])
+    assert b"FileIO\n" == subprocess.check_output(
+        args=[pex]
+    ), "Expected cold run to use un-buffered io."
+    assert b"FileIO\n" == subprocess.check_output(
+        args=[pex]
+    ), "Expected warm run to use un-buffered io."
+
+    process = subprocess.Popen(
+        args=[sys.executable, "-v", pex],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    stdout, stderr = process.communicate()
+    assert 0 == process.returncode
+    assert b"FileIO\n" == stdout, "Expected injected Python arguments to be honored."
+    assert b"import " in stderr, "Expected explicit Python arguments to be honored as well."

--- a/tests/integration/test_inject_python_args.py
+++ b/tests/integration/test_inject_python_args.py
@@ -233,9 +233,9 @@ def test_issue_2422(
     assert b"BufferedWriter\n" == subprocess.check_output(
         args=[pex]
     ), "Expected cold run to use buffered io."
-    # assert b"BufferedWriter\n" == subprocess.check_output(
-    #     args=[pex]
-    # ), "Expected warm run to use buffered io."
+    assert b"BufferedWriter\n" == subprocess.check_output(
+        args=[pex]
+    ), "Expected warm run to use buffered io."
 
     assert b"FileIO\n" == subprocess.check_output(
         args=[sys.executable, "-u", pex]


### PR DESCRIPTION
Support preserving and injecting Python args.

Pex now supports `--inject-python-args` similar to `--inject-args` but
for specifying arguments to pass to the Python interpreter as opposed to
arguments to pass to the application code. This is supported for both
zipapp and venv execution modes as well as standard shebang launching,
launching via a Python explicitly or via the `--sh-boot` mechanism.

In addition, PEX files now support detecting and passing through Python
args embedded in shebangs or passed explicitly on the command line for
all Pythons Pex supports save for `PyPy<3.10` where there appears to be
no facility to retrieve the original argv PyPy was executed with.

Closes #2422