### PR TITLE
Support `--project` locking and PEX building.

### DIFF
--- a/pex/resolve/configured_resolver.py
+++ b/pex/resolve/configured_resolver.py
@@ -79,6 +79,7 @@ class ConfiguredResolver(Resolver):
         requirements,  # type: Iterable[str]
         targets=Targets(),  # type: Targets
         pip_version=None,  # type: Optional[PipVersionValue]
+        transitive=None,  # type: Optional[bool]
         result_type=InstallableType.INSTALLED_WHEEL_CHROOT,  # type: InstallableType.Value
     ):
         # type: (...) -> ResolveResult
@@ -86,7 +87,7 @@ class ConfiguredResolver(Resolver):
             targets=targets,
             requirements=requirements,
             allow_prereleases=False,
-            transitive=self.pip_configuration.transitive,
+            transitive=transitive if transitive is not None else self.pip_configuration.transitive,
             indexes=self.pip_configuration.repos_configuration.indexes,
             find_links=self.pip_configuration.repos_configuration.find_links,
             resolver_version=self.pip_configuration.resolver_version,

--- a/pex/resolve/project.py
+++ b/pex/resolve/project.py
@@ -1,0 +1,157 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os.path
+from argparse import Namespace, _ActionsContainer
+
+from pex.build_system import pep_517
+from pex.dist_metadata import DistMetadata, Requirement
+from pex.exclude_configuration import ExcludeConfiguration
+from pex.fingerprinted_distribution import FingerprintedDistribution
+from pex.interpreter import PythonInterpreter
+from pex.jobs import Raise, SpawnedJob, execute_parallel
+from pex.pep_427 import InstallableType
+from pex.pip.version import PipVersionValue
+from pex.resolve.configured_resolve import resolve
+from pex.resolve.requirement_configuration import RequirementConfiguration
+from pex.resolve.resolver_configuration import PipConfiguration
+from pex.resolve.resolvers import Resolver, Untranslatable
+from pex.targets import LocalInterpreter, Target, Targets
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Iterator, List, Optional, Set, Tuple
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
+
+
+@attr.s(frozen=True)
+class BuiltProject(object):
+    target = attr.ib()  # type: Target
+    fingerprinted_distribution = attr.ib()  # type: FingerprintedDistribution
+
+    def as_requirement(self):
+        # type: () -> Requirement
+        return self.fingerprinted_distribution.distribution.as_requirement()
+
+    @property
+    def requires_dists(self):
+        # type: () -> Tuple[Requirement, ...]
+        return self.fingerprinted_distribution.distribution.metadata.requires_dists
+
+
+@attr.s(frozen=True)
+class Projects(object):
+    paths = attr.ib(default=())  # type: Tuple[str, ...]
+
+    @paths.validator
+    def _is_project_dir(
+        self,
+        attribute,  # type: attr.Attribute
+        value,  # type: Tuple[str, ...]
+    ):
+        # type: (...) -> None
+        invalid_paths = []  # type: List[str]
+        for path in value:
+            if os.path.isfile(os.path.join(path, "pyproject.toml")):
+                continue
+            if os.path.isfile(os.path.join(path, "setup.py")):
+                continue
+            invalid_paths.append(path)
+
+        if invalid_paths:
+            raise ValueError(
+                "The following --project paths do not appear to point to directories containing "
+                "Python projects:\n"
+                "{invalid_paths}".format(
+                    invalid_paths="\n".join(
+                        "{index}. {path}".format(index=index, path=path)
+                        for index, path in enumerate(invalid_paths, start=1)
+                    )
+                )
+            )
+
+    def build(
+        self,
+        targets,  # type: Targets
+        pip_configuration,  # type: PipConfiguration
+        compile_pyc=False,  # type: bool
+        ignore_errors=False,  # type: bool
+        result_type=InstallableType.INSTALLED_WHEEL_CHROOT,  # type: InstallableType.Value
+        exclude_configuration=ExcludeConfiguration(),  # type: ExcludeConfiguration
+    ):
+        # type: (...) -> Iterator[BuiltProject]
+
+        resolve_result = resolve(
+            targets=targets,
+            requirement_configuration=RequirementConfiguration(requirements=self.paths),
+            resolver_configuration=attr.evolve(pip_configuration, transitive=False),
+            compile_pyc=compile_pyc,
+            ignore_errors=ignore_errors,
+            result_type=result_type,
+            exclude_configuration=exclude_configuration,
+        )
+        for resolved_distribution in resolve_result.distributions:
+            yield BuiltProject(
+                target=resolved_distribution.target,
+                fingerprinted_distribution=resolved_distribution.fingerprinted_distribution,
+            )
+
+    def collect_requirements(
+        self,
+        resolver,  # type: Resolver
+        interpreter=None,  # type: Optional[PythonInterpreter]
+        pip_version=None,  # type: Optional[PipVersionValue]
+        max_jobs=None,  # type: Optional[int]
+    ):
+        # type: (...) -> Iterator[Requirement]
+
+        target = LocalInterpreter.create(interpreter)
+
+        def spawn_func(project_directory):
+            # type: (str) -> SpawnedJob[DistMetadata]
+            return pep_517.spawn_prepare_metadata(
+                project_directory, target, resolver, pip_version=pip_version
+            )
+
+        seen = set()  # type: Set[Requirement]
+        for dist_metadata in execute_parallel(
+            self.paths,
+            spawn_func=spawn_func,
+            error_handler=Raise[str, DistMetadata](Untranslatable),
+            max_jobs=max_jobs,
+        ):
+            for req in dist_metadata.requires_dists:
+                if req not in seen:
+                    seen.add(req)
+                    yield req
+
+    def __len__(self):
+        # type: () -> int
+        return len(self.paths)
+
+
+def register_options(
+    parser,  # type: _ActionsContainer
+    help,  # type: str
+):
+    # type: (...) -> None
+
+    parser.add_argument(
+        "--project",
+        dest="projects",
+        metavar="DIR",
+        default=[],
+        type=str,
+        action="append",
+        help=help,
+    )
+
+
+def get_projects(options):
+    # type: (Namespace) -> Projects
+    return Projects(paths=tuple(options.projects))

