### PR TITLE
Add `--site-packages-copies` for external venvs.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -23,7 +23,7 @@ from pex.commands.command import (
     global_environment,
     register_global_arguments,
 )
-from pex.common import die, is_pyc_dir, is_pyc_file, safe_mkdtemp
+from pex.common import CopyMode, die, is_pyc_dir, is_pyc_file, safe_mkdtemp
 from pex.dependency_configuration import DependencyConfiguration
 from pex.dependency_manager import DependencyManager
 from pex.dist_metadata import Requirement
@@ -38,7 +38,7 @@ from pex.pep_427 import InstallableType
 from pex.pep_723 import ScriptMetadata
 from pex.pex import PEX
 from pex.pex_bootstrapper import ensure_venv
-from pex.pex_builder import Check, CopyMode, PEXBuilder
+from pex.pex_builder import Check, PEXBuilder
 from pex.pex_info import PexInfo
 from pex.resolve import (
     project,

--- a/pex/cli/commands/venv.py
+++ b/pex/cli/commands/venv.py
@@ -11,7 +11,7 @@ from argparse import ArgumentParser, _ActionsContainer
 from pex import pex_warnings
 from pex.cli.command import BuildTimeCommand
 from pex.commands.command import JsonMixin, OutputMixin
-from pex.common import DETERMINISTIC_DATETIME, is_script, open_zip, pluralize
+from pex.common import DETERMINISTIC_DATETIME, CopyMode, is_script, open_zip, pluralize
 from pex.dist_metadata import Distribution
 from pex.enum import Enum
 from pex.executor import Executor
@@ -311,7 +311,11 @@ class Venv(OutputMixin, JsonMixin, BuildTimeCommand):
                     venv=venv,
                     distributions=distributions,
                     provenance=provenance,
-                    symlink=False,
+                    copy_mode=(
+                        CopyMode.COPY
+                        if installer_configuration.site_packages_copies
+                        else CopyMode.LINK
+                    ),
                     hermetic_scripts=hermetic_scripts,
                 )
             else:
@@ -319,7 +323,11 @@ class Venv(OutputMixin, JsonMixin, BuildTimeCommand):
                     dest_dir=dest_dir,
                     distributions=distributions,
                     provenance=provenance,
