### PR TITLE
Clean up after the 2.4.0 release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,14 +15,24 @@ arguments appear first on the synthesized command line and the
 explicitly passed arguments appear last so that the explicit arguments
 can trump (which is how Python handles this).
 
-Finally, several bugs existing in the `--exclude` implementation since
-its introduction are now fixed and the feature is greatly improved to
-act on excludes eagerly, never traversing them in the resolve process;
-thus avoiding downloads associated with them as well as potentially
-failing metadata extraction & wheel builds for ill-behaved sdists.
+Several bugs existing in the `--exclude` implementation since its
+introduction are now fixed and the feature is greatly improved to act on
+excludes eagerly, never traversing them in the resolve process; thus
+avoiding downloads associated with them as well as potentially failing
+metadata extraction & wheel builds for ill-behaved sdists.
+
+Finally, a bug was fixed in `pex3 lock export` for lock files containing
+either locked VCS requirements or locked local project directories.
+Previously, these were exported with a `<project name>==<version>`
+requirement, which lost fidelity with the input requirement. Now they
+are exported with their original requirement form. Further, since the
+`--hash` of these styles of locked requirement are unuseable outside
+Pex, a new `--format` option of `pip-no-hashes` is introduced for the
+adventurous.
 
 * Implement support for preserving and injecting Python args. (#2427)
 * Fix `--exclude`. (#2409)
+* Fix `pex3 lock export` handling of exotic reqs. (#2423)
 
 ## 2.3.3
 

--- a/pex/pip/excludes/__init__.py
+++ b/pex/pip/excludes/__init__.py
@@ -22,8 +22,6 @@ class PatchContext(object):
     def load_exclude_configuration(cls):
         # type: () -> ExcludeConfiguration
 
-        # N.B.: The following environment variable is used by the Pex runtime to control Pip and
-        # must be kept in-sync with `__init__.py`.
         excludes_file = os.environ.pop(cls._PEX_EXCLUDES_FILE_ENV_VAR_NAME)
         with open(excludes_file) as fp:
             return ExcludeConfiguration.create(json.load(fp))

--- a/pex/pip/excludes/requires.py
+++ b/pex/pip/excludes/requires.py
@@ -3,22 +3,16 @@
 
 from __future__ import absolute_import, print_function
 
-import json
 import logging
-import os
 
 logger = logging.getLogger(__name__)
 
 
 def patch():
     from pex.dist_metadata import Requirement
-    from pex.exclude_configuration import ExcludeConfiguration
+    from pex.pip.excludes import PatchContext
 
-    # N.B.: The following environment variable is used by the Pex runtime to control Pip and must
-    # be kept in-sync with `__init__.py`.
-    excludes_file = os.environ.pop("_PEX_EXCLUDES_FILE")
-    with open(excludes_file) as fp:
-        exclude_configuration = ExcludeConfiguration.create(json.load(fp))
+    exclude_configuration = PatchContext.load_exclude_configuration()
 
     def create_requires(orig_requires):
         def requires(self, *args, **kwargs):
@@ -28,7 +22,7 @@ def patch():
                 if excluded_by:
                     logger.debug(
                         "[{type}: patched {orig_requires}] Excluded {dep} from {dist} due to "
-                        "configured excludes: {excludes}".format(
+                        "Pex-configured excludes: {excludes}".format(
                             orig_requires=orig_requires,
                             type=type(self),
                             dep=repr(str(req)),


### PR DESCRIPTION
+ Fix a missed item in the changelog.
+ Clean up the `--exclude` Pip patch and improve its logging.