--- a/pex/resolve/resolvers.py
+++ b/pex/resolve/resolvers.py
@@ -39,7 +39,7 @@ class Unsatisfiable(ResolveError):
     pass
 
 
-def _sorted_requirements(requirements):
+def sorted_requirements(requirements):
     # type: (Optional[Iterable[Requirement]]) -> SortedTuple[Requirement]
     return SortedTuple(requirements, key=lambda req: str(req)) if requirements else SortedTuple()
 
@@ -55,7 +55,7 @@ class ResolvedDistribution(object):
     target = attr.ib()  # type: Target
     fingerprinted_distribution = attr.ib()  # type: FingerprintedDistribution
     direct_requirements = attr.ib(
-        converter=_sorted_requirements, factory=SortedTuple
+        converter=sorted_requirements, factory=SortedTuple
     )  # type: SortedTuple[Requirement]
 
     @property
@@ -70,7 +70,7 @@ class ResolvedDistribution(object):
 
     def with_direct_requirements(self, direct_requirements=None):
         # type: (Optional[Iterable[Requirement]]) -> ResolvedDistribution
-        direct_requirements = _sorted_requirements(direct_requirements)
+        direct_requirements = sorted_requirements(direct_requirements)
         if direct_requirements == self.direct_requirements:
             return self
         return ResolvedDistribution(
@@ -108,6 +108,7 @@ class Resolver(object):
         requirements,  # type: Iterable[str]
         targets=Targets(),  # type: Targets
         pip_version=None,  # type: Optional[PipVersionValue]
+        transitive=None,  # type: Optional[bool]
         result_type=InstallableType.INSTALLED_WHEEL_CHROOT,  # type: InstallableType.Value
     ):
         # type: (...) -> ResolveResult

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -227,21 +227,6 @@ class BuildRequest(object):
         fingerprint = fingerprint_path(source_path)
         return cls(target=target, source_path=source_path, fingerprint=fingerprint)
 
-    @classmethod
-    def from_local_distribution(cls, local_distribution):
-        # type: (LocalDistribution) -> BuildRequest
-        request = cls.create(target=local_distribution.target, source_path=local_distribution.path)
-        if local_distribution.fingerprint and request.fingerprint != local_distribution.fingerprint:
-            raise IntegrityError(
-                "Source at {source_path} was expected to have fingerprint {expected_fingerprint} "
-                "but found to have fingerprint {actual_fingerprint}.".format(
-                    source_path=request.source_path,
-                    expected_fingerprint=local_distribution.fingerprint,
-                    actual_fingerprint=request.fingerprint,
-                )
-            )
-        return request
-
     target = attr.ib()  # type: Target
     source_path = attr.ib()  # type: str
     fingerprint = attr.ib()  # type: str
@@ -350,21 +335,6 @@ class BuildResult(object):
 
 @attr.s(frozen=True)
 class InstallRequest(object):
