### PR TITLE
Clean up venv installation code.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -1375,7 +1375,7 @@ def do_main(
             "Running PEX file at %s with args %s" % (pex_builder.path(), cmdline),
             V=options.verbosity,
         )
-        sys.exit(pex.run(args=list(cmdline), env=repl.export_pex_cli_no_args_use(env=env)))
+        sys.exit(pex.run(args=list(cmdline), env=repl.export_pex_cli_run(env=env)))
 
 
 def seed_cache(

--- a/pex/cli_util.py
+++ b/pex/cli_util.py
@@ -27,8 +27,9 @@ def prog_path(prog=None):
         ):
             exe_path = os.path.join(os.curdir, exe_path)
     else:
+        exe_dir = os.path.dirname(exe_path)
         for path_entry in os.environ.get("PATH", "").split(os.pathsep):
             abs_path_entry = os.path.abspath(path_entry)
-            if commonpath((exe_path, abs_path_entry)) == abs_path_entry:
-                return os.path.relpath(exe_path, abs_path_entry)
+            if exe_dir == abs_path_entry:
+                return os.path.basename(exe_path)
     return exe_path

--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -96,7 +96,7 @@ else:
             raise ValueError("Cannot convert %s to a unicode string" % type(st))
 
 
-_PY3_EXEC_FUNCTION = """
+_PY2_EXEC_FUNCTION = """
 def exec_function(ast, globals_map):
   locals_map = globals_map
   exec ast in globals_map, locals_map
@@ -116,7 +116,7 @@ else:
         raise AssertionError("Expected this function to be re-defined at runtime.")
 
     # This will result in `exec_function` being re-defined at runtime.
-    eval(compile(_PY3_EXEC_FUNCTION, "<exec_function>", "exec"))
+    eval(compile(_PY2_EXEC_FUNCTION, "<exec_function>", "exec"))
 
 
 if PY3:

--- a/pex/repl/__init__.py
+++ b/pex/repl/__init__.py
@@ -4,10 +4,6 @@
 from __future__ import absolute_import
 
 # For re-export
-from pex.repl.pex_repl import (  # noqa
-    create_pex_repl,
-    create_pex_repl_exe,
-    export_pex_cli_no_args_use,
-)
+from pex.repl.pex_repl import create_pex_repl, create_pex_repl_exe, export_pex_cli_run  # noqa
 
-__all__ = ("create_pex_repl", "create_pex_repl_exe", "export_pex_cli_no_args_use")
+__all__ = ("create_pex_repl", "create_pex_repl_exe", "export_pex_cli_run")

