### PR TITLE
Add support for PEP-723 script metadata to `--exe`.

### DIFF
--- a/pex/interpreter_constraints.py
+++ b/pex/interpreter_constraints.py
@@ -134,6 +134,9 @@ class InterpreterConstraints(object):
         # type: () -> bool
         return bool(self.constraints)
 
+    # N.B.: For Python 2.7.
+    __nonzero__ = __bool__
+
     def __len__(self):
         # type: () -> int
         return len(self.constraints)

--- a/pex/pep_723.py
+++ b/pex/pep_723.py
@@ -1,0 +1,71 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import re
+
+from pex.dist_metadata import Requirement
+from pex.third_party.packaging.specifiers import SpecifierSet
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Tuple
+
+    import attr  # vendor:skip
+    import toml  # vendor:skip
+else:
+    from pex.third_party import attr, toml
+
+
+@attr.s(frozen=True)
+class ScriptMetadata(object):
+
+    _UNSPECIFIED_SOURCE = "<unspecified source>"
+
+    @classmethod
+    def parse(
+        cls,
+        script,  # type: str
+        source=_UNSPECIFIED_SOURCE,  # type: str
+    ):
+        # type: (...) -> ScriptMetadata
+
+        # The spec this code follows was defined in PEP-723: https://peps.python.org/pep-0723/
+        # and now lives here:
+        # https://packaging.python.org/specifications/inline-script-metadata#inline-script-metadata
+        matches = list(
+            re.finditer(r"^# /// script$\s(?P<content>(^#(| .*)$\s)+)^# ///$", script, re.MULTILINE)
+        )
+        if not matches:
+            return cls()
+        if len(matches) > 1:
+            raise ValueError(
+                "Multiple `script` metadata blocks found and at most one is allowed. "
+                "See: https://packaging.python.org/en/latest/specifications/"
+                "inline-script-metadata/#inline-script-metadata"
+            )
+        content = "".join(
+            line[2:] if line.startswith("# ") else line[1:]
+            for line in matches[0].group("content").splitlines(True)
+        )
+        script_metadata = toml.loads(content)
+
+        return cls(
+            dependencies=tuple(
+                Requirement.parse(req) for req in script_metadata.get("dependencies", ())
+            ),
+            requires_python=SpecifierSet(script_metadata.get("requires-python", "")),
+            source=source,
+        )
+
+    dependencies = attr.ib(default=())  # type: Tuple[Requirement, ...]
+    requires_python = attr.ib(default=SpecifierSet())  # type: SpecifierSet
+    source = attr.ib(default=_UNSPECIFIED_SOURCE)  # type: str
+
+    def __bool__(self):
+        # type: () -> bool
+        return bool(self.dependencies) or bool(self.requires_python)
+
+    # N.B.: For Python 2.7.
+    __nonzero__ = __bool__

--- a/pex/pep_723.py
+++ b/pex/pep_723.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import
 import os
 import re
 from collections import OrderedDict
-from typing import Any, Mapping
 
 from pex.common import pluralize
 from pex.compatibility import string
@@ -15,7 +14,7 @@ from pex.third_party.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from typing import List, Tuple
+    from typing import Any, List, Mapping, Tuple
 
     import attr  # vendor:skip
     import toml  # vendor:skip

--- a/pex/pep_723.py
+++ b/pex/pep_723.py
@@ -3,14 +3,19 @@
 
 from __future__ import absolute_import
 
+import os
 import re
+from collections import OrderedDict
+from typing import Any, Mapping
 
-from pex.dist_metadata import Requirement
-from pex.third_party.packaging.specifiers import SpecifierSet
-from pex.typing import TYPE_CHECKING
+from pex.common import pluralize
+from pex.compatibility import string
+from pex.dist_metadata import Requirement, RequirementParseError
+from pex.third_party.packaging.specifiers import InvalidSpecifier, SpecifierSet
+from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from typing import Tuple
+    from typing import List, Tuple
 
     import attr  # vendor:skip
     import toml  # vendor:skip
@@ -18,11 +23,160 @@ else:
     from pex.third_party import attr, toml
 
 