-    @classmethod
-    def from_local_distribution(cls, local_distribution):
-        # type: (LocalDistribution) -> InstallRequest
-        request = cls.create(target=local_distribution.target, wheel_path=local_distribution.path)
-        if local_distribution.fingerprint and request.fingerprint != local_distribution.fingerprint:
-            raise IntegrityError(
-                "Wheel at {wheel_path} was expected to have fingerprint {expected_fingerprint} "
-                "but found to have fingerprint {actual_fingerprint}.".format(
-                    wheel_path=request.wheel_path,
-                    expected_fingerprint=local_distribution.fingerprint,
-                    actual_fingerprint=request.fingerprint,
-                )
-            )
-        return request
-
     @classmethod
     def create(
         cls,

--- a/tests/integration/resolve/test_issue_2412.py
+++ b/tests/integration/resolve/test_issue_2412.py
@@ -1,0 +1,311 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import filecmp
+import os.path
+import re
+import shutil
+import subprocess
+from textwrap import dedent
+
+from colors import color
+
+from pex.common import safe_open, touch
+from pex.targets import LocalInterpreter
+from pex.typing import TYPE_CHECKING
+from testing import run_pex_command
+from testing.cli import run_pex3
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_invalid_project(
+    tmpdir,  # type: Any
+    pex_project_dir,  # type: str
+):
+    # type: (...) -> None
+
+    non_project_dir = os.path.join(str(tmpdir), "non-project-dir")
+    os.mkdir(non_project_dir)
+    run_pex_command(
+        args=["--project", pex_project_dir, "--project", non_project_dir]
+    ).assert_failure(
+        expected_error_re=r".*{message}$".format(
+            message=re.escape(
+                "The following --project paths do not appear to point to directories containing "
+                "Python projects:\n"
+                "1. {non_project_dir}".format(non_project_dir=non_project_dir)
+            )
+        ),
+        re_flags=re.DOTALL,
+    )
+
+    non_project_file = os.path.join(str(tmpdir), "non-project-file")
+    touch(non_project_file)
+    run_pex3(
+        "lock",
+        "create",
+        "--project",
+        non_project_dir,
+        "--project",
+        pex_project_dir,
+        "--project",
+        non_project_file,
+    ).assert_failure(
+        expected_error_re=r".*{message}$".format(
+            message=re.escape(
+                "The following --project paths do not appear to point to directories containing "
+                "Python projects:\n"
+                "1. {non_project_dir}\n"
+                "2. {non_project_file}".format(
+                    non_project_dir=non_project_dir, non_project_file=non_project_file
+                )
+            )
+        ),
+        re_flags=re.DOTALL,
+    )
+
+
+def test_locked_project(tmpdir):
+    # type: (Any) -> None
+
+    project_dir = os.path.join(str(tmpdir), "project")
+
+    def write_speak(fg_color):
+        # type: (str) -> None
+        with safe_open(os.path.join(project_dir, "speak.py"), "w") as fp:
+            fp.write(
+                dedent(
+                    """\
+                    import cowsay
+                    from colors import color
+
+
+                    def tux():
+                        cowsay.tux(color("Moo?", fg={fg_color!r}))
+                    """
+                ).format(fg_color=fg_color)
+            )
+
+    def write_setup(cowsay_requirement):
+        # type: (str) -> None
+        with safe_open(os.path.join(project_dir, "setup.py"), "w") as fp:
+            fp.write(
+                dedent(
+                    """\
+                    from setuptools import setup
+
+
+                    setup(
+                        name="speak",
+                        version="0.1",
+                        install_requires=["ansicolors", {cowsay_requirement!r}],
+                        entry_points={{
+                            "console_scripts": [
+                                "speak = speak:tux",
+                            ],
+                        }},
+                        py_modules=["speak"],
+                    )
+                    """
+                ).format(cowsay_requirement=cowsay_requirement)
+            )
+
+    def assert_pex(
+        pex,  # type: str
+        expected_color,  # type: str
+    ):
+        # type: (...) -> None
+        assert "| {message} |".format(
+            message=color("Moo?", fg=expected_color)
+        ) in subprocess.check_output(args=[pex]).decode("utf-8")
+
+    pex_root = os.path.join(str(tmpdir), "pex-root")
+
+    write_speak(fg_color="brown")
+    write_setup(cowsay_requirement="cowsay<5")
+
+    project_lock = os.path.join(str(tmpdir), "project-lock.json")
+    run_pex3(
+        "lock", "create", "--pex-root", pex_root, project_dir, "--indent", "2", "-o", project_lock
+    ).assert_success()
+    pex1 = os.path.join(str(tmpdir), "pex1")
+    run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "--lock",
+            project_lock,
+            "-c",
+            "speak",
+            "-o",
+            pex1,
+        ]
+    ).assert_success()
+    assert_pex(pex1, expected_color="brown")
+
+    third_party_lock = os.path.join(str(tmpdir), "third-party-lock.json")
+    run_pex3(
+        "lock",
+        "create",
+        "--pex-root",
+        pex_root,
+        "--project",
+        project_dir,
+        "--indent",
+        "2",
+        "-o",
+        third_party_lock,
+    ).assert_success()
+    pex2 = os.path.join(str(tmpdir), "pex2")
+    run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "--project",
+            project_dir,
+            "--lock",
+            third_party_lock,
+            "-c",
+            "speak",
+            "-o",
+            pex2,
+        ]
+    ).assert_success()
+    assert_pex(pex2, expected_color="brown")
+
+    # Using `pex --project local/project` should produce identical results to `pex local/project`;
+    # the utility of `pex --project` comes only when combined with a lock or PEX repository.
+    assert filecmp.cmp(pex1, pex2, shallow=False)
+
+    # Modifying the project should invalidate the full project lock, but work with a `--project`
+    # lock.
+    write_speak(fg_color="blue")
+    shutil.rmtree(pex_root)
+
+    run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "--lock",
+            project_lock,
+            "-c",
+            "speak",
+            "-o",
+            pex1,
+        ]
+    ).assert_failure(
+        expected_error_re=(
+            r".*{lead_in_message} {sha256_re} when downloading speak but hashed to "
+            r"{sha256_re}\.\n$".format(
+                lead_in_message=re.escape(
+                    "There was 1 error downloading required artifacts:\n"
+                    "1. speak 0.1 from file://{project_dir}\n"
+                    "    Expected sha256 hash of".format(project_dir=project_dir)
+                ),
+                sha256_re=r"[a-f0-9]{64}",
+            )
+        ),
+        re_flags=re.DOTALL,
+    )
+
+    pex3 = os.path.join(str(tmpdir), "pex3")
+    run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "--project",
+            project_dir,
+            "--lock",
+            third_party_lock,
+            "-c",
+            "speak",
+            "-o",
+            pex3,
+        ]
+    ).assert_success()
+    assert_pex(pex3, expected_color="blue")
+
+    # If the project is updated in a way incompatible with the lock, building a
+    # `pex --project ... --lock ...` should fail.
+    write_setup(cowsay_requirement="cowsay==5.0")
+    target = LocalInterpreter.create()
+    run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "--project",
+            project_dir,
+            "--lock",
+            third_party_lock,
+            "-c",
+            "speak",
+            "-o",
+            pex3,
+        ]
+    ).assert_failure(
+        expected_error_re=r".*{message}$".format(
+            message=re.escape(
+                "Failed to resolve compatible artifacts from lock {lock} for 1 target:\n"
+                "1. {target}:\n"
+                "    Failed to resolve all requirements for {target_description} from {lock}:\n"
+                "\n"
+                "Configured with:\n"
+                "    build: True\n"
+                "    use_wheel: True\n"
+                "\n"
+                "Dependency on cowsay not satisfied, 1 incompatible candidate found:\n"
+                "1.) cowsay 4 does not satisfy the following requirements:\n"
+                "    ==5.0 (via: cowsay==5.0)\n".format(
+                    lock=third_party_lock,
+                    target=target,
+                    target_description=target.render_description(),
+                )
+            )
+        ),
+        re_flags=re.DOTALL,
+    )
+
+    # But syncing the `--project` lock to the modified project should re-right the ship.
+    run_pex3(
+        "lock",
+        "sync",
+        "--pex-root",
+        pex_root,
+        "--project",
+        project_dir,
+        "--indent",
+        "2",
+        "--lock",
+        third_party_lock,
+    ).assert_success()
+    run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "--project",
+            project_dir,
+            "--lock",
+            third_party_lock,
+            "-c",
+            "speak",
+            "-o",
+            pex3,
+        ]
+    ).assert_success()
+    assert_pex(pex3, expected_color="blue")


### PR DESCRIPTION
Although Pex already supported local project requirements, they worked
like any other requirement and were included in locks. In the typical
case, a project would rather maintain a lock of its third party
requirements separate from itself. For projects that used requirement
files to record their unlocked dependencies, `-r` could be used instead
of locking the local project. For projects that recorded their
dependencies in a `setup.py`, `setup.cfg` or `pyproject.toml`, the
dependency information needed to be extracted from those files to create
a lock that did not lock the project code itself. Just as bad, when
constructing a PEX the source code layout of the project recorded in
those same project files needed to be replicated in some combination of
`-D`, `-P` and `-M` since resolving from a lock required all projects
needed by the PEX were represented in the lock.

With the addition of the new `--project` option to PEX builds and
`pex3 lock {create,sync}`, a project's dependencies and source code
layout can be referenced from their canonical home in the project
configuration files.

Fixes #2412.