### PR TITLE
Fix PEXes for `-i` / `PYTHONINSPECT=x`.

### DIFF
--- a/pex/globals.py
+++ b/pex/globals.py
@@ -1,0 +1,12 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+
+class Globals(dict):
+    """The globals dict returned by PEX executions that evaluate code without exiting / exec'ing."""
+
+    def __int__(self):
+        # type: () -> int
+
+        # When a globals dict is returned, this should always be interpreted as a successful exit.
+        return 0

--- a/pex/globals.py
+++ b/pex/globals.py
@@ -4,9 +4,3 @@
 
 class Globals(dict):
     """The globals dict returned by PEX executions that evaluate code without exiting / exec'ing."""
-
-    def __int__(self):
-        # type: () -> int
-
-        # When a globals dict is returned, this should always be interpreted as a successful exit.
-        return 0

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -938,6 +938,10 @@ class PythonInterpreter(object):
         pythonpath = list(pythonpath or ())
         if pythonpath:
             env["PYTHONPATH"] = os.pathsep.join(pythonpath)
+
+            # If we're being forced into interactive mode, we don't want that to apply to any
+            # Pex internal interpreter executions ever.
+            env.pop("PYTHONINSPECT", None)
         else:
             # Turn off reading of PYTHON* environment variables.
             cmd.append("-E")

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -576,7 +576,7 @@ class PEX(object):  # noqa: T000
 
         result = self._wrap_coverage(self._wrap_profiling, self._execute)
         if "PYTHONINSPECT" not in os.environ:
-            sys.exit(result)
+            sys.exit(0 if isinstance(result, Globals) else result)
         else:
             return result
 

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -19,6 +19,7 @@ from pex.environment import PEXEnvironment
 from pex.executor import Executor
 from pex.finders import get_entry_point_from_console_script, get_script_from_distributions
 from pex.fingerprinted_distribution import FingerprintedDistribution
+from pex.globals import Globals
 from pex.inherit_path import InheritPath
 from pex.interpreter import PythonIdentity, PythonInterpreter
 from pex.layout import Layout
@@ -536,7 +537,7 @@ class PEX(object):  # noqa: T000
         return self._pex
 
     def execute(self):