+_UNSPECIFIED_SOURCE = "<unspecified source>"
+_SPEC_URL = (
+    "https://packaging.python.org/specifications/inline-script-metadata#inline-script-metadata"
+)
+
+
+class InvalidMetadataError(ValueError):
+    """Indicates invalid PEP-723 script metadata."""
+
+
+@attr.s(frozen=True)
+class MetadataBlock(object):
+    source = attr.ib()  # type: str
+    start_line = attr.ib()  # type: int
+    type = attr.ib()  # type: str
+    content = attr.ib()  # type: Tuple[str, ...]
+
+    def create_metadata_error(self, problem_clause):
+        # type: (str) -> InvalidMetadataError
+        return InvalidMetadataError(
+            "The script metadata found in {source} starting at line {line} {problem_clause}.\n"
+            "See: {spec_url}".format(
+                source=self.source,
+                line=self.start_line,
+                problem_clause=problem_clause,
+                spec_url=_SPEC_URL,
+            )
+        )
+
+    def parse_metadata(self):
+        # type: () -> Mapping[str, Any]
+        stripped_content = os.linesep.join(
+            line[2:] if line.startswith("# ") else line[1:] for line in self.content
+        )
+        try:
+            return cast("Mapping[str, Any]", toml.loads(stripped_content))
+        except toml.TomlDecodeError as e:
+            raise self.create_metadata_error("embeds malformed toml: {err}".format(err=e))
+
+
+@attr.s
+class ParseState(object):
+    start_type = attr.ib(default="", init=False)  # type: str
+    start_line = attr.ib(default=0, init=False)  # type: int
+    end_line = attr.ib(default=0, init=False)  # type: int
+
+    def reset(
+        self,
+        start_type="",  # type: str
+        start_line=0,  # type: int
+    ):
+        # type: (...) -> None
+        self.start_type = start_type
+        self.start_line = start_line
+        self.end_line = 0
+
+    @property
+    def started(self):
+        # type: () -> bool
+        return bool(self.start_type) and self.start_line > 0
+
+    @property
+    def finished(self):
+        # type: () -> bool
+        return self.started and self.end_line >= self.start_line
+
+
+def parse_metadata_blocks(
+    script,  # type: str
+    source=_UNSPECIFIED_SOURCE,  # type: str
+):
+    # type: (...) -> Mapping[str, MetadataBlock]
+
+    lines = script.splitlines()
+    metadata_blocks = OrderedDict()  # type: OrderedDict[str, List[MetadataBlock]]
+    parse_state = ParseState()
+
+    def add_metadata_block():
+        # type: () -> None
+        metadata_blocks.setdefault(parse_state.start_type, []).append(
+            MetadataBlock(
+                source=source,
+                start_line=parse_state.start_line,
+                type=parse_state.start_type,
+                content=tuple(lines[parse_state.start_line : parse_state.end_line - 1]),
+            )
+        )
+        parse_state.reset()
+
+    for line_no, line in enumerate(lines, start=1):
+        start = re.match(r"^# /// (?P<type>[a-zA-Z0-9-]+)$", line)
+        if start and parse_state.started and not parse_state.finished:
+            raise InvalidMetadataError(
+                "The script metadata found in {source} contains a `# /// {outer_type}` block "
+                "beginning on line {outer_start_line} that is followed by a `# /// {inner_type}` "
+                "block beginning on line {inner_start_line} before the {outer_type!r} block "
+                "starting on line {outer_start_line} is closed.\n"
+                "Metadata blocks must be closed before a new metadata block can begin.\n"
+                "See: {spec_url}".format(
+                    source=source,
+                    outer_type=parse_state.start_type,
+                    outer_start_line=parse_state.start_line,
+                    inner_type=start.group("type"),
+                    inner_start_line=line_no,
+                    spec_url=_SPEC_URL,
+                )
+            )
+        elif start:
+            if parse_state.finished:
+                add_metadata_block()
+            parse_state.reset(start_type=start.group("type"), start_line=line_no)
+        elif parse_state.started and "# ///" == line:
+            parse_state.end_line = line_no
+        elif line != "#" and not line.startswith("# "):
+            if parse_state.finished and parse_state.end_line == line_no - 1:
+                add_metadata_block()
+            else:
+                parse_state.reset()
+    if parse_state.finished:
+        add_metadata_block()
+
+    over_abundant_blocks = []  # type: List[str]
+    for type_, blocks in metadata_blocks.items():
+        count = len(blocks)
+        if count > 1:
+            over_abundant_blocks.append(
+                "+ {count} `# /// {type}` metadata blocks beginning on lines {lines}.".format(
+                    count=count,
+                    type=type_,
+                    lines="{lines} and {last_line}".format(
+                        lines=", ".join(map(str, (block.start_line for block in blocks[:-1]))),
+                        last_line=blocks[-1].start_line,
+                    ),
+                )
+            )
+
+    if over_abundant_blocks:
+        raise InvalidMetadataError(
+            "Found {count} metadata block {types} in {source} with more than one appearance:\n"
+            "{over_abundant_blocks}\n"
+            "At most one metadata block of each type is allowed.\n"
+            "See: {spec_url}".format(
+                count=len(over_abundant_blocks),
+                types=pluralize(over_abundant_blocks, "type"),
+                source=source,
+                over_abundant_blocks="\n".join(over_abundant_blocks),
+                spec_url=_SPEC_URL,
+            )
+        )
+    return {type_: blocks[0] for type_, blocks in metadata_blocks.items()}
+
+
 @attr.s(frozen=True)
 class ScriptMetadata(object):
