### PR TITLE
Add support for `--pip-version 24.1.2`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,8 @@ jobs:
           - py311-pip20
           - py311-pip22_3_1
           - py311-pip23_1_2
-          - py312-pip24_1_1
-          - py313-pip24_1_1
+          - py312-pip24_1_2
+          - py313-pip24_1_2
           - pypy310-pip20
           - pypy310-pip22_3_1
           - pypy310-pip23_1_2
@@ -84,8 +84,8 @@ jobs:
           - py311-pip20-integration
           - py311-pip22_3_1-integration
           - py311-pip23_1_2-integration
-          - py312-pip24_1_1-integration
-          - py313-pip24_1_1-integration
+          - py312-pip24_1_2-integration
+          - py313-pip24_1_2-integration
           - pypy310-pip20-integration
           - pypy310-pip22_3_1-integration
           - pypy310-pip23_1_2-integration
@@ -129,10 +129,10 @@ jobs:
       matrix:
         include:
           - python-version: [ 3, 12 ]
-            tox-env: py312-pip24_1_1
+            tox-env: py312-pip24_1_2
             tox-env-python: python3.11
           - python-version: [ 3, 12 ]
-            tox-env: py312-pip24_1_1-integration
+            tox-env: py312-pip24_1_2-integration
             tox-env-python: python3.11
     steps:
       - name: Calculate Pythons to Expose

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 2.9.0
+
+This release adds support for Pip 24.1.2.
+
+* Add support for `--pip-version 24.1.2`. (#2459)
+
 ## 2.8.1
 
 This release fixes the `bdist_pex` distutils command to use the

--- a/pex/pip/version.py
+++ b/pex/pip/version.py
@@ -271,6 +271,13 @@ class PipVersion(Enum["PipVersionValue"]):
         requires_python=">=3.8,<3.14",
     )
 
+    v24_1_2 = PipVersionValue(
+        version="24.1.2",
+        setuptools_version="70.2.0",
+        wheel_version="0.43.0",
+        requires_python=">=3.8,<3.14",
+    )
+
     VENDORED = v20_3_4_patched
     LATEST = LatestPipVersion()
     DEFAULT = DefaultPipVersion(preferred=(VENDORED, v23_2, v24_1))

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.8.1"
+__version__ = "2.9.0"

--- a/tox.ini
+++ b/tox.ini
@@ -87,6 +87,7 @@ setenv =
     pip24_0: _PEX_PIP_VERSION=24.0
     pip24_1: _PEX_PIP_VERSION=24.1
     pip24_1_1: _PEX_PIP_VERSION=24.1.1
+    pip24_1_2: _PEX_PIP_VERSION=24.1.2
 
     # Python 3 (until a fix here in 3.9: https://bugs.python.org/issue13601) switched from stderr
     # being unbuffered to stderr being buffered by default. This can lead to tests checking stderr


### PR DESCRIPTION
The changelog is here:
  https://pip.pypa.io/en/stable/news/#v24-1-2