### PR TITLE
Fix PEX repl prompt for Linux PBS libedit.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,11 +2,12 @@
 
 ## 2.16.1
 
-This release fixes the PEX repl for Pythons that use some versions of
-libedit to support readline functionality. For those versions, ansi
-terminal escape sequences for prompt colorization were not working.
+This release fixes the PEX repl for [Python Standalone Builds][PBS]
+CPython PEX scies. These PEXes ship using a version of libedit for
+readline support that does not support naive use of ansi terminal
+escape sequences for prompt colorization.
 
-* Fix PEX repl prompt for libedit. (#2503)
+* Fix PEX repl prompt for PBS libedit. (#2503)
 
 ## 2.16.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,11 +3,11 @@
 ## 2.16.1
 
 This release fixes the PEX repl for [Python Standalone Builds][PBS]
-CPython PEX scies. These PEXes ship using a version of libedit for
-readline support that does not support naive use of ansi terminal
+Linux CPython PEX scies. These PEXes ship using a version of libedit
+for readline support that does not support naive use of ansi terminal
 escape sequences for prompt colorization.
 
-* Fix PEX repl prompt for PBS libedit. (#2503)
+* Fix PEX repl prompt for Linux PBS libedit. (#2503)
 
 ## 2.16.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 2.16.1
+
+This release fixes the PEX repl for Pythons that use some versions of
+libedit to support readline functionality. For those versions, ansi
+terminal escape sequences for prompt colorization were not working.
+
+* Fix PEX repl prompt for libedit. (#2503)
+
 ## 2.16.0
 
 This release adds support for `--venv-system-site-packages` when

--- a/pex/repl/custom.py
+++ b/pex/repl/custom.py
@@ -85,6 +85,7 @@ def repl_loop(
     custom_commands=None,  # type: Optional[Mapping[str, Tuple[Callable, str]]]
     history=False,  # type: bool
     history_file=None,  # type: Optional[str]
+    use_libedit_color_prompt_workaround=False,  # type: bool
 ):
     # type: (...) -> Callable[[], Dict[str, Any]]
 
@@ -123,7 +124,7 @@ def repl_loop(
 
         if not sys.stdout.isatty():
             text = _ANSI_RE.sub("", text)
-        elif prompt and libedit:
+        elif prompt and libedit and use_libedit_color_prompt_workaround:
             # Most versions of libedit do not support ansi terminal escape sequences, but they do
             # support a readline back door where you can bracket characters that should be ignored
             # for prompt width calculation but otherwise passed through unaltered to the terminal.

--- a/pex/repl/pex_repl.py
+++ b/pex/repl/pex_repl.py
@@ -130,6 +130,9 @@ def _create_pex_repl(
         },
         history=history,
         history_file=history_file,
+        # The PBS CPythons used by PEX scies use a version of libedit that needs workarounds to
+        # support color prompts.
+        use_libedit_color_prompt_workaround=os.environ.get("SCIE") is not None,
     )
 
 

--- a/pex/repl/pex_repl.py
+++ b/pex/repl/pex_repl.py
@@ -130,9 +130,11 @@ def _create_pex_repl(
         },
         history=history,
         history_file=history_file,
-        # The PBS CPythons used by PEX scies use a version of libedit that needs workarounds to
-        # support color prompts.
-        use_libedit_color_prompt_workaround=os.environ.get("SCIE") is not None,
+        # The PBS Linux CPythons used by PEX scies use a version of libedit that needs workarounds
+        # to support color prompts.
+        use_libedit_color_prompt_workaround=(
+            os.environ.get("SCIE") is not None and sys.platform.lower().startswith("linux")
+        ),
     )
 
 

--- a/pex/repl/pex_repl.py
+++ b/pex/repl/pex_repl.py
@@ -32,6 +32,8 @@ else:
     from pex.third_party import attr
 
 
+_ARGV0 = os.environ.get("SCIE_ARGV0", sys.argv[0])
+
 _PEX_CLI_RUN_ENV_VAR_NAME = "_PEX_CLI_RUN"
 _PEX_CLI_RUN_NO_ARGS_ENV_VAR_NAME = "_PEX_CLI_RUN_NO_ARGS"
 
@@ -41,9 +43,9 @@ def export_pex_cli_run(env=None):
     """Records the fact that the Pex CLI executable is being run with no arguments."""
 
     _env = cast("Dict[str, str]", env or os.environ)
-    _env[_PEX_CLI_RUN_ENV_VAR_NAME] = sys.argv[0]
+    _env[_PEX_CLI_RUN_ENV_VAR_NAME] = _ARGV0
     if len(sys.argv) == 1:
-        _env[_PEX_CLI_RUN_NO_ARGS_ENV_VAR_NAME] = sys.argv[0]
+        _env[_PEX_CLI_RUN_NO_ARGS_ENV_VAR_NAME] = _ARGV0
     return _env
 
 
@@ -143,7 +145,7 @@ def _create_repl_data(
     pex_info,  # type: PexInfo
     requirements,  # type: Sequence[str]
     activated_dists,  # type: Sequence[Distribution]
-    pex=sys.argv[0],  # type: str
+    pex=_ARGV0,  # type: str
     env=ENV,  # type: Variables
     venv=False,  # type: bool
 ):
@@ -239,8 +241,8 @@ def _create_repl_data(
     return _REPLData(
         banner=banner,
         pex_info_summary=os.linesep.join(pex_info_summary),
-        ps1=colors.yellow(">>> "),
-        ps2=colors.yellow("... "),
+        ps1=colors.yellow(">>>"),
+        ps2=colors.yellow("..."),
     )
 
 
@@ -248,7 +250,7 @@ def create_pex_repl_exe(
     shebang,  # type: str
     pex_info,  # type: PexInfo
     activated_dists,  # type: Sequence[Distribution]
-    pex=sys.argv[0],  # type: str
+    pex=_ARGV0,  # type: str
     env=ENV,  # type: Variables
     venv=False,  # type: bool
 ):
@@ -306,7 +308,7 @@ def create_pex_repl(
     pex_info,  # type: PexInfo
     requirements,  # type: Sequence[str]
     activated_dists,  # type: Sequence[Distribution]
-    pex=sys.argv[0],  # type: str
+    pex=_ARGV0,  # type: str
     env=ENV,  # type: Variables
 ):
     # type: (...) -> Callable[[], Dict[str, Any]]

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.16.0"
+__version__ = "2.16.1"

--- a/tests/integration/test_issue_157.py
+++ b/tests/integration/test_issue_157.py
@@ -17,7 +17,7 @@ from colors import color  # vendor:skip
 from pex.pex_info import PexInfo
 from pex.typing import TYPE_CHECKING
 from pex.version import __version__
-from testing import IS_PYPY, make_env, run_pex_command
+from testing import IS_PYPY, make_env, run_pex_command, scie
 
 if TYPE_CHECKING:
     from typing import Any, Iterable, Iterator, List, Tuple
@@ -112,7 +112,7 @@ def create_pex(
             env=make_env(PEX_INTERPRETER=1),
         )
         .decode("utf-8")
-        .splitlines(keepends=False)
+        .splitlines()
     )
     return Pex(path=pex, expected_python_banner_lines=tuple(expected_python_banner_lines))
 
@@ -147,10 +147,8 @@ def pexpect_spawn(
 @execution_mode_args
 @pytest.mark.parametrize(
     "scie_args",
-    [
-        pytest.param([], id="traditional"),
-        pytest.param(["--scie", "eager"], id="scie"),
-    ],
+    [pytest.param([], id="traditional")]
+    + ([pytest.param(["--scie", "eager"], id="scie")] if scie.has_provider() else []),
 )
 def test_empty_pex_no_args(
     tmpdir,  # type: Any

--- a/tests/integration/test_issue_157.py
+++ b/tests/integration/test_issue_157.py
@@ -5,8 +5,9 @@ from __future__ import absolute_import
 
 import os
 import subprocess
-import sys
 from contextlib import closing, contextmanager
+from textwrap import dedent
+from typing import Text
 
 import colors  # vendor:skip
 import pexpect  # type: ignore[import]  # MyPy can't see the types under Python 2.7.
@@ -19,7 +20,11 @@ from pex.version import __version__
 from testing import IS_PYPY, make_env, run_pex_command
 
 if TYPE_CHECKING:
-    from typing import Any, Iterable, Iterator, List
+    from typing import Any, Iterable, Iterator, List, Tuple
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
 
 
 def expect_banner_header(
@@ -46,41 +51,70 @@ def expect_banner_header(
 
 
 def expect_banner_footer(
+    pex,  # type: Pex
     process,  # type: pexpect.spawn
     timeout,  # type: int
 ):
     # type: (...) -> None
 
-    # N.B.: The sys.version can contain multiple lines for some distributions; so we split here.
-    for line in (
-        "Python {python_version} on {platform}".format(
-            python_version=sys.version, platform=sys.platform
-        )
-        .encode("utf-8")
-        .splitlines()
-    ):
+    for line in pex.expected_python_banner_lines:
         process.expect_exact(line, timeout=timeout)
     process.expect_exact(
         'Type "help", "{pex}", "copyright", "credits" or "license" for more '
         "information.".format(pex=colors.yellow("pex")).encode("utf-8"),
         timeout=timeout,
     )
-    process.expect_exact(colors.yellow(">>> ").encode("utf-8"), timeout=timeout)
+    process.expect_exact((colors.yellow(">>>") + " ").encode("utf-8"), timeout=timeout)
+
+
+@attr.s(frozen=True)
+class Pex(object):
+    path = attr.ib()  # type: str
+    expected_python_banner_lines = attr.ib()  # type: Tuple[Text, ...]
+
+    def venv(self, venv_dir):
+        # type: (str) -> Pex
+        return Pex(
+            path=os.path.join(venv_dir, "pex"),
+            expected_python_banner_lines=self.expected_python_banner_lines,
+        )
 
 
 def create_pex(
     tmpdir,  # type: Any
     extra_args=(),  # type: Iterable[str]
 ):
-    # type: (...) -> str
+    # type: (...) -> Pex
     pex = os.path.join(str(tmpdir), "pex")
     pex_root = os.path.join(str(tmpdir), "pex_root")
     run_pex_command(
-        args=["--pex-root", pex_root, "--runtime-pex-root", pex_root, "-o", pex]
-        + list(extra_args)
-        + ["--seed"]
+        args=["--pex-root", pex_root, "--runtime-pex-root", pex_root, "-o", pex] + list(extra_args)
     ).assert_success()
-    return pex
+
+    # N.B.: The sys.version can contain multiple lines for some distributions; so we split into
+    # multiple lines here.
+    expected_python_banner_lines = (
+        subprocess.check_output(
+            args=[
+                os.path.join(pex, "__main__.py") if os.path.isdir(pex) else pex,
+                "-c",
+                dedent(
+                    """\
+                from __future__ import print_function
+
+                import sys
+
+
+                print(sys.version, "on", sys.platform)
+                """
+                ),
+            ],
+            env=make_env(PEX_INTERPRETER=1),
+        )
+        .decode("utf-8")
+        .splitlines(keepends=False)
+    )
+    return Pex(path=pex, expected_python_banner_lines=tuple(expected_python_banner_lines))
 
 
 execution_mode_args = pytest.mark.parametrize(
@@ -95,25 +129,38 @@ execution_mode_args = pytest.mark.parametrize(
 @contextmanager
 def pexpect_spawn(
     tmpdir,  # type: Any
-    *args,  # type: Any
+    pex,  # type: Pex
     **kwargs  # type: Any
 ):
     # type: (...) -> Iterator[pexpect.spawn]
     with open(os.path.join(str(tmpdir), "pexpect.log"), "wb") as log:
         kwargs.update(dimensions=(24, 80), logfile=log)
-        with closing(pexpect.spawn(*args, **kwargs)) as process:
+        with closing(
+            pexpect.spawn(
+                os.path.join(pex.path, "__main__.py") if os.path.isdir(pex.path) else pex.path,
+                **kwargs
+            )
+        ) as process:
             yield process
 
 
 @execution_mode_args
+@pytest.mark.parametrize(
+    "scie_args",
+    [
+        pytest.param([], id="traditional"),
+        pytest.param(["--scie", "eager"], id="scie"),
+    ],
+)
 def test_empty_pex_no_args(
     tmpdir,  # type: Any
     pexpect_timeout,  # type: int
     execution_mode_args,  # type: List[str]
+    scie_args,  # type: List[str]
 ):
     # type: (...) -> None
 
-    pex = create_pex(tmpdir, extra_args=execution_mode_args)
+    pex = create_pex(tmpdir, extra_args=execution_mode_args + scie_args)
     with pexpect_spawn(tmpdir, pex) as process:
         expect_banner_header(
             process,
@@ -121,7 +168,7 @@ def test_empty_pex_no_args(
             expected_ephemeral=False,
             expected_suffix="no dependencies.",
         )
-        expect_banner_footer(process, timeout=pexpect_timeout)
+        expect_banner_footer(pex, process, timeout=pexpect_timeout)
 
 
 @execution_mode_args
@@ -137,7 +184,7 @@ def test_pex_cli_no_args(
     with pexpect_spawn(
         tmpdir,
         pex,
-        env=make_env(PATH=os.pathsep.join((os.path.dirname(pex), os.environ.get("PATH", "")))),
+        env=make_env(PATH=os.pathsep.join((os.path.dirname(pex.path), os.environ.get("PATH", "")))),
     ) as process:
         expect_banner_header(
             process,
@@ -148,11 +195,11 @@ def test_pex_cli_no_args(
         process.expect_exact(
             colors.yellow(
                 "Exit the repl (type quit()) and run `{pex} -h` for Pex CLI help.".format(
-                    pex=os.path.basename(pex)
+                    pex=os.path.basename(pex.path)
                 )
             ).encode("utf-8")
         )
-        expect_banner_footer(process, timeout=pexpect_timeout)
+        expect_banner_footer(pex, process, timeout=pexpect_timeout)
 
 
 @execution_mode_args
@@ -171,13 +218,13 @@ def test_pex_with_deps(
             expected_ephemeral=False,
             expected_suffix="1 requirement and 1 activated distribution.",
         )
-        expect_banner_footer(process, timeout=pexpect_timeout)
+        expect_banner_footer(pex, process, timeout=pexpect_timeout)
 
 
 @contextmanager
 def expect_pex_info_response(
     tmpdir,  # type: Any
-    pex,  # type: str
+    pex,  # type: Pex
     timeout,  # type: int
     json=False,  # type: bool
 ):
@@ -186,7 +233,7 @@ def expect_pex_info_response(
         expect_banner_header(
             process, timeout=timeout, expected_ephemeral=False, expected_suffix="no dependencies."
         )
-        expect_banner_footer(process, timeout=timeout)
+        expect_banner_footer(pex, process, timeout=timeout)
         process.sendline("pex(json={json!r})".format(json=json).encode("utf-8"))
         yield process
 
@@ -198,7 +245,7 @@ def test_pex_info_command_pex_file(
     # type: (...) -> None
     pex = create_pex(tmpdir)
     with expect_pex_info_response(tmpdir, pex, pexpect_timeout) as process:
-        process.expect_exact("Running from PEX file: {pex}".format(pex=pex).encode("utf-8"))
+        process.expect_exact("Running from PEX file: {pex}".format(pex=pex.path).encode("utf-8"))
 
 
 def test_pex_info_command_packed_pex_directory(
@@ -207,11 +254,9 @@ def test_pex_info_command_packed_pex_directory(
 ):
     # type: (...) -> None
     pex = create_pex(tmpdir, extra_args=["--layout", "packed"])
-    with expect_pex_info_response(
-        tmpdir, os.path.join(pex, "__main__.py"), pexpect_timeout
-    ) as process:
+    with expect_pex_info_response(tmpdir, pex, pexpect_timeout) as process:
         process.expect_exact(
-            "Running from packed PEX directory: {pex}".format(pex=pex).encode("utf-8")
+            "Running from packed PEX directory: {pex}".format(pex=pex.path).encode("utf-8")
         )
 
 
@@ -222,7 +267,9 @@ def test_pex_info_command_venv_pex_file(
     # type: (...) -> None
     pex = create_pex(tmpdir, extra_args=["--venv"])
     with expect_pex_info_response(tmpdir, pex, pexpect_timeout) as process:
-        process.expect_exact("Running from --venv PEX file: {pex}".format(pex=pex).encode("utf-8"))
+        process.expect_exact(
+            "Running from --venv PEX file: {pex}".format(pex=pex.path).encode("utf-8")
+        )
 
 
 def test_pex_info_command_loose_venv_pex_directory(
@@ -231,11 +278,9 @@ def test_pex_info_command_loose_venv_pex_directory(
 ):
     # type: (...) -> None
     pex = create_pex(tmpdir, extra_args=["--layout", "loose", "--venv"])
-    with expect_pex_info_response(
-        tmpdir, os.path.join(pex, "__main__.py"), pexpect_timeout
-    ) as process:
+    with expect_pex_info_response(tmpdir, pex, pexpect_timeout) as process:
         process.expect_exact(
-            "Running from loose --venv PEX directory: {pex}".format(pex=pex).encode("utf-8")
+            "Running from loose --venv PEX directory: {pex}".format(pex=pex.path).encode("utf-8")
         )
 
 
@@ -246,8 +291,8 @@ def test_pex_info_command_pex_venv(
     # type: (...) -> None
     pex = create_pex(tmpdir, extra_args=["--include-tools"])
     venv = os.path.join(str(tmpdir), "venv")
-    subprocess.check_call(args=[pex, "venv", venv], env=make_env(PEX_TOOLS=1))
-    with expect_pex_info_response(tmpdir, os.path.join(venv, "pex"), pexpect_timeout) as process:
+    subprocess.check_call(args=[pex.path, "venv", venv], env=make_env(PEX_TOOLS=1))
+    with expect_pex_info_response(tmpdir, pex.venv(venv), pexpect_timeout) as process:
         process.expect_exact("Running in a PEX venv: {venv}".format(venv=venv).encode("utf-8"))
 
 
@@ -258,5 +303,5 @@ def test_pex_info_command_json(
     # type: (...) -> None
     pex = create_pex(tmpdir)
     with expect_pex_info_response(tmpdir, pex, pexpect_timeout, json=True) as process:
-        for line in PexInfo.from_pex(pex).dump(indent=2).encode("utf-8").splitlines():
+        for line in PexInfo.from_pex(pex.path).dump(indent=2).encode("utf-8").splitlines():
             process.expect_exact(line, timeout=pexpect_timeout)


### PR DESCRIPTION
Previously the ansi terminal escape sequences were being displayed raw
instead of being interpreted as color codes by the terminal. This was
noticed when using a PEX scie since the Linux PBS CPython builds use a
an un-patched version of libedit that does not handle ansi terminal 
escape sequences unless finessed like we do now.