### PR TITLE
Support `--pip-version 24.1` and Python 3.13.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,8 @@ jobs:
           - py311-pip20
           - py311-pip22_3_1
           - py311-pip23_1_2
-          - py312-pip24_0
-          - py313-pip24_0_patched
+          - py312-pip24_1
+          - py313-pip24_1
           - pypy310-pip20
           - pypy310-pip22_3_1
           - pypy310-pip23_1_2
@@ -84,8 +84,8 @@ jobs:
           - py311-pip20-integration
           - py311-pip22_3_1-integration
           - py311-pip23_1_2-integration
-          - py312-pip24_0-integration
-          - py313-pip24_0_patched-integration
+          - py312-pip24_1-integration
+          - py313-pip24_1-integration
           - pypy310-pip20-integration
           - pypy310-pip22_3_1-integration
           - pypy310-pip23_1_2-integration
@@ -129,10 +129,10 @@ jobs:
       matrix:
         include:
           - python-version: [ 3, 12 ]
-            tox-env: py312-pip24_0
+            tox-env: py312-pip24_1
             tox-env-python: python3.11
           - python-version: [ 3, 12 ]
-            tox-env: py312-pip24_0-integration
+            tox-env: py312-pip24_1-integration
             tox-env-python: python3.11
     steps:
       - name: Calculate Pythons to Expose

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 2.5.0
+
+This release brings support for Python 3.13 and `--pip-version 24.1`,
+which is the first Pip version to support it.
+
+* Support `--pip-version 24.1` and Python 3.13. (#2434)
+
 ## 2.4.1
 
 This release fixes `pex --only-binary X --lock ...` to work with lock

--- a/pex/pip/foreign_platform/markers.py
+++ b/pex/pip/foreign_platform/markers.py
@@ -3,17 +3,53 @@
 
 from __future__ import absolute_import
 
-import json
-import os
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Dict
 
 
 def patch():
+    # type: () -> None
+
     from pip._vendor.packaging import markers  # type: ignore[import]
 
-    # N.B.: The following environment variable is used by the Pex runtime to control Pip and must be
-    # kept in-sync with `__init__.py`.
-    patched_markers_file = os.environ.pop("_PEX_PATCHED_MARKERS_FILE")
-    with open(patched_markers_file) as fp:
-        patched_markers = json.load(fp)
+    from pex.exceptions import production_assert
+    from pex.pip.foreign_platform import EvaluationEnvironment, PatchContext
 
-    markers.default_environment = patched_markers.copy
+    evaluation_environment = PatchContext.load_evaluation_environment()
+
+    def _get_env(
+        environment,  # type: Dict[Any, Any]
+        name,  # type: Any
+    ):
+        # type: (...) -> Any
+        production_assert(
+            isinstance(environment, EvaluationEnvironment),
+            "Expected environment to come from the {function} function, "
+            "which we patch to return {expected_type}, but was {actual_type}".format(
+                function=markers.default_environment,
+                expected_type=EvaluationEnvironment,
+                actual_type=type(environment),
+            ),
+        )
+        return environment[name]
+
+    # Works with all Pip vendored packaging distributions.
+    markers.default_environment = evaluation_environment.default
+    # Covers Pip<24.1 vendored packaging.
+    markers._get_env = _get_env
+
+    original_eval_op = markers._eval_op
+
+    def _eval_op(
+        lhs,  # type: Any
+        op,  # type: Any
+        rhs,  # type: Any
+    ):
+        # type: (...) -> Any
+        evaluation_environment.raise_if_missing(lhs)
+        evaluation_environment.raise_if_missing(rhs)
+        return original_eval_op(lhs, op, rhs)
+
+    markers._eval_op = _eval_op

--- a/pex/pip/version.py
+++ b/pex/pip/version.py
@@ -257,21 +257,13 @@ class PipVersion(Enum["PipVersionValue"]):
         requires_python=">=3.7,<3.13",
     )
 