-        # type: () -> None
+        # type: () -> Any
         """Execute the PEX.
 
         This function makes assumptions that it is the last function called by the interpreter.
@@ -573,7 +574,11 @@ class PEX(object):  # noqa: T000
                     V=3,
                 )
 
-        sys.exit(self._wrap_coverage(self._wrap_profiling, self._execute))
+        result = self._wrap_coverage(self._wrap_profiling, self._execute)
+        if "PYTHONINSPECT" not in os.environ:
+            sys.exit(0 if isinstance(result, dict) else result)
+        else:
+            return result
 
     def _execute(self):
         # type: () -> Any
@@ -719,11 +724,12 @@ class PEX(object):  # noqa: T000
 
             import code
 
-            code.interact()
-            return None
+            local = {}  # type: Dict[str, Any]
+            code.interact(local=local)
+            return Globals(local)
 
+    @staticmethod
     def execute_with_options(
-        self,
         python_options,  # type: List[str]
         args,  # List[str]
     ):
@@ -744,6 +750,11 @@ class PEX(object):  # noqa: T000
                 cmdline=" ".join(cmdline)
             )
         )
+        if any(
+            arg.startswith("-") and not arg.startswith("--") and "i" in arg
+            for arg in python_options
+        ):
+            os.environ["PYTHONINSPECT"] = "1"
         os.execv(python, cmdline)
 
     def execute_script(self, script_name):
@@ -786,7 +797,7 @@ class PEX(object):  # noqa: T000
         content,  # type: str
         argv0=None,  # type: Optional[str]
     ):
-        # type: (...) -> Optional[str]
+        # type: (...) -> Any
         try:
             program = compile(content, name, "exec", flags=0, dont_inherit=1)
         except SyntaxError as e:
@@ -800,7 +811,7 @@ class PEX(object):  # noqa: T000
         program,  # type: ast.AST
         argv0=None,  # type: Optional[str]
     ):
-        # type: (...) -> Optional[str]
+        # type: (...) -> Any
         bootstrap.demote()
 
         from pex.compatibility import exec_function
@@ -809,8 +820,7 @@ class PEX(object):  # noqa: T000
         globals_map = globals().copy()
         globals_map["__name__"] = "__main__"
         globals_map["__file__"] = name
-        exec_function(program, globals_map)
-        return None
+        return Globals(exec_function(program, globals_map))
 
     def execute_entry(self, entry_point):
         # type: (Union[ModuleEntryPoint, CallableEntryPoint]) -> Any
@@ -820,12 +830,12 @@ class PEX(object):  # noqa: T000
         return self.execute_module(entry_point.module)
 
     def execute_module(self, module_name):
-        # type: (str) -> None
+        # type: (str) -> Any
         bootstrap.demote()
 
         import runpy
 
-        runpy.run_module(module_name, run_name="__main__", alter_sys=True)
+        return Globals(runpy.run_module(module_name, run_name="__main__", alter_sys=True))
 
     @classmethod
     def execute_entry_point(cls, entry_point):

--- a/pex/pex.py
+++ b/pex/pex.py
@@ -576,7 +576,7 @@ class PEX(object):  # noqa: T000
 
         result = self._wrap_coverage(self._wrap_profiling, self._execute)
         if "PYTHONINSPECT" not in os.environ:
-            sys.exit(0 if isinstance(result, dict) else result)
+            sys.exit(result)
         else:
             return result
 

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -27,7 +27,18 @@ from pex.variables import ENV
 from pex.venv import installer
 
 if TYPE_CHECKING:
-    from typing import Iterable, Iterator, List, NoReturn, Optional, Sequence, Set, Tuple, Union
+    from typing import (
+        Any,
+        Iterable,
+        Iterator,
+        List,
+        NoReturn,
+        Optional,
+        Sequence,
+        Set,
+        Tuple,
+        Union,
+    )
 
     import attr  # vendor:skip
 
@@ -607,7 +618,7 @@ def bootstrap_pex(
     venv_dir=None,  # type: Optional[str]
     python_args=(),  # type: Sequence[str]
 ):
-    # type: (...) -> None
+    # type: (...) -> Any
 
     pex_info = _bootstrap(entry_point)
 
@@ -644,7 +655,7 @@ def bootstrap_pex(
             maybe_reexec_pex(interpreter_test=interpreter_test, python_args=python_args)
             from . import pex
 
-            pex.PEX(entry_point).execute()
+            return pex.PEX(entry_point).execute()
 
 
 def _activate_pex(

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -497,7 +497,7 @@ class PEXBuilder(object):
                 inject_python_args={inject_python_args!r},
             )
             if should_exit:
-                sys.exit(result)
+                sys.exit(0 if is_globals else result)
             elif is_globals:
                 globals().update(result)
             """

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -486,7 +486,7 @@ class PEXBuilder(object):
 
         pex_main = dedent(
             """
-            result = boot(
+            result, should_exit, is_globals = boot(
                 bootstrap_dir={bootstrap_dir!r},
                 pex_root={pex_root!r},
                 pex_hash={pex_hash!r},
@@ -496,8 +496,10 @@ class PEXBuilder(object):
                 is_venv={is_venv!r},
                 inject_python_args={inject_python_args!r},
             )
-            if __SHOULD_EXECUTE__:
+            if should_exit:
                 sys.exit(result)
+            elif is_globals:
+                globals().update(result)
             """
         ).format(
             bootstrap_dir=self._pex_info.bootstrap,

--- a/pex/scie/science.py
+++ b/pex/scie/science.py
@@ -230,7 +230,7 @@ def create_manifests(
                 "env": {
                     "default": env_default,
                     "remove_exact": ["PATH"],
-                    "remove_re": ["PEX_.*"],
+                    "remove_re": ["PEX_.*", "PYTHON.*"],
                     "replace": {
                         "PEX_INTERPRETER": "1",
                         # We can get a warning about too-long script shebangs, but this is not

--- a/testing/scie.py
+++ b/testing/scie.py
@@ -1,0 +1,21 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pex.scie import SciePlatform
+from testing import IS_PYPY, PY_VER
+
+
+def has_provider():
+    # type: () -> bool
+    if IS_PYPY:
+        if PY_VER == (2, 7):
+            return True
+
+        if SciePlatform.LINUX_AARCH64 is SciePlatform.CURRENT:
+            return PY_VER >= (3, 7)
+        elif SciePlatform.MACOS_AARCH64 is SciePlatform.CURRENT:
+            return PY_VER >= (3, 8)
+        else:
+            return PY_VER >= (3, 6)
+    else:
+        return (3, 8) <= PY_VER < (3, 13)

--- a/tests/integration/scie/test_pex_scie.py
+++ b/tests/integration/scie/test_pex_scie.py
@@ -23,7 +23,7 @@ from pex.scie import SciePlatform, ScieStyle
 from pex.targets import LocalInterpreter
 from pex.typing import TYPE_CHECKING
 from pex.version import __version__
-from testing import IS_PYPY, PY_VER, make_env, run_pex_command
+from testing import IS_PYPY, PY_VER, make_env, run_pex_command, scie
 
 if TYPE_CHECKING:
     from typing import Any, Iterable, List
@@ -480,24 +480,8 @@ def bar(tmpdir):
     return make_project(tmpdir, "bar")
 
 
-def has_provider():
-    # type: () -> bool
-    if IS_PYPY:
-        if PY_VER == (2, 7):
-            return True
-
-        if SciePlatform.LINUX_AARCH64 is SciePlatform.CURRENT:
-            return PY_VER >= (3, 7)
-        elif SciePlatform.MACOS_AARCH64 is SciePlatform.CURRENT:
-            return PY_VER >= (3, 8)
-        else:
-            return PY_VER >= (3, 6)
-    else:
-        return PY_VER >= (3, 8) and PY_VER < (3, 13)
-
-
 skip_if_no_provider = pytest.mark.skipif(
-    not has_provider(),
+    not scie.has_provider(),
     reason=(
         "Either A PBS or PyPy release must be available for the current interpreter to run this test."
     ),

--- a/tests/integration/test_issue_2249.py
+++ b/tests/integration/test_issue_2249.py
@@ -93,8 +93,8 @@ def test_inspect(
             process.expect_exact(
                 "{green_hello} 42".format(green_hello=colors.green("hello")).encode("utf-8"),
                 # The PyPy venv scies are quite slow to set up; so we extend the initial timeout
-                # for those.
-                timeout=pexpect_timeout * (5 if IS_PYPY and scie_args else 1),
+                # for those even more.
+                timeout=pexpect_timeout * (6 if IS_PYPY and scie_args else 3),
             )
             process.expect_exact(b">>>", timeout=pexpect_timeout)
             process.sendline(b"print(colors.blue(bar))")

--- a/tests/integration/test_issue_2249.py
+++ b/tests/integration/test_issue_2249.py
@@ -1,0 +1,107 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os.path
+import subprocess
+from contextlib import closing
+from textwrap import dedent
+from typing import Iterator
+
+import colors
+import pexpect  # type: ignore[import]  # MyPy can't see the types under Python 2.7.
+import pytest
+
+from pex.common import safe_rmtree
+from pex.typing import TYPE_CHECKING
+from testing import IS_PYPY, make_env, run_pex_command, scie
+
+if TYPE_CHECKING:
+    from typing import Any, List
+
+
+def _scie_args():
+    # type: () -> Iterator[Any]
+    yield pytest.param([], id="PEX")
+    if scie.has_provider():
+        yield pytest.param(["--scie", "eager"], id="SCIE")
+
+
+@pytest.mark.parametrize(
+    "execution_mode_args",
+    [
+        pytest.param([], id="ZIPAPP"),
+        pytest.param(["--sh-boot"], id="SH_BOOT"),
+        pytest.param(["--venv"], id="VENV"),
+        pytest.param(["--venv", "--sh-boot"], id="VENV-SH_BOOT"),
+    ],
+)
+@pytest.mark.parametrize("scie_args", list(_scie_args()))
+def test_inspect(
+    tmpdir,  # type: Any
+    execution_mode_args,  # type: List[str]
+    scie_args,  # type: List[str]
+    pexpect_timeout,  # type: int
+):
+    # type: (...) -> None
+
+    pex = os.path.join(str(tmpdir), "pex")
+    run_pex_command(
+        args=["ansicolors==1.1.8", "-o", pex] + execution_mode_args + scie_args
+    ).assert_success()
+
+    foo = os.path.join(str(tmpdir), "foo.py")
+    with open(foo, "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                from __future__ import print_function
+
+                import colors
+
+
+                bar = 42
+                print(colors.green("hello"), bar)
+                """
+            )
+        )
+
+    assert (
+        "{hello} 42".format(hello=colors.green("hello"))
+        == subprocess.check_output(args=[pex, foo]).decode("utf-8").strip()
+    )
+
+    scie_base = os.path.join(str(tmpdir), "nce")
+
+    def assert_inspect(
+        args,  # type: List[str]
+        **env  # type: Any
+    ):
+        # type: (...) -> None
+        with open(os.path.join(str(tmpdir), "pexpect.log"), "wb") as log, closing(
+            pexpect.spawn(
+                pex,
+                args,
+                # MyPy expects an os._Environ[str] private type from the typeshed not compatible
+                # with Dict[str, str] but this code does actually work at runtime!
+                env=make_env(SCIE_BASE=scie_base, **env),  # type: ignore[arg-type]
+                dimensions=(24, 80),
+                logfile=log,
+            )
+        ) as process:
+            process.expect_exact(
+                "{green_hello} 42".format(green_hello=colors.green("hello")).encode("utf-8"),
+                # The PyPy venv scies are quite slow to set up; so we extend the initial timeout
+                # for those.
+                timeout=pexpect_timeout * (5 if IS_PYPY and scie_args else 1),
+            )
+            process.expect_exact(b">>>", timeout=pexpect_timeout)
+            process.sendline(b"print(colors.blue(bar))")
+            process.expect_exact(colors.blue(42).encode("utf-8"), timeout=pexpect_timeout)
+            process.expect_exact(b">>>", timeout=pexpect_timeout)
+            process.sendline(b"quit()")
+
+    assert_inspect(args=["-i", foo])
+    safe_rmtree(scie_base)
+    assert_inspect(args=[foo], PYTHONINSPECT=1)

--- a/tests/tools/commands/test_venv.py
+++ b/tests/tools/commands/test_venv.py
@@ -691,7 +691,12 @@ def test_warn_unused_pex_env_vars():
         stdout, stderr = process.communicate()
         assert 0 == process.returncode
         assert not stdout
-        assert expected_stderr.strip() == stderr.decode("utf-8").strip()
+        expected = expected_stderr.strip()
+        error = stderr.decode("utf-8").strip()
+        if expected:
+            assert error.endswith(expected), error
+        else:
+            assert not error, error
 
     assert_execute_venv_pex(expected_stderr="")
     assert_execute_venv_pex(expected_stderr="", PEX_ROOT=os.path.join(tmpdir, "pex_root"))
@@ -699,6 +704,7 @@ def test_warn_unused_pex_env_vars():
     assert_execute_venv_pex(expected_stderr="", PEX_EXTRA_SYS_PATH="more")
     assert_execute_venv_pex(expected_stderr="", PEX_VERBOSE="0")
 
+    assert_execute_venv_pex(expected_stderr="", PEX_INHERIT_PATH="fallback")
     assert_execute_venv_pex(
         expected_stderr=dedent(
             """\
@@ -707,6 +713,7 @@ def test_warn_unused_pex_env_vars():
             """
         ),
         PEX_INHERIT_PATH="fallback",
+        PEX_VERBOSE="0",
     )
 
     assert_execute_venv_pex(
@@ -719,7 +726,7 @@ def test_warn_unused_pex_env_vars():
         ),
         PEX_COVERAGE="1",
         PEX_INHERIT_PATH="fallback",
-        PEX_VERBOSE="0",
+        PEX_VERBOSE="1",
     )
 
 


### PR DESCRIPTION
Previously PEXes did not behave like a Python interpreter when invoked
with either `-i` or with `PYTHONINSPECT=x`; now they do.

Fixes #2249