-                    symlink=False,
+                    copy_mode=(
+                        CopyMode.COPY
+                        if installer_configuration.site_packages_copies
+                        else CopyMode.LINK
+                    ),
                 )
             source = (
                 "PEX at {pex}".format(pex=pex.path())
@@ -388,7 +396,9 @@ def _install_from_pex(
                 venv=venv,
                 distributions=distributions,
                 provenance=provenance,
-                symlink=False,
+                copy_mode=(
+                    CopyMode.COPY if installer_configuration.site_packages_copies else CopyMode.LINK
+                ),
                 hermetic_scripts=hermetic_scripts,
                 top_level_source_packages=top_level_source_packages,
             )
@@ -397,7 +407,9 @@ def _install_from_pex(
                 dest_dir=dest_dir,
                 distributions=distributions,
                 provenance=provenance,
-                symlink=False,
+                copy_mode=(
+                    CopyMode.COPY if installer_configuration.site_packages_copies else CopyMode.LINK
+                ),
             )
 
     if installer_configuration.scope in (InstallScope.ALL, InstallScope.SOURCE_ONLY):

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -9,7 +9,7 @@ import sys
 
 from pex import pex_warnings
 from pex.atomic_directory import atomic_directory
-from pex.common import die, pluralize
+from pex.common import CopyMode, die, pluralize
 from pex.environment import ResolveError
 from pex.inherit_path import InheritPath
 from pex.interpreter import PythonInterpreter
@@ -555,7 +555,11 @@ def ensure_venv(
                     # so we'll not have a stable base there to symlink from. As such, always copy
                     # for loose PEXes to ensure the PEX_ROOT venv is stable in the face of
                     # modification of the source loose PEX.
-                    symlink = pex.layout != Layout.LOOSE and not pex_info.venv_site_packages_copies
+                    copy_mode = (
+                        CopyMode.SYMLINK
+                        if (pex.layout != Layout.LOOSE and not pex_info.venv_site_packages_copies)
+                        else CopyMode.LINK
+                    )
 
                     shebang = installer.populate_venv_from_pex(
                         virtualenv,
@@ -568,7 +572,7 @@ def ensure_venv(
                             os.path.basename(virtualenv.interpreter.binary),
                         ),
                         collisions_ok=collisions_ok,
-                        symlink=symlink,
+                        copy_mode=copy_mode,
                         hermetic_scripts=pex_info.venv_hermetic_scripts,
                     )
 

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -15,6 +15,7 @@ from pex import pex_warnings
 from pex.atomic_directory import atomic_directory
 from pex.common import (
     Chroot,
+    CopyMode,
     chmod_plus_x,
     deterministic_walk,
     is_pyc_file,
@@ -49,15 +50,6 @@ if TYPE_CHECKING:
 # path here at import time before any cd'ing occurs in test code that might interfere with our
 # attempts to locate Pex files later below.
 _ABS_PEX_PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
-
-
-class CopyMode(Enum["CopyMode.Value"]):
-    class Value(Enum.Value):
-        pass
-
-    COPY = Value("copy")
-    LINK = Value("link")
-    SYMLINK = Value("symlink")
 
 
 class InvalidZipAppError(Exception):

--- a/pex/tools/commands/venv.py
+++ b/pex/tools/commands/venv.py
@@ -9,7 +9,7 @@ import os
 from argparse import ArgumentParser
 
 from pex import pex_warnings
-from pex.common import safe_delete, safe_rmtree
+from pex.common import CopyMode, safe_delete, safe_rmtree
 from pex.enum import Enum
 from pex.executor import Executor
 from pex.pex import PEX
@@ -143,7 +143,9 @@ class Venv(PEXCommand):
             pex,
             bin_path=installer_configuration.bin_path,
             collisions_ok=installer_configuration.collisions_ok,
-            symlink=False,
+            copy_mode=(
+                CopyMode.COPY if installer_configuration.site_packages_copies else CopyMode.LINK
+            ),
             scope=installer_configuration.scope,
             hermetic_scripts=installer_configuration.hermetic_scripts,
         )

--- a/pex/venv/installer_configuration.py
+++ b/pex/venv/installer_configuration.py
@@ -23,6 +23,7 @@ class InstallerConfiguration(object):
     collisions_ok = attr.ib(default=False)  # type: bool
     pip = attr.ib(default=False)  # type: bool
     copies = attr.ib(default=False)  # type: bool
+    site_packages_copies = attr.ib(default=False)  # type: bool
     compile = attr.ib(default=False)  # type: bool
     prompt = attr.ib(default=None)  # type: Optional[str]
     hermetic_scripts = attr.ib(default=False)  # type: bool

--- a/pex/venv/installer_options.py
+++ b/pex/venv/installer_options.py
@@ -78,6 +78,12 @@ def register(
         help="Create the venv using copies of system files instead of symlinks",
     )
     parser.add_argument(
+        "--site-packages-copies",
+        action="store_true",
+        default=False,
+        help="Create the venv using copies of distributions instead of links or symlinks",
+    )
+    parser.add_argument(
         "--compile",
         action="store_true",
         default=False,
@@ -109,6 +115,7 @@ def configure(options):
         collisions_ok=options.collisions_ok,
         pip=options.pip,
         copies=options.copies,
+        site_packages_copies=options.site_packages_copies,
         compile=options.compile,
         prompt=options.prompt,
         hermetic_scripts=options.hermetic_scripts,

--- a/testing/venv.py
+++ b/testing/venv.py
@@ -1,0 +1,61 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os
+
+from pex.common import CopyMode
+from pex.typing import TYPE_CHECKING
+from pex.venv.virtualenv import Virtualenv
+
+if TYPE_CHECKING:
+    from typing import Iterable, Optional, Set
+
+
+def assert_venv_site_packages_copy_mode(
+    venv_dir,  # type: str
+    expected_copy_mode,  # type: CopyMode.Value
+    expected_files=None,  # type: Optional[Iterable[str]]
+):
+    # type: (...) -> None
+
+    site_packages_files = set()  # type: Set[str]
+    site_packages_dir = os.path.realpath(Virtualenv(venv_dir).site_packages_dir)
+    for root, dirs, files in os.walk(site_packages_dir):
+        # Metadata files are always copied for inscrutable historical reasons; so we skip
+        # checking those.
+        dirs[:] = [d for d in dirs if not d.endswith(".dist-info")]
+        for f in files:
+            if f == "PEX_EXTRA_SYS_PATH.pth":
+                continue
+            file_path = os.path.join(root, f)
+            if expected_copy_mode is CopyMode.SYMLINK:
+                assert os.path.islink(file_path)
+            else:
+                assert not os.path.islink(file_path)
+                nlink = os.stat(file_path).st_nlink
+                if expected_copy_mode is CopyMode.COPY:
+                    assert 1 == nlink, "Expected {file} to have 1 link but found {nlink}".format(
+                        file=file_path, nlink=nlink
+                    )
+                else:
+                    assert (
+                        nlink > 1
+                    ), "Expected {file} to have more than 1 link but found {nlink}".format(
+                        file=file_path, nlink=nlink
+                    )
+            site_packages_files.add(file_path)
+
+    if expected_files:
+        expected_files = set(os.path.join(site_packages_dir, f) for f in expected_files)
+        assert expected_files == site_packages_files, (
+            "Expected venv site-packages dir to contain these files:\n"
+            "{expected_files}\n"
+            "\n"
+            "Found these files:\n"
+            "{actual_files}"
+        ).format(
+            expected_files="\n".join(sorted(expected_files)),
+            actual_files="\n".join(sorted(site_packages_files)),
+        )

--- a/tests/integration/cli/commands/test_issue_2313.py
+++ b/tests/integration/cli/commands/test_issue_2313.py
@@ -1,0 +1,48 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os.path
+
+from pex.common import CopyMode
+from pex.typing import TYPE_CHECKING
+from testing.cli import run_pex3
+from testing.venv import assert_venv_site_packages_copy_mode
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+def test_venv_site_packages_copies(tmpdir):
+    # type: (Any) -> None
+
+    pex_root = os.path.join(str(tmpdir), "pex_root")
+    expected_files = [
+        os.path.join("cowsay", "__init__.py"),
+        os.path.join("cowsay", "__main__.py"),
+        os.path.join("cowsay", "characters.py"),
+        os.path.join("cowsay", "main.py"),
+        os.path.join("cowsay", "test.py"),
+    ]
+
+    venv = os.path.join(str(tmpdir), "venv")
+    run_pex3("venv", "create", "--pex-root", pex_root, "-d", venv, "cowsay==5.0")
+    assert_venv_site_packages_copy_mode(
+        venv, expected_copy_mode=CopyMode.LINK, expected_files=expected_files
+    )
+
+    venv_copies = os.path.join(str(tmpdir), "venv-copies")
+    run_pex3(
+        "venv",
+        "create",
+        "--pex-root",
+        pex_root,
+        "-d",
+        venv_copies,
+        "cowsay==5.0",
+        "--site-packages-copies",
+    )
+    assert_venv_site_packages_copy_mode(
+        venv_copies, expected_copy_mode=CopyMode.COPY, expected_files=expected_files
+    )

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -13,12 +13,12 @@ from zipfile import ZipFile
 
 import pytest
 
-from pex.common import open_zip, safe_open, temporary_dir, touch
+from pex.common import CopyMode, open_zip, safe_open, temporary_dir, touch
 from pex.compatibility import WINDOWS, commonpath
 from pex.executor import Executor
 from pex.layout import Layout
 from pex.pex import PEX
-from pex.pex_builder import Check, CopyMode, InvalidZipAppError, PEXBuilder
+from pex.pex_builder import Check, InvalidZipAppError, PEXBuilder
 from pex.pex_warnings import PEXWarning
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV

--- a/tests/tools/commands/test_venv.py
+++ b/tests/tools/commands/test_venv.py
@@ -15,12 +15,12 @@ from textwrap import dedent
 
 import pytest
 
-from pex.common import safe_mkdtemp, safe_open, temporary_dir, touch
+from pex.common import CopyMode, safe_mkdtemp, safe_open, temporary_dir, touch
 from pex.compatibility import PY2
 from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
 from pex.layout import Layout
-from pex.pex_builder import CopyMode, PEXBuilder
+from pex.pex_builder import PEXBuilder
 from pex.typing import TYPE_CHECKING, cast
 from pex.util import named_temporary_file
 from pex.venv.virtualenv import Virtualenv


### PR DESCRIPTION
When creating a venv external to the `PEX_ROOT` via either
`pex3 venv create ...` or `PEX_TOOLS=1 ./my.pex venv ...` you can now
specify `--site-packages-copies` to ensure all code populated in the
venv is isolated from the `PEX_ROOT` cache. Although this takes more
space on disk, it may make sense to use when you expect the venv might
be tampered with or used for experimentation that might alter its files;
otherwise contaminating the `PEX_ROOT` cache.

Fixes #2313