### PR TITLE
Handle all output file names when building scies.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## 2.13.1
+
+This release fixes the `--scie` option to support building a Pex PEX
+scie with something like `pex pex -c pex --venv --scie eager -o pex`.
+Previously, due to the output filename of `pex` colliding with fixed
+internal scie lift manifest file names, this would fail.
+
+* Handle all output file names when building scies. (#2484)
+
 ## 2.13.0
 
 This release improves error message detail when there are failures in

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.13.0"
+__version__ = "2.13.1"

--- a/tests/integration/scie/test_pex_scie.py
+++ b/tests/integration/scie/test_pex_scie.py
@@ -372,6 +372,7 @@ def test_custom_lazy_urls(tmpdir):
     ), stderr.decode("utf-8")
 
 
+@skip_if_pypy
 def test_pex_pex_scie(
     tmpdir,  # type: Any
     pex_project_dir,  # type: Any

--- a/tests/integration/scie/test_pex_scie.py
+++ b/tests/integration/scie/test_pex_scie.py
@@ -19,6 +19,7 @@ from pex.orderedset import OrderedSet
 from pex.scie import SciePlatform, ScieStyle
 from pex.targets import LocalInterpreter
 from pex.typing import TYPE_CHECKING
+from pex.version import __version__
 from testing import IS_PYPY, PY_VER, make_env, run_pex_command
 
 if TYPE_CHECKING:
@@ -369,3 +370,21 @@ def test_custom_lazy_urls(tmpdir):
         stderr.decode("utf-8"),
         flags=re.DOTALL | re.MULTILINE,
     ), stderr.decode("utf-8")
+
+
+def test_pex_pex_scie(
+    tmpdir,  # type: Any
+    pex_project_dir,  # type: Any
+):
+    # type: (...) -> None
+
+    pex = os.path.join(str(tmpdir), "pex")
+    run_pex_command(
+        args=[pex_project_dir, "-c", "pex", "--scie", "lazy", "-o", pex]
+    ).assert_success()
+    assert (
+        __version__
+        == subprocess.check_output(args=[pex, "-V"], env=make_env(PATH=None))
+        .decode("utf-8")
+        .strip()
+    )

--- a/tests/integration/scie/test_pex_scie.py
+++ b/tests/integration/scie/test_pex_scie.py
@@ -380,7 +380,17 @@ def test_pex_pex_scie(
 
     pex = os.path.join(str(tmpdir), "pex")
     run_pex_command(
-        args=[pex_project_dir, "-c", "pex", "--scie", "lazy", "-o", pex]
+        args=[
+            pex_project_dir,
+            "-c",
+            "pex",
+            "--scie",
+            "lazy",
+            "--scie-python-version",
+            "3.12",
+            "-o",
+            pex,
+        ]
     ).assert_success()
     assert (
         __version__


### PR DESCRIPTION
Previously, invoking `pex pex -c pex --venv --scie eager -o pex` to
build the Pex PEX scie would error deep inside the science scie build
process due to the name collision. Since the user has no control over
the lift manifest, this was not able to be corrected.