-
-    _UNSPECIFIED_SOURCE = "<unspecified source>"
-
     @classmethod
     def parse(
         cls,
@@ -34,30 +188,57 @@ class ScriptMetadata(object):
         # The spec this code follows was defined in PEP-723: https://peps.python.org/pep-0723/
         # and now lives here:
         # https://packaging.python.org/specifications/inline-script-metadata#inline-script-metadata
-        matches = list(
-            re.finditer(r"^# /// script$\s(?P<content>(^#(| .*)$\s)+)^# ///$", script, re.MULTILINE)
-        )
-        if not matches:
+        script_metadata_block = parse_metadata_blocks(script, source=source).get("script")
+        if not script_metadata_block:
             return cls()
-        if len(matches) > 1:
-            raise ValueError(
-                "Multiple `script` metadata blocks found and at most one is allowed. "
-                "See: https://packaging.python.org/en/latest/specifications/"
-                "inline-script-metadata/#inline-script-metadata"
-            )
-        content = "".join(
-            line[2:] if line.startswith("# ") else line[1:]
-            for line in matches[0].group("content").splitlines(True)
-        )
-        script_metadata = toml.loads(content)
+        script_metadata = script_metadata_block.parse_metadata()
 
-        return cls(
-            dependencies=tuple(
-                Requirement.parse(req) for req in script_metadata.get("dependencies", ())
-            ),
-            requires_python=SpecifierSet(script_metadata.get("requires-python", "")),
-            source=source,
-        )
+        raw_dependencies = script_metadata.get("dependencies", [])
+        if not isinstance(raw_dependencies, list):
+            raise script_metadata_block.create_metadata_error(
+                "contains an invalid `dependencies` value of type `{type}`\n"
+                "Expected a list of dependency specifier strings".format(
+                    type=type(raw_dependencies).__name__
+                )
+            )
+
+        invalid_dependencies = []  # type: List[str]
+        dependencies = []  # type: List[Requirement]
+        for index, req in enumerate(raw_dependencies):
+            try:
+                dependencies.append(Requirement.parse(req))
+            except RequirementParseError as e:
+                invalid_dependencies.append(
+                    "+ dependencies[{index}] {req!r}: {err}".format(index=index, req=req, err=e)
+                )
+        if invalid_dependencies:
+            raise script_metadata_block.create_metadata_error(
+                "contains a `dependencies` list with {count} invalid dependency {specifiers}:\n"
+                "{invalid_dependencies}".format(
+                    count=len(invalid_dependencies),
+                    specifiers=pluralize(invalid_dependencies, "specifier"),
+                    invalid_dependencies="\n".join(invalid_dependencies),
+                )
+            )
+
+        raw_requires_python = script_metadata.get("requires-python", "")
+        if not isinstance(raw_requires_python, string):
+            raise script_metadata_block.create_metadata_error(
+                "contains an invalid `requires-python` value of type `{type}`\n"
+                "Expected a version specifier string".format(
+                    type=type(raw_requires_python).__name__
+                )
+            )
+        try:
+            requires_python = SpecifierSet(raw_requires_python)
+        except InvalidSpecifier as e:
+            raise script_metadata_block.create_metadata_error(
+                "contains an invalid `requires-python` value {value!r}: {err}".format(
+                    value=raw_requires_python, err=e
+                )
+            )
+
+        return cls(dependencies=tuple(dependencies), requires_python=requires_python, source=source)
 
     dependencies = attr.ib(default=())  # type: Tuple[Requirement, ...]
     requires_python = attr.ib(default=SpecifierSet())  # type: SpecifierSet

--- a/pex/resolve/requirement_configuration.py
+++ b/pex/resolve/requirement_configuration.py
@@ -55,3 +55,8 @@ class RequirementConfiguration(object):
                     if isinstance(requirement_or_constraint, Constraint)
                 )
         return parsed_constraints
