### PR TITLE
Fix GitHub Releases deployment.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
     permissions:
       id-token: write
       attestations: write
+      contents: write
     steps:
       - name: Checkout Pex ${{ needs.determine-tag.outputs.release-tag }}
         uses: actions/checkout@v4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,19 @@
 # Release Notes
 
+## 2.6.2
+
+There are no changes to Pex code or released artifacts over 2.6.1, just
+a fix to the GitHub Releases release process which #2442 broke.
+
+* Fix GitHub Releases deployment. (#2444)
+
 ## 2.6.1
+
+> [!NOTE]
+> Although 2.6.1 successfully released to [PyPI](
+> https://pypi.org/project/pex/2.6.1/), it failed to release to GitHub
+> Releases (neither the Pex PEX nor the pex.pdf were published.) You
+> can use Pex 2.6.2 instead which has no Pex code changes.
 
 This release improves error messages when attempting to read invalid
 metadata from distributions such that the problematic distribution is

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.6.1"
+__version__ = "2.6.2"


### PR DESCRIPTION
The addition of digital attestations in #2442 broke the GitHub Releases
release by moving from default permissions to more restrictive explicit
permission. Those permissions lacked the content write permission needed
to create the release and post its artifacts.