-    # This is https://github.com/pypa/pip/pull/12462 which is approved but not yet merged or
-    # released. It allows testing Python 3.13 pre-releases but should not be used by the public; so
-    # we keep it hidden.
-    v24_0_dev0_patched = PipVersionValue(
-        name="24.0.dev0-patched",
-        version="24.0.dev0+patched",
-        requirement=(
-            "pip @ git+https://github.com/jsirois/pip@0257c9422f7bb99a6f319b54f808a5c50339be6c"
-        ),
-        setuptools_version="69.0.3",
-        wheel_version="0.42.0",
-        requires_python=">=3.7",
-        hidden=True,
+    v24_1 = PipVersionValue(
+        version="24.1",
+        setuptools_version="70.1.0",
+        wheel_version="0.43.0",
+        requires_python=">=3.8,<3.14",
     )
 
     VENDORED = v20_3_4_patched
     LATEST = LatestPipVersion()
-    DEFAULT = DefaultPipVersion(preferred=(VENDORED, v23_2))
+    DEFAULT = DefaultPipVersion(preferred=(VENDORED, v23_2, v24_1))

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.4.1"
+__version__ = "2.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ requires = ["hatchling"]
 expand = {"pex_version" = "version"}
 
 [tool.hatch.metadata.hooks.pex-adjust-metadata.project]
-requires-python = ">=2.7,<3.13,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+requires-python = ">=2.7,<3.14,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 
 [tool.hatch.metadata.hooks.pex-adjust-metadata.project.urls]
 Changelog = "https://github.com/pex-tool/pex/blob/v{pex_version}/CHANGES.md"
@@ -59,6 +59,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Software Development :: Build Tools",

--- a/tests/integration/cli/commands/test_issue_1667.py
+++ b/tests/integration/cli/commands/test_issue_1667.py
@@ -47,6 +47,8 @@ def test_interpreter_constraints_range_coverage(
         "create",
         "--style",
         "universal",
+        "--pip-version",
+        "24.0",
         "--resolver-version",
         "pip-2020-resolver",
         "--interpreter-constraint",

--- a/tests/integration/cli/commands/test_issue_2050.py
+++ b/tests/integration/cli/commands/test_issue_2050.py
@@ -101,7 +101,7 @@ def test_lock_uncompilable_sdist(
 
 
                 setup_kwargs = dict(
-                    name="pex.tests.bad-c-extension",
+                    name="pex_tests_bad_c_extension",
                     version="0.1.0+test",
                     author="John Sirois",
                     author_email="js@example.com",
@@ -122,7 +122,7 @@ def test_lock_uncompilable_sdist(
         "create",
         "-f",
         repo.find_links,
-        "pex.tests.bad-c-extension",
+        "pex_tests_bad_c_extension",
         "--path-mapping",
         repo.path_mapping_arg,
         "--indent",
@@ -143,7 +143,7 @@ def test_lock_uncompilable_sdist(
         locked_requirement.pin.project_name: locked_requirement
         for locked_requirement in locked_resolve.locked_requirements
     }  # type: Dict[ProjectName, LockedRequirement]
-    bad = locked_requirements.pop(ProjectName("pex.tests.bad-c-extension"))
+    bad = locked_requirements.pop(ProjectName("pex_tests_bad_c_extension"))
     assert Version("0.1.0+test") == bad.pin.version
     assert SpecifierSet(">=3.5") == bad.requires_python
     assert SortedTuple([Requirement.parse("ansicolors==1.1.8")]) == bad.requires_dists
@@ -152,7 +152,7 @@ def test_lock_uncompilable_sdist(
 
     result = run_pex_command(args=["--lock", lock, "--path-mapping", repo.path_mapping_arg])
     result.assert_failure()
-    assert "pex.tests.bad-c-extension-0.1.0+test.tar.gz" in result.error, result.error
+    assert "pex_tests_bad_c_extension-0.1.0+test.tar.gz" in result.error, result.error
     assert "ERROR: Failed to build one or more wheels" in result.error, result.error
 
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1733,9 +1733,15 @@ def test_pip_issues_9420_workaround():
 
     # N.B.: isort 5.7.0 needs Python >=3.6
     python = ensure_python_interpreter(PY310)
-
     results = run_pex_command(
-        args=["--resolver-version", "pip-2020-resolver", "isort[colors]==5.7.0", "colorama==0.4.1"],
+        args=[
+            "--pip-version",
+            "24.1",
+            "--resolver-version",
+            "pip-2020-resolver",
+            "isort[colors]==5.7.0",
+            "colorama==0.4.1",
+        ],
         python=python,
         quiet=True,
     )
@@ -1760,7 +1766,7 @@ def test_pip_issues_9420_workaround():
 
             To fix this you could try to:
             1. loosen the range of package versions you've specified
-            2. remove package versions to allow pip attempt to solve the dependency conflict
+            2. remove package versions to allow pip to attempt to solve the dependency conflict
             """
         ).strip()
     )

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -231,21 +231,23 @@ def test_download_platform_markers_issue_1366_indeterminate(
     python310_interpreter = PythonInterpreter.from_binary(ensure_python_interpreter(PY310))
     pip = create_pip(python310_interpreter, version=version)
 
-    python27_platform = Platform.create("manylinux_2_33_x86_64-cp-27-cp27mu")
+    target = AbbreviatedPlatform.create(Platform.create("manylinux_2_33_x86_64-cp-27-cp27mu"))
     download_dir = os.path.join(str(tmpdir), "downloads")
 
     with pytest.raises(Job.Error) as exc_info:
         pip.spawn_download_distributions(
-            target=AbbreviatedPlatform.create(python27_platform),
+            target=target,
             requirements=["typing_extensions==3.7.4.2; python_full_version < '3.8'"],
             download_dir=download_dir,
             transitive=False,
         ).wait()
     assert (
-        "Failed to resolve for platform manylinux_2_33_x86_64-cp-27-cp27mu. Resolve requires "
+        "Failed to resolve for {target_description}. Resolve requires "
         "evaluation of unknown environment marker: 'python_full_version' does not exist in "
         "evaluation environment."
-    ) in str(exc_info.value)
+    ).format(target_description=target.render_description()) in str(exc_info.value), str(
+        exc_info.value
+    )
 
 
 @applicable_pip_versions

--- a/tox.ini
+++ b/tox.ini
@@ -85,10 +85,7 @@ setenv =
     pip23_3_1: _PEX_PIP_VERSION=23.3.1
     pip23_3_2: _PEX_PIP_VERSION=23.3.2
     pip24_0: _PEX_PIP_VERSION=24.0
-
-    # This Pip and custom Requires-Python are just here to support un-released Python 3.13 testing.
-    pip24_0_patched: _PEX_PIP_VERSION=24.0.dev0-patched
-    pip24_0_patched: _PEX_REQUIRES_PYTHON=>=2.7,<3.14,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*
+    pip24_1: _PEX_PIP_VERSION=24.1
 
     # Python 3 (until a fix here in 3.9: https://bugs.python.org/issue13601) switched from stderr
     # being unbuffered to stderr being buffered by default. This can lead to tests checking stderr


### PR DESCRIPTION
Pex has been testing against Python 3.13 alpha and then beta releases 
for a while now using a patched Pip with Python 3.13 support. Those
patches have made it into the Pip 24.1 release; so now Pex can
officially support Python 3.13.

The Pip 24.1 release notes: https://pip.pypa.io/en/stable/news/#v24-1

Closes #2406