+
+    @property
+    def has_requirements(self):
+        # type: () -> bool
+        return bool(self.requirements) or bool(self.requirement_files)

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -109,7 +109,11 @@ class DownloadRequest(object):
             prefix="resolver_download.", dir=safe_mkdir(get_downloads_dir())
         )
         spawn_download = functools.partial(self._spawn_download, dest)
-        with TRACER.timed("Resolving for:\n  {}".format("\n  ".join(map(str, self.targets)))):
+        with TRACER.timed(
+            "Resolving for:\n  {}".format(
+                "\n  ".join(target.render_description() for target in self.targets)
+            )
+        ):
             return list(
                 execute_parallel(
                     inputs=self.targets,

--- a/pex/targets.py
+++ b/pex/targets.py
@@ -16,7 +16,7 @@ from pex.third_party.packaging.specifiers import SpecifierSet
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from typing import Iterable, Iterator, Optional, Tuple, Union
+    from typing import Any, Iterable, Iterator, Optional, Tuple, Union
 
     import attr  # vendor:skip
 else:
@@ -78,7 +78,7 @@ class Target(object):
     def requires_python_applies(
         self,
         requires_python,  # type: SpecifierSet
-        source,  # type: Requirement
+        source,  # type: Any
     ):
         # type: (...) -> bool
         """Determines if the given python requirement applies to this target.

--- a/tests/integration/test_script_metadata.py
+++ b/tests/integration/test_script_metadata.py
@@ -1,0 +1,250 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os.path
+import re
+import subprocess
+import sys
+from textwrap import dedent
+
+import colors
+
+from pex.targets import LocalInterpreter
+from pex.third_party.packaging.specifiers import SpecifierSet
+from pex.typing import TYPE_CHECKING
+from testing import PY310, ensure_python_interpreter, run_pex_command
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def current_interpreter_applies(specifier):
+    # type: (str) -> bool
+
+    return LocalInterpreter.create().requires_python_applies(
+        SpecifierSet(specifier), source=__name__ + ".current_interpreter_applies"
+    )
+
+
+def test_nominal(tmpdir):
+    # type: (Any) -> None
+
+    curl_exe = os.path.join(str(tmpdir), "curl.py")
+    with open(curl_exe, "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                # /// script
+                # dependencies = ["requests"]
+                # requires-python = ">=3.8,<3.13"
+                # ///
+
+                import io
+                import os
+                import sys
+                from typing import NoReturn
+
+                import requests
+
+
+                def curl(url: str) -> None:
+                    for chunk in requests.get(url, stream=True).iter_content(
+                        chunk_size=io.DEFAULT_BUFFER_SIZE
+                    ):
+                        sys.stdout.buffer.write(chunk)
+
+
+                def main() -> NoReturn:
+                    if len(sys.argv) != 2:
+                        sys.exit(f"Usage: {os.environ.get('PEX', sys.argv[0])} <URL>")
+                    try:
+                        curl(sys.argv[1])
+                        sys.exit(0)
+                    except requests.RequestException as e:
+                        sys.exit(str(e))
+
+
+                if __name__ == "__main__":
+                    main()
+                """
+            )
+        )
+    curl_pex = os.path.join(str(tmpdir), "curl.pex")
+    args = ["--exe", curl_exe, "-o", curl_pex]
+    python = sys.executable
+    if not current_interpreter_applies(">=3.8,<3.13"):
+        python = ensure_python_interpreter(PY310)
+        args.append("--python")
+        args.append(python)
+
+    run_pex_command(args=args).assert_success()
+    output = (
+        subprocess.check_output(args=[python, curl_pex, "https://docs.pex-tool.org"])
+        .decode("utf-8")
+        .strip()
+    )
+    assert output.startswith("<!doctype html>"), output
+    assert output.endswith("</html>"), output
+
+
+def test_dependencies_additive(tmpdir):
+    # type: (Any) -> None
+
+    cowsay_exe = os.path.join(str(tmpdir), "cowsay.py")
+    with open(cowsay_exe, "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                # /// script
+                # dependencies = ["cowsay==5.0"]
+                # ///
+
+                from cowsay import main
+                try:
+                    from colors import yellow
+                except ImportError:
+                    yellow = lambda text: text
+
+                if __name__ == "__main__":
+                    main.tux(yellow("Bird Beak!"))
+                """
+            )
+        )
+    run_pex_command(args=["--exe", cowsay_exe]).assert_success(
+        expected_output_re=r".*^{expected}$.*".format(expected=re.escape("| Bird Beak! |")),
+        re_flags=re.DOTALL | re.MULTILINE,
+    )
+    run_pex_command(args=["--exe", cowsay_exe, "ansicolors==1.1.8"]).assert_success(
+        expected_output_re=r".*^{expected}$.*".format(
+            expected=re.escape("| {colorized} |".format(colorized=colors.yellow("Bird Beak!")))
+        ),
+        re_flags=re.DOTALL | re.MULTILINE,
+    )
+
+
+def test_dependencies_conflicting(tmpdir):
+    # type: (Any) -> None
+
+    cowsay_exe = os.path.join(str(tmpdir), "cowsay.py")
+    with open(cowsay_exe, "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                # /// script
+                # dependencies = ["cowsay==5.0"]
+                # ///
+                """
+            )
+        )
+    run_pex_command(
+        args=["--exe", cowsay_exe, "cowsay>=6.0", "--resolver-version", "pip-2020-resolver"]
+    ).assert_failure(
+        expected_error_re=r".*{expected}.*".format(
+            expected=re.escape(
+                "ERROR: Cannot install cowsay==5.0 and cowsay>=6.0 because these package versions "
+                "have conflicting dependencies."
+            )
+        ),
+        re_flags=re.DOTALL,
+    )
+
+
+def test_targets_additive(tmpdir):
+    # type: (Any) -> None
+
+    hello_world_exe = os.path.join(str(tmpdir), "hello-world.py")
+    with open(hello_world_exe, "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                # /// script
+                # requires-python = ">=3.10,<3.13"
+                # ///
+
+                import os
+                import sys
+
+
+                if __name__ == "__main__":
+                    match sys.argv:
+                        case [_, single_arg]:
+                            print(f"Hello {single_arg}!")
+                        case _:
+                            sys.exit(f"Usage {os.environ.get('PEX', sys.argv[0])} <greetee>")
+                """
+            )
+        )
+
+    python = (
+        ensure_python_interpreter(PY310)
+        if not current_interpreter_applies(">=3.10,<3.13")
+        else None
+    )
+
+    # In nominal mode it should work.
+    run_pex_command(args=["--exe", hello_world_exe, "--", "World"], python=python).assert_success(
+        expected_output_re=r"^Hello World!$"
+    )
+
+    # As should a compatible target addition.
+    run_pex_command(
+        args=[
+            "--exe",
+            hello_world_exe,
+            "--platform",
+            "macosx-10.9-x86_64-cp-310-cp310",
+            "--",
+            "Mac, I<3 you",
+        ],
+        python=python,
+    ).assert_success(expected_output_re=r"^Hello Mac, I<3 you!$")
+
+    # But an incompatible target addition should be detected and fail.
+    run_pex_command(
+        args=[
+            "--exe",
+            hello_world_exe,
+            "--platform",
+            "macosx-10.9-x86_64-cp-39-cp39",
+            "--",
+            "World",
+        ],
+        python=python,
+        quiet=True,
+    ).assert_failure(
+        expected_error_re=re.escape(
+            "The script metadata from {script} specifies a requires-python of <3.13,>=3.10 but "
+            "the following configured targets are incompatible with that constraint: abbreviated "
+            "platform cp39-cp39-macosx_10_9_x86_64".format(script=hello_world_exe)
+        )
+    )
+
+
+def test_no_script_metadata(tmpdir):
+    # type: (Any) -> None
+
+    exe = os.path.join(str(tmpdir), "exe.py")
+    with open(exe, "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                # /// script
+                # dependencies = ["ansicolors==1.1.8"]
+                # ///
+
+                try:
+                    from colors import yellow
+                except ImportError:
+                    yellow = lambda text: text
+
+                if __name__ == "__main__":
+                    print(yellow("Mellow"))
+                """
+            )
+        )
+    run_pex_command(args=["--exe", exe]).assert_success(
+        expected_output_re=re.escape(colors.yellow("Mellow"))
+    )
+    run_pex_command(args=["--exe", exe, "--no-pep723"]).assert_success(expected_output_re=r"Mellow")