--- a/pex/repl/custom.py
+++ b/pex/repl/custom.py
@@ -73,6 +73,8 @@ def _try_enable_readline(
 
 def repl_loop(
     banner=None,  # type: Optional[str]
+    ps1=None,  # type: Optional[str]
+    ps2=None,  # type: Optional[str]
     custom_commands=None,  # type: Optional[Mapping[str, Tuple[Callable, str]]]
     history=False,  # type: bool
     history_file=None,  # type: Optional[str]
@@ -110,6 +112,10 @@ def repl_loop(
 
     def loop():
         # type: () -> Dict[str, Any]
+        if ps1:
+            sys.ps1 = ps1
+        if ps2:
+            sys.ps2 = ps2
         repl.interact(banner=repl_banner, **extra_args)
         return local
 

--- a/pex/repl/pex_repl.py
+++ b/pex/repl/pex_repl.py
@@ -260,8 +260,8 @@ def create_pex_repl_exe(
         """
     ).format(
         shebang=shebang,
-        custom_module=inspect.getsource(custom),
-        create_pex_repl=inspect.getsource(_create_pex_repl),
+        custom_module=inspect.getsource(custom).strip(),
+        create_pex_repl=inspect.getsource(_create_pex_repl).strip(),
         banner=repl_data.banner,
         pex_info_summary=repl_data.pex_info_summary,
     )

--- a/pex/repl/pex_repl.py
+++ b/pex/repl/pex_repl.py
@@ -18,6 +18,7 @@ from pex.layout import Layout
 from pex.pex_info import PexInfo
 from pex.repl import custom
 from pex.repl.custom import repl_loop
+from pex.third_party import colors
 from pex.third_party.colors import color
 from pex.typing import TYPE_CHECKING, cast
 from pex.variables import ENV, Variables
@@ -87,6 +88,8 @@ def _pex_cli_no_args_hint():
 
 def _create_pex_repl(
     banner,  # type: str
+    ps1,  # type: str
+    ps2,  # type: str
     pex_info,  # type: Union[str, Dict[str, Any]]
     pex_info_summary,  # type: str
     history=False,  # type: bool
@@ -114,6 +117,8 @@ def _create_pex_repl(
 
     return repl_loop(
         banner=banner,
+        ps1=ps1,
+        ps2=ps2,
         custom_commands={
             "pex": (
                 pex,
@@ -130,6 +135,8 @@ def _create_pex_repl(
 class _REPLData(object):
     banner = attr.ib()  # type: str
     pex_info_summary = attr.ib()  # type: str
+    ps1 = attr.ib()  # type: str
+    ps2 = attr.ib()  # type: str
 
 
 def _create_repl_data(
@@ -211,7 +218,7 @@ def _create_repl_data(
 
     more_info_footer = (
         'Type "help", "{pex}", "copyright", "credits" or "license" for more information.'
-    ).format(pex=color("pex", fg="yellow"))
+    ).format(pex=colors.yellow("pex"))
     banner = (
         dedent(
             """\
@@ -229,7 +236,12 @@ def _create_repl_data(
         .strip()
     )
 
-    return _REPLData(banner=banner, pex_info_summary=os.linesep.join(pex_info_summary))
+    return _REPLData(
+        banner=banner,
+        pex_info_summary=os.linesep.join(pex_info_summary),
+        ps1=colors.yellow(">>> "),
+        ps2=colors.yellow("... "),
+    )
 
 
 def create_pex_repl_exe(
@@ -262,7 +274,8 @@ def create_pex_repl_exe(
 
         _BANNER = {banner!r}
         _PEX_INFO_SUMMARY = {pex_info_summary!r}
-
+        _PS1 = {ps1!r}
+        _PS2 = {ps2!r}
 
         if __name__ == "__main__":
             import os
@@ -270,6 +283,8 @@ def create_pex_repl_exe(
 
             _create_pex_repl(
                 banner=_BANNER,
+                ps1=_PS1,
+                ps2=_PS2,
                 pex_info=os.path.join(os.path.dirname(__file__), "PEX-INFO"),
                 pex_info_summary=_PEX_INFO_SUMMARY,
                 history=os.environ.get("PEX_INTERPRETER_HISTORY", "0").lower() in ("1", "true"),
@@ -282,6 +297,8 @@ def create_pex_repl_exe(
         create_pex_repl=inspect.getsource(_create_pex_repl).strip(),
         banner=repl_data.banner,
         pex_info_summary=repl_data.pex_info_summary,
+        ps1=repl_data.ps1,
+        ps2=repl_data.ps2,
     )
 
 
@@ -303,6 +320,8 @@ def create_pex_repl(
     )
     return _create_pex_repl(
         banner=repl_data.banner,
+        ps1=repl_data.ps1,
+        ps2=repl_data.ps2,
         pex_info=pex_info.as_json_dict(),
         pex_info_summary=repl_data.pex_info_summary,
         history=env.PEX_INTERPRETER_HISTORY,

--- a/pex/repl/pex_repl.py
+++ b/pex/repl/pex_repl.py
@@ -31,28 +31,35 @@ else:
     from pex.third_party import attr
 
 
-_PEX_CLI_NO_ARGS_IN_USE_ENV_VAR_NAME = "_PEX_CLI_NO_ARGS_IN_USE"
+_PEX_CLI_RUN_ENV_VAR_NAME = "_PEX_CLI_RUN"
+_PEX_CLI_RUN_NO_ARGS_ENV_VAR_NAME = "_PEX_CLI_RUN_NO_ARGS"
 
 
-def export_pex_cli_no_args_use(env=None):
+def export_pex_cli_run(env=None):
     # type: (Optional[Dict[str, str]]) -> Dict[str, str]
     """Records the fact that the Pex CLI executable is being run with no arguments."""
 
     _env = cast("Dict[str, str]", env or os.environ)
+    _env[_PEX_CLI_RUN_ENV_VAR_NAME] = sys.argv[0]
     if len(sys.argv) == 1:
-        _env[_PEX_CLI_NO_ARGS_IN_USE_ENV_VAR_NAME] = sys.argv[0]
+        _env[_PEX_CLI_RUN_NO_ARGS_ENV_VAR_NAME] = sys.argv[0]
     return _env
 
 
-def _pex_cli_no_args_in_use():
+def _pex_cli_run_in_use():
+    # type: () -> bool
+    return os.environ.pop(_PEX_CLI_RUN_ENV_VAR_NAME, None) is not None
+
+
+def _pex_cli_run_no_args_in_use():
     # type: () -> Optional[str]
-    return os.environ.pop(_PEX_CLI_NO_ARGS_IN_USE_ENV_VAR_NAME, None)
+    return os.environ.pop(_PEX_CLI_RUN_NO_ARGS_ENV_VAR_NAME, None)
 
 
 def _pex_cli_no_args_hint():
     # type: () -> Optional[str]
 
-    pex_cli = _pex_cli_no_args_in_use()
+    pex_cli = _pex_cli_run_no_args_in_use()
     if not pex_cli or len(sys.argv) > 1:
         return None
 
@@ -73,7 +80,9 @@ def _pex_cli_no_args_hint():
                 )
             ),
         )
-    return " Run `{pex} -h` for Pex CLI help.".format(pex=pex_cli_no_args)
+    return "Exit the repl (type quit()) and run `{pex} -h` for Pex CLI help.".format(
+        pex=pex_cli_no_args
+    )
 
 
 def _create_pex_repl(
@@ -87,7 +96,7 @@ def _create_pex_repl(
 
     import json as stdlib_json
 
-    def pex_info_func(json=False):
+    def pex(json=False):
         # type: (bool) -> None
         """Print information about this PEX environment.
 
@@ -106,10 +115,10 @@ def _create_pex_repl(
     return repl_loop(
         banner=banner,
         custom_commands={
-            "pex_info": (
-                pex_info_func,
-                "Type pex_info() for information about this PEX, or pex_info(json=True) for even "
-                "more details.",
+            "pex": (
+                pex,
+                "Type pex() for information about this PEX, or pex(json=True) for even more "
+                "details.",
             )
         },
         history=history,
@@ -138,6 +147,9 @@ def _create_repl_data(
     venv = venv or pex_info.venv
     venv_pex = venv and pex_root == commonpath((os.path.abspath(pex), pex_root))
     pex_prog_path = prog_path(env.PEX if venv_pex else pex)
+    pex_cli_run_in_use = _pex_cli_run_in_use()
+    ephemeral = "ephemeral " if pex_cli_run_in_use else ""
+
     if venv and not venv_pex:
         pex_info_summary = [
             "Running in a PEX venv: {location}".format(location=os.path.dirname(pex_prog_path))
@@ -153,13 +165,15 @@ def _create_repl_data(
             pex_type = "{layout} {venv}PEX directory".format(layout=layout, venv=venv_indicator)
 
         pex_info_summary = [
-            "Running from {pex_type}: {location}".format(pex_type=pex_type, location=pex_prog_path)
+            "Running from {ephemeral}{pex_type}: {location}".format(
+                ephemeral=ephemeral, pex_type=pex_type, location=pex_prog_path
+            )
         ]
 
     if activated_dists:
         req_count = len(requirements)
         dist_count = len(activated_dists)
-        dep_info = "{req_count} {requirements} and {dist_count} activated {dists}.".format(
+        dep_info = "{req_count} {requirements} and {dist_count} activated {dists}".format(
             req_count=req_count,
             requirements=pluralize(req_count, "requirement"),
             dist_count=dist_count,
@@ -170,9 +184,9 @@ def _create_repl_data(
         pex_info_summary.append("Activated Distributions:")
         pex_info_summary.extend("  " + os.path.basename(dist.location) for dist in activated_dists)
     else:
-        dep_info = "no dependencies."
+        dep_info = "no dependencies"
 
-    if pex_info.includes_tools and (not venv or venv_pex):
+    if not pex_cli_run_in_use and pex_info.includes_tools and (not venv or venv_pex):
         pex_info_summary.append(
             "This PEX includes tools. Exit the repl (type quit()) and run "
             "`PEX_TOOLS=1 {pex} -h` for tools help.".format(
@@ -182,18 +196,22 @@ def _create_repl_data(
             )
         )
 
-    color_style = dict(fg="yellow", style="negative")
-    pex_header = color(
-        "Pex {pex_version} hermetic environment with {dep_info}{maybe_pex_cli_no_args_hint}".format(
-            pex_version=__version__,
-            dep_info=dep_info,
-            maybe_pex_cli_no_args_hint=_pex_cli_no_args_hint() or "",
-        ),
-        **color_style
-    )
+    pex_header = [
+        color(
+            "Pex {pex_version} {ephemeral}hermetic environment with {dep_info}.".format(
+                pex_version=__version__, ephemeral=ephemeral, dep_info=dep_info
+            ),
+            fg="yellow",
+            style="negative",
+        )
+    ]
+    pex_cli_no_args_hint = _pex_cli_no_args_hint()
+    if pex_cli_no_args_hint:
+        pex_header.append(color(pex_cli_no_args_hint, fg="yellow"))
+
     more_info_footer = (
-        'Type "help", "{pex_info}", "copyright", "credits" or "license" for more information.'
-    ).format(pex_info=color("pex_info", **color_style))
+        'Type "help", "{pex}", "copyright", "credits" or "license" for more information.'
+    ).format(pex=color("pex", fg="yellow"))
     banner = (
         dedent(
             """\
@@ -203,7 +221,7 @@ def _create_repl_data(
             """
         )
         .format(
-            pex_header=pex_header,
+            pex_header=os.linesep.join(pex_header),
             python_version=sys.version,
             platform=sys.platform,
             more_info_footer=more_info_footer,

--- a/pex/venv/installer.py
+++ b/pex/venv/installer.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import, print_function
 
+import inspect
 import os
 import subprocess
 from collections import Counter, OrderedDict, defaultdict
@@ -22,6 +23,7 @@ from pex.result import Error
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 from pex.util import CacheHelper
+from pex.venv import venv_pex
 from pex.venv.bin_path import BinPath
 from pex.venv.install_scope import InstallScope
 from pex.venv.virtualenv import PipUnavailableError, Virtualenv
@@ -596,323 +598,39 @@ def _populate_first_party(
 
     # 2. Add a __main__ to the root of the venv for running the venv dir like a loose PEX dir
     # and a main.py for running as a script.
-    main_contents = dedent(
-        """\
-        {shebang}
-
-        from __future__ import print_function
-
-
-        if __name__ == "__main__":
-            import os
-            import sys
-
-            venv_dir = os.path.abspath(os.path.dirname(__file__))
-            venv_bin_dir = os.path.join(venv_dir, "bin")
-            shebang_python = {shebang_python!r}
-            python = os.path.join(venv_bin_dir, os.path.basename(shebang_python))
-
-            def iter_valid_venv_pythons():
-                # Allow for both the known valid venv pythons and their fully resolved venv path
-                # version in the case their parent directories contain symlinks.
-                for python_binary in (python, shebang_python):
-                    yield python_binary
-                    yield os.path.join(
-                        os.path.realpath(os.path.dirname(python_binary)),
-                        os.path.basename(python_binary)
-                    )
-
-            def sys_executable_paths():
-                exe = sys.executable
-                executables = {{exe}}
-                while os.path.islink(exe):
-                    exe = os.readlink(exe)
-                    if not os.path.isabs(exe):
-                        exe = os.path.join(venv_bin_dir, exe)
-
-                    if os.path.dirname(exe) == venv_bin_dir and exe not in executables:
-                        executables.add(exe)
-                    else:
-                        # We've either followed relative links inside the bin/ dir out of the bin
-                        # dir to the original venv seed Python binary or we've walked around a loop
-                        # of symlinks once; either way, we've found all valid venv python binaries.
-                        break
-                return executables
-
-            def maybe_log(*message):
-                if "PEX_VERBOSE" in os.environ:
-                    print(*message, file=sys.stderr)
-
-            current_interpreter_blessed_env_var = "_PEX_SHOULD_EXIT_VENV_REEXEC"
-            if (
-                not os.environ.pop(current_interpreter_blessed_env_var, None)
-                and sys_executable_paths().isdisjoint(iter_valid_venv_pythons())
-            ):
-                maybe_log("Re-exec'ing from", sys.executable)
-                os.environ[current_interpreter_blessed_env_var] = "1"
-                argv = [python]
-                if {hermetic_re_exec!r}:
-                    argv.append("-sE")
-                argv.extend(sys.argv)
-                os.execv(python, argv)
-
-            pex_file = os.environ.get("PEX", None)
-            if pex_file:
-                pex_file_path = os.path.realpath(pex_file)
-                sys.argv[0] = pex_file_path
-                os.environ["PEX"] = pex_file_path
-                try:
-                    from setproctitle import setproctitle
-
-                    setproctitle("{{python}} {{pex_file}} {{args}}".format(
-                        python=sys.executable, pex_file=pex_file, args=" ".join(sys.argv[1:]))
-                    )
-                except ImportError:
-                    pass
-
-            ignored_pex_env_vars = [
-                "{{}}={{}}".format(name, value)
-                for name, value in os.environ.items()
-                if name.startswith(("PEX_", "_PEX_", "__PEX_")) and name not in (
-                    # These are used inside this script / the PEX_EXTRA_SYS_PATH.pth site-packages
-                    # file.
-                    "_PEX_SHOULD_EXIT_VENV_REEXEC",
-                    "PEX_EXTRA_SYS_PATH",
-                    "PEX_VENV_BIN_PATH",
-                    "PEX_INTERPRETER",
-                    "PEX_INTERPRETER_HISTORY",
-                    "PEX_INTERPRETER_HISTORY_FILE",
-                    "PEX_SCRIPT",
-                    "PEX_MODULE",
-                    # This is used when loading ENV (Variables()):
-                    "PEX_IGNORE_RCFILES",
-                    # And ENV is used to access these during PEX bootstrap when delegating here via
-                    # a --venv mode PEX file.
-                    "PEX_ROOT",
-                    "PEX_VENV",
-                    "PEX_PATH",
-                    "PEX_PYTHON",
-                    "PEX_PYTHON_PATH",
-                    "PEX_VERBOSE",
-                    "PEX_EMIT_WARNINGS",
-                    "PEX_MAX_INSTALL_JOBS",
-                    # This is used by the vendoring system.
-                    "__PEX_UNVENDORED__",
-                    # These are _not_ used at runtime, but are present under testing / CI and
-                    # simplest to add an exception for here and not warn about in CI runs.
-                    "_PEX_PEXPECT_TIMEOUT",
-                    "_PEX_PIP_VERSION",
-                    "_PEX_REQUIRES_PYTHON",
-                    "_PEX_TEST_DEV_ROOT",
-                    "_PEX_TEST_PROJECT_DIR",
-                    "_PEX_USE_PIP_CONFIG",
-                    # This is used by Pex's Pip to inject runtime patches dynamically.
-                    "_PEX_PIP_RUNTIME_PATCHES_PACKAGE",
-                    # These are used by Pex's Pip venv to provide foreign platform support and work
-                    # around https://github.com/pypa/pip/issues/10050.
-                    "_PEX_PATCHED_MARKERS_FILE",
-                    "_PEX_PATCHED_TAGS_FILE",
-                    # These are used by Pex's Pip venv to implement universal locks.
-                    "_PEX_PYTHON_VERSIONS_FILE",
-                    "_PEX_TARGET_SYSTEMS_FILE",
-                    # This is used to implement Pex --exclude and --override support.
-                    "_PEX_DEP_CONFIG_FILE",
-                    # This is used as an experiment knob for atomic_directory locking.
-                    "_PEX_FILE_LOCK_STYLE",
-                    # This is used in the scie binding command for ZIPAPP PEXes.
-                    "_PEX_SCIE_INSTALLED_PEX_DIR",
-                    # This is used to override PBS distribution URLs in lazy PEX scies.
-                    "PEX_BOOTSTRAP_URLS",
-                )
-            ]
-            if ignored_pex_env_vars:
-                maybe_log(
-                    "Ignoring the following environment variables in Pex venv mode:\\n"
-                    "{{}}\\n".format(
-                        os.linesep.join(sorted(ignored_pex_env_vars))
-                    )
-                )
-
-            os.environ["VIRTUAL_ENV"] = venv_dir
-
-            bin_path = os.environ.get("PEX_VENV_BIN_PATH", {bin_path!r})
-            if bin_path != "false":
-                PATH = os.environ.get("PATH", "").split(os.pathsep)
-                if bin_path == "prepend":
-                    PATH.insert(0, venv_bin_dir)
-                elif bin_path == "append":
-                    PATH.append(venv_bin_dir)
-                else:
-                    sys.stderr.write(
-                        "PEX_VENV_BIN_PATH must be one of 'false', 'prepend' or 'append', given: "
-                        "{{!r}}\\n".format(
-                            bin_path
-                        )
-                    )
-                    sys.exit(1)
-                os.environ["PATH"] = os.pathsep.join(PATH)
-
-            PEX_EXEC_OVERRIDE_KEYS = ("PEX_INTERPRETER", "PEX_SCRIPT", "PEX_MODULE")
-            pex_overrides = {{
-                key: os.environ.get(key) for key in PEX_EXEC_OVERRIDE_KEYS if key in os.environ
-            }}
-            if len(pex_overrides) > 1:
-                sys.stderr.write(
-                    "Can only specify one of {{overrides}}; found: {{found}}\\n".format(
-                        overrides=", ".join(PEX_EXEC_OVERRIDE_KEYS),
-                        found=" ".join("{{}}={{}}".format(k, v) for k, v in pex_overrides.items())
-                    )
-                )
-                sys.exit(1)
-            is_exec_override = len(pex_overrides) == 1
-
-            pex_interpreter_history = os.environ.get("PEX_INTERPRETER_HISTORY")
-            pex_interpreter_history_file = os.environ.get("PEX_INTERPRETER_HISTORY_FILE")
-            if {strip_pex_env!r}:
-                for key in list(os.environ):
-                    if key.startswith("PEX_"):
-                        if key == "PEX_EXTRA_SYS_PATH":
-                            # We always want sys.path additions to propagate so that the venv PEX
-                            # acts like a normal Python interpreter where sys.path seen in
-                            # subprocesses is the same as the sys.executable in the parent process.
-                            os.environ["__PEX_EXTRA_SYS_PATH__"] = os.environ.get(
-                                "PEX_EXTRA_SYS_PATH"
-                            )
-                        del os.environ[key]
-  
-            for name, value in {inject_env!r}:
-                os.environ.setdefault(name, value)
-                
-            pex_script = pex_overrides.get("PEX_SCRIPT") if pex_overrides else {script!r}
-            if pex_script:
-                script_path = os.path.join(venv_bin_dir, pex_script)
-                os.execv(script_path, [script_path] + sys.argv[1:])
-
-            pex_interpreter = pex_overrides.get("PEX_INTERPRETER", "").lower() in ("1", "true")
-            PEX_INTERPRETER_ENTRYPOINT = "code:interact"
-            entry_point = (
-                PEX_INTERPRETER_ENTRYPOINT
-                if pex_interpreter
-                else pex_overrides.get("PEX_MODULE", {entry_point!r} or PEX_INTERPRETER_ENTRYPOINT)
-            )
-                                  
-            if entry_point == PEX_INTERPRETER_ENTRYPOINT:
-                # A Python interpreter always inserts the CWD at the head of the sys.path.
-                # See https://docs.python.org/3/library/sys.html#sys.path
-                sys.path.insert(0, "")
-
-                args = sys.argv[1:]
-
-                python_options = []
-                for index, arg in enumerate(args):
-                    # Check if the arg is an expected startup arg
-                    if (
-                        arg != "-"
-                        and arg.startswith("-")
-                        and not arg.startswith(("--", "-c", "-m"))
-                    ):
-                        python_options.append(arg)
-                    else:
-                        args = args[index:]
-                        break
-                else:
-                    # All the args were python options
-                    args = []
-
-                # The pex was called with Python interpreter options, so we need to re-exec to
-                # respect those:
-                if not args or python_options or "PYTHONINSPECT" in os.environ:
-                    python = sys.executable
-                    cmdline = [python] + python_options
-                    inspect = "PYTHONINSPECT" in os.environ or any(
-                        arg.startswith("-") and not arg.startswith("--") and "i" in arg
-                        for arg in python_options
-                    )
-                    if not args:
-                        if pex_interpreter_history:
-                            os.environ["PEX_INTERPRETER_HISTORY"] = pex_interpreter_history
-                        if pex_interpreter_history_file:
-                            os.environ["PEX_INTERPRETER_HISTORY_FILE"] = pex_interpreter_history_file
-                        cmdline.append(os.path.join(os.path.dirname(__file__), "pex-repl"))
-                    elif not inspect:
-                        # We're not interactive; so find the installed (unzipped) PEX entry point.
-                        cmdline.append(__file__)
-                    cmdline.extend(args)
-                    maybe_log(
-                        "Re-executing with Python interpreter options: "
-                        "cmdline={{cmdline!r}}".format(cmdline=" ".join(cmdline))
-                    )
-                    os.execv(python, cmdline)
-
-                arg = args[0]
-                if arg == "-m":
-                    if len(args) < 2:
-                        sys.stderr.write("Argument expected for the -m option\\n")
-                        sys.exit(2)
-                    entry_point = module = args[1]
-                    sys.argv = args[1:]
-                    # Fall through to entry_point handling below.
-                else:
-                    filename = arg
-                    sys.argv = args
-                    if arg == "-c":
-                        if len(args) < 2:
-                            sys.stderr.write("Argument expected for the -c option\\n")
-                            sys.exit(2)
-                        filename = "-c <cmd>"
-                        content = args[1]
-                        sys.argv = ["-c"] + args[2:]
-                    elif arg == "-":
-                        content = sys.stdin.read()
-                    else:
-                        file_path = arg if os.path.isfile(arg) else os.path.join(arg, "__main__.py")
-                        with open(file_path) as fp:
-                            content = fp.read()
-
-                    ast = compile(content, filename, "exec", flags=0, dont_inherit=1)
-                    globals_map = globals().copy()
-                    globals_map["__name__"] = "__main__"
-                    globals_map["__file__"] = filename
-                    locals_map = globals_map
-                    {exec_ast}
-                    sys.exit(0)
-
-            if not is_exec_override:
-                sys.argv[1:1] = {inject_args!r}
-
-            module_name, _, function = entry_point.partition(":")
-            if not function:
-                import runpy
-                runpy.run_module(module_name, run_name="__main__", alter_sys=True)
-            else:
-                import importlib
-                module = importlib.import_module(module_name)
-                # N.B.: Functions may be hung off top-level objects in the module namespace,
-                # e.g.: Class.method; so we drill down through any attributes to the final function
-                # object.
-                namespace, func = module, None
-                for attr in function.split("."):
-                    func = namespace = getattr(namespace, attr)
-                sys.exit(func())
-        """.format(
-            shebang=shebang,
-            shebang_python=venv_python,
-            bin_path=bin_path,
-            strip_pex_env=pex_info.strip_pex_env,
-            inject_env=tuple(pex_info.inject_env.items()),
-            inject_args=list(pex_info.inject_args),
-            entry_point=pex_info.entry_point,
-            script=pex_info.script,
-            exec_ast=(
-                "exec ast in globals_map, locals_map"
-                if venv.interpreter.version[0] == 2
-                else "exec(ast, globals_map, locals_map)"
-            ),
-            hermetic_re_exec=pex_info.venv_hermetic_scripts,
-        )
-    )
     with open(venv.join_path("__main__.py"), "w") as fp:
-        fp.write(main_contents)
+        fp.write(
+            dedent(
+                """\
+                {shebang}
+                {code}
+
+
+                if __name__ == "__main__":
+                    boot(
+                        shebang_python={shebang_python!r},
+                        bin_path={bin_path!r},
+                        strip_pex_env={strip_pex_env!r},
+                        inject_env={inject_env!r},
+                        inject_args={inject_args!r},
+                        entry_point={entry_point!r},
+                        script={script!r},
+                        hermetic_re_exec={hermetic_re_exec!r},
+                    )
+                """
+            ).format(
+                shebang=shebang,
+                code=inspect.getsource(venv_pex).strip(),
+                shebang_python=venv_python,
+                bin_path=bin_path,
+                strip_pex_env=pex_info.strip_pex_env,
+                inject_env=tuple(pex_info.inject_env.items()),
+                inject_args=list(pex_info.inject_args),
+                entry_point=pex_info.entry_point,
+                script=pex_info.script,
+                hermetic_re_exec=pex_info.venv_hermetic_scripts,
+            )
+        )
     chmod_plus_x(fp.name)
     os.symlink(os.path.basename(fp.name), venv.join_path("pex"))
 

--- a/pex/venv/venv_pex.py
+++ b/pex/venv/venv_pex.py
@@ -1,0 +1,329 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import print_function
+
+import os
+import sys
+from types import CodeType
+
+TYPE_CHECKING = False
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+_PY2_EXEC_FUNCTION = """
+def exec_function(ast, globals_map):
+    locals_map = globals_map
+    exec ast in globals_map, locals_map
+    return locals_map
+"""
+
+if sys.version_info[0] == 2:
+
+    def exec_function(
+        ast,  # type: CodeType
+        globals_map,  # type: Dict[str, Any]
+    ):
+        raise AssertionError("Expected this function to be re-defined at runtime.")
+
+    # This will result in `exec_function` being re-defined at runtime.
+    eval(compile(_PY2_EXEC_FUNCTION, "<exec_function>", "exec"))
+else:
+
+    def exec_function(
+        ast,  # type: CodeType
+        globals_map,  # type: Dict[str, Any]
+    ):
+        locals_map = globals_map
+        exec (ast, globals_map, locals_map)
+        return locals_map
+
+
+def boot(
+    shebang_python,  # type: str
+    bin_path,  # type: str
+    strip_pex_env,  # type: bool
+    inject_env,  # type: Iterable[Tuple[str, str]]
+    inject_args,  # type: List[str]
+    entry_point,  # type: Optional[str]
+    script,  # type: Optional[str]
+    hermetic_re_exec,  # type: bool
+):
+    # type: (...) -> None
+
+    venv_dir = os.path.abspath(os.path.dirname(__file__))
+    venv_bin_dir = os.path.join(venv_dir, "bin")
+    python = os.path.join(venv_bin_dir, os.path.basename(shebang_python))
+
+    def iter_valid_venv_pythons():
+        # Allow for both the known valid venv pythons and their fully resolved venv path
+        # version in the case their parent directories contain symlinks.
+        for python_binary in (python, shebang_python):
+            yield python_binary
+            yield os.path.join(
+                os.path.realpath(os.path.dirname(python_binary)), os.path.basename(python_binary)
+            )
+
+    def sys_executable_paths():
+        exe = sys.executable
+        executables = {exe}
+        while os.path.islink(exe):
+            exe = os.readlink(exe)
+            if not os.path.isabs(exe):
+                exe = os.path.join(venv_bin_dir, exe)
+
+            if os.path.dirname(exe) == venv_bin_dir and exe not in executables:
+                executables.add(exe)
+            else:
+                # We've either followed relative links inside the bin/ dir out of the bin
+                # dir to the original venv seed Python binary or we've walked around a loop
+                # of symlinks once; either way, we've found all valid venv python binaries.
+                break
+        return executables
+
+    def maybe_log(*message):
+        if "PEX_VERBOSE" in os.environ:
+            print(*message, file=sys.stderr)
+
+    current_interpreter_blessed_env_var = "_PEX_SHOULD_EXIT_VENV_REEXEC"
+    if not os.environ.pop(
+        current_interpreter_blessed_env_var, None
+    ) and sys_executable_paths().isdisjoint(iter_valid_venv_pythons()):
+        maybe_log("Re-exec'ing from", sys.executable)
+        os.environ[current_interpreter_blessed_env_var] = "1"
+        argv = [python]
+        if hermetic_re_exec:
+            argv.append("-sE")
+        argv.extend(sys.argv)
+        os.execv(python, argv)
+
+    pex_file = os.environ.get("PEX", None)
+    if pex_file:
+        pex_file_path = os.path.realpath(pex_file)
+        sys.argv[0] = pex_file_path
+        os.environ["PEX"] = pex_file_path
+        try:
+            from setproctitle import setproctitle  # type: ignore[import]
+
+            setproctitle(
+                "{python} {pex_file} {args}".format(
+                    python=sys.executable, pex_file=pex_file, args=" ".join(sys.argv[1:])
+                )
+            )
+        except ImportError:
+            pass
+
+    ignored_pex_env_vars = [
+        "{}={}".format(name, value)
+        for name, value in os.environ.items()
+        if name.startswith(("PEX_", "_PEX_", "__PEX_"))
+        and name
+        not in (
+            # These are used inside this script / the PEX_EXTRA_SYS_PATH.pth site-packages
+            # file.
+            "_PEX_SHOULD_EXIT_VENV_REEXEC",
+            "PEX_EXTRA_SYS_PATH",
+            "PEX_VENV_BIN_PATH",
+            "PEX_INTERPRETER",
+            "PEX_INTERPRETER_HISTORY",
+            "PEX_INTERPRETER_HISTORY_FILE",
+            "PEX_SCRIPT",
+            "PEX_MODULE",
+            # This is used when loading ENV (Variables()):
+            "PEX_IGNORE_RCFILES",
+            # And ENV is used to access these during PEX bootstrap when delegating here via
+            # a --venv mode PEX file.
+            "PEX_ROOT",
+            "PEX_VENV",
+            "PEX_PATH",
+            "PEX_PYTHON",
+            "PEX_PYTHON_PATH",
+            "PEX_VERBOSE",
+            "PEX_EMIT_WARNINGS",
+            "PEX_MAX_INSTALL_JOBS",
+            # This is used by the vendoring system.
+            "__PEX_UNVENDORED__",
+            # These are _not_ used at runtime, but are present under testing / CI and
+            # simplest to add an exception for here and not warn about in CI runs.
+            "_PEX_PEXPECT_TIMEOUT",
+            "_PEX_PIP_VERSION",
+            "_PEX_REQUIRES_PYTHON",
+            "_PEX_TEST_DEV_ROOT",
+            "_PEX_TEST_PROJECT_DIR",
+            "_PEX_USE_PIP_CONFIG",
+            # This is used by Pex's Pip to inject runtime patches dynamically.
+            "_PEX_PIP_RUNTIME_PATCHES_PACKAGE",
+            # These are used by Pex's Pip venv to provide foreign platform support and work
+            # around https://github.com/pypa/pip/issues/10050.
+            "_PEX_PATCHED_MARKERS_FILE",
+            "_PEX_PATCHED_TAGS_FILE",
+            # These are used by Pex's Pip venv to implement universal locks.
+            "_PEX_PYTHON_VERSIONS_FILE",
+            "_PEX_TARGET_SYSTEMS_FILE",
+            # This is used to implement Pex --exclude and --override support.
+            "_PEX_DEP_CONFIG_FILE",
+            # This is used as an experiment knob for atomic_directory locking.
+            "_PEX_FILE_LOCK_STYLE",
+            # This is used in the scie binding command for ZIPAPP PEXes.
+            "_PEX_SCIE_INSTALLED_PEX_DIR",
+            # This is used to override PBS distribution URLs in lazy PEX scies.
+            "PEX_BOOTSTRAP_URLS",
+        )
+    ]
+    if ignored_pex_env_vars:
+        maybe_log(
+            "Ignoring the following environment variables in Pex venv mode:\n"
+            "{}".format(os.linesep.join(sorted(ignored_pex_env_vars)))
+        )
+
+    os.environ["VIRTUAL_ENV"] = venv_dir
+
+    bin_path = os.environ.get("PEX_VENV_BIN_PATH", bin_path)
+    if bin_path != "false":
+        PATH = os.environ.get("PATH", "").split(os.pathsep)
+        if bin_path == "prepend":
+            PATH.insert(0, venv_bin_dir)
+        elif bin_path == "append":
+            PATH.append(venv_bin_dir)
+        else:
+            print(
+                "PEX_VENV_BIN_PATH must be one of 'false', 'prepend' or 'append', given: "
+                "{!r}".format(bin_path),
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        os.environ["PATH"] = os.pathsep.join(PATH)
+
+    PEX_EXEC_OVERRIDE_KEYS = ("PEX_INTERPRETER", "PEX_SCRIPT", "PEX_MODULE")
+    pex_overrides = {key: os.environ[key] for key in PEX_EXEC_OVERRIDE_KEYS if key in os.environ}
+    if len(pex_overrides) > 1:
+        print(
+            "Can only specify one of {overrides}; found: {found}".format(
+                overrides=", ".join(PEX_EXEC_OVERRIDE_KEYS),
+                found=" ".join("{}={}".format(k, v) for k, v in pex_overrides.items()),
+            ),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    is_exec_override = len(pex_overrides) == 1
+
+    pex_interpreter_history = os.environ.get("PEX_INTERPRETER_HISTORY")
+    pex_interpreter_history_file = os.environ.get("PEX_INTERPRETER_HISTORY_FILE")
+    if strip_pex_env:
+        for key in list(os.environ):
+            if key.startswith("PEX_"):
+                if key == "PEX_EXTRA_SYS_PATH":
+                    # We always want sys.path additions to propagate so that the venv PEX
+                    # acts like a normal Python interpreter where sys.path seen in
+                    # subprocesses is the same as the sys.executable in the parent process.
+                    os.environ["__PEX_EXTRA_SYS_PATH__"] = os.environ["PEX_EXTRA_SYS_PATH"]
+                del os.environ[key]
+
+    for name, value in inject_env:
+        os.environ.setdefault(name, value)
+
+    pex_script = pex_overrides.get("PEX_SCRIPT") if pex_overrides else script
+    if pex_script:
+        script_path = os.path.join(venv_bin_dir, pex_script)
+        os.execv(script_path, [script_path] + sys.argv[1:])
+
+    pex_interpreter = pex_overrides.get("PEX_INTERPRETER", "").lower() in ("1", "true")
+    entry_point = None if pex_interpreter else pex_overrides.get("PEX_MODULE", entry_point)
+    if not entry_point:
+        # A Python interpreter always inserts the CWD at the head of the sys.path.
+        # See https://docs.python.org/3/library/sys.html#sys.path
+        sys.path.insert(0, "")
+
+        args = sys.argv[1:]
+
+        python_options = []
+        for index, arg in enumerate(args):
+            # Check if the arg is an expected startup arg
+            if arg != "-" and arg.startswith("-") and not arg.startswith(("--", "-c", "-m")):
+                python_options.append(arg)
+            else:
+                args = args[index:]
+                break
+        else:
+            # All the args were python options
+            args = []
+
+        # The pex was called with Python interpreter options, so we need to re-exec to
+        # respect those:
+        if not args or python_options or "PYTHONINSPECT" in os.environ:
+            python = sys.executable
+            cmdline = [python] + python_options
+            inspect = "PYTHONINSPECT" in os.environ or any(
+                arg.startswith("-") and not arg.startswith("--") and "i" in arg
+                for arg in python_options
+            )
+            if not args:
+                if pex_interpreter_history:
+                    os.environ["PEX_INTERPRETER_HISTORY"] = pex_interpreter_history
+                if pex_interpreter_history_file:
+                    os.environ["PEX_INTERPRETER_HISTORY_FILE"] = pex_interpreter_history_file
+                cmdline.append(os.path.join(os.path.dirname(__file__), "pex-repl"))
+            elif not inspect:
+                # We're not interactive; so find the installed (unzipped) PEX entry point.
+                cmdline.append(__file__)
+            cmdline.extend(args)
+            maybe_log(
+                "Re-executing with Python interpreter options: "
+                "cmdline={cmdline!r}".format(cmdline=" ".join(cmdline))
+            )
+            os.execv(python, cmdline)
+
+        arg = args[0]
+        if arg == "-m":
+            if len(args) < 2:
+                print("Argument expected for the -m option", file=sys.stderr)
+                sys.exit(2)
+            entry_point = args[1]
+            sys.argv = args[1:]
+            # Fall through to entry_point handling below.
+        else:
+            filename = arg
+            sys.argv = args
+            if arg == "-c":
+                if len(args) < 2:
+                    print("Argument expected for the -c option", file=sys.stderr)
+                    sys.exit(2)
+                filename = "-c <cmd>"
+                content = args[1]
+                sys.argv = ["-c"] + args[2:]
+            elif arg == "-":
+                content = sys.stdin.read()
+            else:
+                file_path = arg if os.path.isfile(arg) else os.path.join(arg, "__main__.py")
+                with open(file_path) as fp:
+                    content = fp.read()
+
+            ast = compile(content, filename, "exec", flags=0, dont_inherit=1)
+            globals_map = globals().copy()
+            globals_map["__name__"] = "__main__"
+            globals_map["__file__"] = filename
+            exec_function(ast, globals_map)
+            sys.exit(0)
+
+    if not is_exec_override:
+        sys.argv[1:1] = inject_args
+
+    module_name, _, function = entry_point.partition(":")
+    if not function:
+        import runpy
+
+        runpy.run_module(module_name, run_name="__main__", alter_sys=True)
+    else:
+        import importlib
+
+        module = importlib.import_module(module_name)
+        # N.B.: Functions may be hung off top-level objects in the module namespace,
+        # e.g.: Class.method; so we drill down through any attributes to the final function
+        # object.
+        root_object, _, chained_access = function.partition(".")
+        func = getattr(module, root_object)
+        if chained_access:
+            for attr in chained_access.split("."):
+                func = getattr(func, attr)
+        sys.exit(func())

--- a/tests/integration/test_issue_157.py
+++ b/tests/integration/test_issue_157.py
@@ -65,7 +65,7 @@ def expect_banner_footer(
         "information.".format(pex=colors.yellow("pex")).encode("utf-8"),
         timeout=timeout,
     )
-    process.expect_exact(b">>> ", timeout=timeout)
+    process.expect_exact(colors.yellow(">>> ").encode("utf-8"), timeout=timeout)
 
 
 def create_pex(

--- a/tests/integration/test_issue_157.py
+++ b/tests/integration/test_issue_157.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 from contextlib import closing, contextmanager
 
+import colors  # vendor:skip
 import pexpect  # type: ignore[import]  # MyPy can't see the types under Python 2.7.
 import pytest
 from colors import color  # vendor:skip
@@ -15,29 +16,32 @@ from colors import color  # vendor:skip
 from pex.pex_info import PexInfo
 from pex.typing import TYPE_CHECKING
 from pex.version import __version__
-from testing import make_env, run_pex_command
+from testing import IS_PYPY, make_env, run_pex_command
 
 if TYPE_CHECKING:
     from typing import Any, Iterable, Iterator, List
 
 
-EXPECTED_COLOR = dict(fg="yellow", style="negative")
-
-
 def expect_banner_header(
     process,  # type: pexpect.spawn
     timeout,  # type: int
+    expected_ephemeral,  # type: bool
     expected_suffix,  # type: str
 ):
     # type: (...) -> None
     process.expect_exact(
         color(
-            "Pex {pex_version} hermetic environment with {expected_suffix}".format(
-                pex_version=__version__, expected_suffix=expected_suffix
+            "Pex {pex_version} {ephemeral}hermetic environment with {expected_suffix}".format(
+                pex_version=__version__,
+                ephemeral="ephemeral " if expected_ephemeral else "",
+                expected_suffix=expected_suffix,
             ),
-            **EXPECTED_COLOR
+            fg="yellow",
+            style="negative",
         ).encode("utf-8"),
-        timeout=timeout,
+        # We extend the timeout to read the initial header line and even more so for PyPy, which is
+        # slower to start up.
+        timeout=timeout * (6 if IS_PYPY else 3),
     )
 
 
@@ -57,8 +61,8 @@ def expect_banner_footer(
     ):
         process.expect_exact(line, timeout=timeout)
     process.expect_exact(
-        'Type "help", "{pex_info}", "copyright", "credits" or "license" for more '
-        "information.".format(pex_info=color("pex_info", **EXPECTED_COLOR)).encode("utf-8"),
+        'Type "help", "{pex}", "copyright", "credits" or "license" for more '
+        "information.".format(pex=colors.yellow("pex")).encode("utf-8"),
         timeout=timeout,
     )
     process.expect_exact(b">>> ", timeout=timeout)
@@ -111,7 +115,12 @@ def test_empty_pex_no_args(
 
     pex = create_pex(tmpdir, extra_args=execution_mode_args)
     with pexpect_spawn(tmpdir, pex) as process:
-        expect_banner_header(process, timeout=pexpect_timeout, expected_suffix="no dependencies.")
+        expect_banner_header(
+            process,
+            timeout=pexpect_timeout,
+            expected_ephemeral=False,
+            expected_suffix="no dependencies.",
+        )
         expect_banner_footer(process, timeout=pexpect_timeout)
 
 
@@ -133,9 +142,15 @@ def test_pex_cli_no_args(
         expect_banner_header(
             process,
             timeout=pexpect_timeout,
-            expected_suffix="no dependencies. Run `{pex} -h` for Pex CLI help.".format(
-                pex=os.path.basename(pex)
-            ),
+            expected_ephemeral=True,
+            expected_suffix="no dependencies.",
+        )
+        process.expect_exact(
+            colors.yellow(
+                "Exit the repl (type quit()) and run `{pex} -h` for Pex CLI help.".format(
+                    pex=os.path.basename(pex)
+                )
+            ).encode("utf-8")
         )
         expect_banner_footer(process, timeout=pexpect_timeout)
 
@@ -153,6 +168,7 @@ def test_pex_with_deps(
         expect_banner_header(
             process,
             timeout=pexpect_timeout,
+            expected_ephemeral=False,
             expected_suffix="1 requirement and 1 activated distribution.",
         )
         expect_banner_footer(process, timeout=pexpect_timeout)
@@ -167,9 +183,11 @@ def expect_pex_info_response(
 ):
     # type: (...) -> Iterator[pexpect.spawn]
     with pexpect_spawn(tmpdir, pex) as process:
-        expect_banner_header(process, timeout=timeout, expected_suffix="no dependencies.")
+        expect_banner_header(
+            process, timeout=timeout, expected_ephemeral=False, expected_suffix="no dependencies."
+        )
         expect_banner_footer(process, timeout=timeout)
-        process.sendline("pex_info(json={json!r})".format(json=json).encode("utf-8"))
+        process.sendline("pex(json={json!r})".format(json=json).encode("utf-8"))
         yield process
 
 

--- a/tests/integration/venv_ITs/test_issue_2248.py
+++ b/tests/integration/venv_ITs/test_issue_2248.py
@@ -83,7 +83,7 @@ def test_repl_python_options(
         """\
         Pex {pex_version} hermetic environment with 1 requirement and 1 activated distribution.
         Python {python_version} on {platform}
-        Type "help", "pex_info", "copyright", "credits" or "license" for more information.
+        Type "help", "pex", "copyright", "credits" or "license" for more information.
         """
     ).format(python_version=sys.version, platform=sys.platform, pex_version=__version__)
 

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -791,7 +791,7 @@ EXPECTED_REPL_BANNER_NO_DEPS = (
         """\
         Pex {pex_version} hermetic environment with no dependencies.
         Python {python_version} on {platform}
-        Type "help", "pex_info", "copyright", "credits" or "license" for more information.
+        Type "help", "pex", "copyright", "credits" or "license" for more information.
         """
     )
     .format(python_version=sys.version, platform=sys.platform, pex_version=__version__)


### PR DESCRIPTION
This extracts the large venv PEX formatted code blob to its own file for
standard formatting, linting and type check treatment. Also clean up
small bits of PEX venv repl code from #2496.