### PR TITLE
Update the documentation to make the pip freeze method in README to work

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Or instead freeze your current virtualenv via requirements.txt and execute it an
 
 .. code-block:: bash
 
-    $ pex $(pip freeze) -o my_virtualenv.pex
+    $ pex -o my_virtualenv.pex -- $(pip freeze) 
     $ deactivate
     $ ./my_virtualenv.pex
 


### PR DESCRIPTION
Very minor change to correct non-functioning command in docs. 

Expected: 

A file called `my_virtualenv.pex` in the current directory.


Actual:

```
usage: pex [-o OUTPUT.PEX] [options] [-- arg1 arg2 ...]

pex builds a PEX (Python Executable) file based on the given specification ...
```