--- a/tests/test_pep_723.py
+++ b/tests/test_pep_723.py
@@ -284,7 +284,7 @@ def test_parse_invalid_dependencies_value_type():
 @pytest.mark.skipif(
     PY_VER < (3, 7),
     reason=(
-        "The version of vendored packaging used for Python>=2.7 is required for the precise error "
+        "The version of vendored packaging used for Python>=3.7 is required for the precise error "
         "message being tested against."
     ),
 )

--- a/tests/test_pep_723.py
+++ b/tests/test_pep_723.py
@@ -9,8 +9,9 @@ from textwrap import dedent
 import pytest
 
 from pex.dist_metadata import Requirement
-from pex.pep_723 import ScriptMetadata
+from pex.pep_723 import InvalidMetadataError, ScriptMetadata
 from pex.third_party.packaging import specifiers
+from testing import PY_VER
 
 
 def test_parse_empty():
@@ -75,7 +76,7 @@ def test_parse_greedy():
     # type: () -> None
 
     with pytest.raises(
-        specifiers.InvalidSpecifier,
+        InvalidMetadataError,
         match=re.escape(
             "Invalid specifier: 'Invalid specifier with embedded script metadata block trojan.\n"
             "///'"
@@ -96,6 +97,8 @@ def test_parse_greedy():
 
 
 def test_parse_nominal():
+    # type: () -> None
+
     assert ScriptMetadata(
         dependencies=tuple([Requirement.parse("ansicolors")])
     ) == ScriptMetadata.parse(
@@ -139,3 +142,236 @@ def test_parse_nominal():
             """
         )
     )
+
+
+def test_parse_invalid_embedded_start():
+    # type: () -> None
+
+    with pytest.raises(
+        InvalidMetadataError,
+        match=re.escape(
+            "The script metadata found in <unspecified source> contains a `# /// script` block "
+            "beginning on line 1 that is followed by a `# /// script` block beginning on line 2 "
+            "before the 'script' block starting on line 1 is closed.\n"
+            "Metadata blocks must be closed before a new metadata block can begin.\n"
+            "See: https://packaging.python.org/specifications/"
+            "inline-script-metadata#inline-script-metadata"
+        ),
+    ):
+        ScriptMetadata.parse(
+            dedent(
+                """\
+                # /// script
+                # /// script
+                # ///
+                """
+            )
+        )
+
+    with pytest.raises(
+        InvalidMetadataError,
+        match=re.escape(
+            "The script metadata found in <unspecified source> contains a `# /// script` block "
+            "beginning on line 3 that is followed by a `# /// future` block beginning on line 5 "
+            "before the 'script' block starting on line 3 is closed.\n"
+            "Metadata blocks must be closed before a new metadata block can begin.\n"
+            "See: https://packaging.python.org/specifications/"
+            "inline-script-metadata#inline-script-metadata"
+        ),
+    ):
+        ScriptMetadata.parse(
+            dedent(
+                """\
+                # Preamble.
+                #
+                # /// script
+                #
+                # /// future
+                # ///
+                """
+            )
+        )
+
+
+def test_parse_invalid_multiple_blocks():
+    # type: () -> None
+
+    with pytest.raises(
+        InvalidMetadataError,
+        match=re.escape(
+            "Found 2 metadata block types in <unspecified source> with more than one appearance:\n"
+            "+ 2 `# /// script` metadata blocks beginning on lines 3 and 8.\n"
+            "+ 3 `# /// future` metadata blocks beginning on lines 6, 11 and 15.\n"
+            "At most one metadata block of each type is allowed.\n"
+            "See: https://packaging.python.org/specifications/"
+            "inline-script-metadata#inline-script-metadata"
+        ),
+    ):
+        ScriptMetadata.parse(
+            dedent(
+                """\
+                # A script that uses PEP-723, badly.
+                #
+                # /// script
+                # ///
+
+                # /// future
+                # ///
+                # /// script
+                # ///
+                #
+                # /// future
+                # ///
+                # /// bob
+                # ///
+                # /// future
+                # ///
+                """
+            )
+        )
+
+
+def test_parse_invalid_toml():
+    # type: () -> None
+
+    with pytest.raises(
+        InvalidMetadataError,
+        match=re.escape(
+            "The script metadata found in exe.py starting at line 3 embeds malformed toml: "
+            "Empty value is invalid (line 1 column 1 char 0).\n"
+            "See: https://packaging.python.org/specifications/"
+            "inline-script-metadata#inline-script-metadata"
+        ),
+    ):
+        ScriptMetadata.parse(
+            dedent(
+                """\
+                # Preamble.
+                #
+                # /// script
+                # unspecified_value = # These are invalid in TOML; you must specify a value.
+                # ///
+                """
+            ),
+            source="exe.py",
+        )
+
+
+def test_parse_invalid_dependencies_value_type():
+    # type: () -> None
+
+    with pytest.raises(
+        InvalidMetadataError,
+        match=re.escape(
+            "The script metadata found in <unspecified source> starting at line 1 contains an "
+            "invalid `dependencies` value of type `int`\n"
+            "Expected a list of dependency specifier strings.\n"
+            "See: https://packaging.python.org/specifications/"
+            "inline-script-metadata#inline-script-metadata"
+        ),
+    ):
+        ScriptMetadata.parse(
+            dedent(
+                """\
+                # /// script
+                # dependencies = 42
+                # ///
+                """
+            )
+        )
+
+
+@pytest.mark.skipif(
+    PY_VER < (3, 7),
+    reason=(
+        "The version of vendored packaging used for Python>=2.7 is required for the precise error "
+        "message being tested against."
+    ),
+)
+def test_parse_invalid_dependencies_values():
+    # type: () -> None
+
+    with pytest.raises(
+        InvalidMetadataError,
+        match=re.escape(
+            "The script metadata found in <unspecified source> starting at line 1 contains a "
+            "`dependencies` list with 2 invalid dependency specifiers:\n"
+            "+ dependencies[1] '; python_version >= \"3.8\"': Expected package name at the "
+            "start of dependency specifier\n"
+            '    ; python_version >= "3.8"\n'
+            "    ^\n"
+            "+ dependencies[3] '|': Expected package name at the start of dependency specifier\n"
+            "    |\n"
+            "    ^.\n"
+            "See: https://packaging.python.org/specifications/"
+            "inline-script-metadata#inline-script-metadata"
+        ),
+    ):
+        ScriptMetadata.parse(
+            dedent(
+                """\
+                # /// script
+                # dependencies = [
+                #     "ansicolors",
+                #     "; python_version >= \\"3.8\\"",
+                #     "cowsay",
+                #     "|",
+                # ]
+                # ///
+                """
+            )
+        )
+
+
+def test_parse_invalid_requires_python_value_type():
+    # type: () -> None
+
+    with pytest.raises(
+        InvalidMetadataError,
+        match=re.escape(
+            "The script metadata found in <unspecified source> starting at line 1 contains an "
+            "invalid `requires-python` value of type `int`\n"
+            "Expected a version specifier string.\n"
+            "See: https://packaging.python.org/specifications/"
+            "inline-script-metadata#inline-script-metadata"
+        ),
+    ):
+        ScriptMetadata.parse(
+            dedent(
+                """\
+                # /// script
+                # requires-python = 42
+                # ///
+                """
+            )
+        )
+
+
+@pytest.mark.skipif(
+    PY_VER < (3, 7),
+    reason=(
+        "The version of vendored packaging used for Python>=3.7 is required for the precise error "
+        "message being tested against."
+    ),
+)
+def test_parse_invalid_requires_python_value():
+    # type: () -> None
+
+    with pytest.raises(
+        InvalidMetadataError,
+        match=re.escape(
+            "The script metadata found in <unspecified source> starting at line 1 contains an "
+            "invalid `requires-python` value '>=3.8.*': Invalid specifier: '>=3.8.*'.\n"
+            "See: https://packaging.python.org/specifications/"
+            "inline-script-metadata#inline-script-metadata"
+        ),
+    ):
+        ScriptMetadata.parse(
+            dedent(
+                """\
+                # /// script
+                # requires-python = ">=3.8.*"
+                # ///
+                """
+            )
+        )

--- a/tests/test_pep_723.py
+++ b/tests/test_pep_723.py
@@ -1,0 +1,141 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import re
+from textwrap import dedent
+
+import pytest
+
+from pex.dist_metadata import Requirement
+from pex.pep_723 import ScriptMetadata
+from pex.third_party.packaging import specifiers
+
+
+def test_parse_empty():
+    # type: () -> None
+
+    assert not ScriptMetadata.parse("")
+    assert not ScriptMetadata.parse(
+        dedent(
+            """\
+            # /// script
+            # ///
+            """
+        )
+    )
+    assert not ScriptMetadata.parse(
+        dedent(
+            """\
+            # /// script
+            # unknown_key = 42
+            # ///
+            """
+        )
+    )
+    assert not ScriptMetadata.parse(
+        dedent(
+            """\
+            # /// script
+            # unknown_key = 42
+            # ///
+            # dependencies = ["ansicolors"]
+            """
+        )
+    )
+
+
+def test_parse_unterminated():
+    # type: () -> None
+
+    assert not ScriptMetadata.parse(
+        dedent(
+            """\
+            # /// script
+            # dependencies = ["ansicolors"]
+
+            # # N.B.: The line above does not start with # which should terminate the search for
+            # # the terminator immediately below.
+            # ///
+            """
+        )
+    )
+    assert not ScriptMetadata.parse(
+        dedent(
+            """\
+            # /// script
+            # dependencies = ["ansicolors"]
+            """
+        )
+    )
+
+
+def test_parse_greedy():
+    # type: () -> None
+
+    with pytest.raises(
+        specifiers.InvalidSpecifier,
+        match=re.escape(
+            "Invalid specifier: 'Invalid specifier with embedded script metadata block trojan.\n"
+            "///'"
+        ),
+    ):
+        ScriptMetadata.parse(
+            dedent(
+                '''\
+                # /// script
+                # requires-python = """
+                # Invalid specifier with embedded script metadata block trojan.
+                # ///
+                # """
+                # ///
+                '''
+            )
+        )
+
+
+def test_parse_nominal():
+    assert ScriptMetadata(
+        dependencies=tuple([Requirement.parse("ansicolors")])
+    ) == ScriptMetadata.parse(
+        dedent(
+            """
+            # /// script
+            # dependencies = ["ansicolors"]
+            # ///
+            """
+        )
+    )
+
+    assert ScriptMetadata(requires_python=specifiers.SpecifierSet("~=3.8")) == ScriptMetadata.parse(
+        dedent(
+            """
+            # /// script
+            # requires-python = "~=3.8"
+            # ///
+            """
+        )
+    )
+
+    assert ScriptMetadata(
+        dependencies=tuple([Requirement.parse("cowsay<6")]),
+        requires_python=specifiers.SpecifierSet("==2.7.*"),
+    ) == ScriptMetadata.parse(
+        dedent(
+            """
+            dependencies = ["before"]
+            # /// script
+            # dependencies = [
+            #   "cowsay<6",
+            # ]
+            #
+            # # Yup, 2.7.
+            # requires-python = "==2.7.*"
+            #
+            # not-a-recognized-key = 42
+            # ///
+            dependencies = ["after"]
+            """
+        )
+    )


### PR DESCRIPTION
Pex now reads script metadata present in `--exe`s by default to augment
requirements and constrain allowed target Pythons. Pex can be instructed
to ignore this script metadata though with `--no-pep723` /
`--no-script-metadata`.

This apparently makes due on a promise no active Pex maintainer ever
made, as immortalized in PEP-723:
  https://peps.python.org/pep-0723/#tooling-buy-in