### PR TITLE
Introduce `pex3 cache {dir,info,purge}`.

### DIFF
--- a/pex/atomic_directory.py
+++ b/pex/atomic_directory.py
@@ -196,6 +196,7 @@ class _FileLock(object):
         lock_api(lock_fd, fcntl.LOCK_EX)  # A blocking write lock.
 
         def release():
+            # type: () -> None
             try:
                 lock_api(lock_fd, fcntl.LOCK_UN)
             finally:

--- a/pex/cache/__init__.py
+++ b/pex/cache/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).

--- a/pex/cache/access.py
+++ b/pex/cache/access.py
@@ -1,0 +1,101 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, print_function
+
+import fcntl
+import os
+from contextlib import contextmanager
+
+from pex.common import safe_mkdir
+from pex.typing import TYPE_CHECKING
+from pex.variables import ENV
+
+if TYPE_CHECKING:
+    from typing import Iterator, Optional, Tuple
+
+
+# N.B.: The lock file path is last in the lock state tuple to allow for a simple encoding scheme in
+# `save_lock_state` that is impervious to a delimiter collision in the lock file path when decoding
+# in `_maybe_restore_lock_state` (due to maxsplit).
+
+_LOCK = None  # type: Optional[Tuple[bool, int, str]]
+
+_PEX_CACHE_ACCESS_LOCK_ENV_VAR = "_PEX_CACHE_ACCESS_LOCK"
+
+
+def save_lock_state():
+    # type: () -> None
+    """Records any current lock state in a manner that can survive un-importing of this module."""
+
+    # N.B.: This supports the sole case of a Pex PEX, whose runtime obtains a lock that it must hand
+    # off to the Pex CLI it spawns.
+
+    global _LOCK
+    if _LOCK is not None:
+        exclusive, lock_fd, lock_file = _LOCK
+        os.environ[_PEX_CACHE_ACCESS_LOCK_ENV_VAR] = "|".join(
+            (str(int(exclusive)), str(lock_fd), lock_file)
+        )
+
+
+def _maybe_restore_lock_state():
+    # type: () -> None
+
+    saved_lock_state = os.environ.pop(_PEX_CACHE_ACCESS_LOCK_ENV_VAR, None)
+    if saved_lock_state:
+        encoded_exclusive, encoded_lock_fd, lock_file = saved_lock_state.split("|", 2)
+        global _LOCK
+        _LOCK = bool(int(encoded_exclusive)), int(encoded_lock_fd), lock_file
+
+
+def _lock(exclusive):
+    # type: (bool) -> str
+
+    lock_fd = None  # type: Optional[int]
+
+    global _LOCK
+    if _LOCK is None:
+        _maybe_restore_lock_state()
+    if _LOCK is not None:
+        existing_exclusive, lock_fd, existing_lock_file = _LOCK
+        if existing_exclusive == exclusive:
+            return existing_lock_file
+
+    lock_file = os.path.join(ENV.PEX_ROOT, "access.lck")
+
+    if lock_fd is None:
+        # N.B.: We don't actually write anything to the lock file but the fcntl file locking
+        # operations only work on files opened for at least write.
+        safe_mkdir(os.path.dirname(lock_file))
+        lock_fd = os.open(lock_file, os.O_CREAT | os.O_WRONLY)
+
+    # N.B.: Since flock operates on an open file descriptor and these are
+    # guaranteed to be closed by the operating system when the owning process exits,
+    # this lock is immune to staleness.
+    fcntl.flock(lock_fd, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+
+    _LOCK = exclusive, lock_fd, lock_file
+    return lock_file
+
+
+def read_write():
+    # type: () -> str
+    """Obtains the shared Pex cache read-write lock.
+
+    This function blocks until it is safe to use the Pex cache.
+    """
+    return _lock(exclusive=False)
+
+
+@contextmanager
+def await_delete_lock():
+    # type: () -> Iterator[str]
+    """Awaits the Pex cache delete lock, yielding the lock file path.
+
+    When the context manager exits, the delete lock is held, and it is safe to delete all or
+    portions of the Pex cache.
+    """
+    lock_file = _lock(exclusive=False)
+    yield lock_file
+    _lock(exclusive=True)

--- a/pex/cache/dirs.py
+++ b/pex/cache/dirs.py
@@ -1,0 +1,181 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os
+
+from pex.enum import Enum
+from pex.typing import TYPE_CHECKING
+from pex.variables import ENV, Variables
+
+if TYPE_CHECKING:
+    from typing import Iterable, Iterator, Union
+
+
+class CacheDir(Enum["CacheDir.Value"]):
+    class Value(Enum.Value):
+        def __init__(
+            self,
+            value,  # type: str
+            name,  # type: str
+            version,  # type: int
+            description,  # type: str
+            dependencies=(),  # type: Iterable[CacheDir.Value]
+        ):
+            Enum.Value.__init__(self, value)
+            self.name = name
+            self.version = version
+            self.description = description
+            self.dependencies = tuple(dependencies)
+
+        @property
+        def rel_path(self):
+            # type: () -> str
+            return os.path.join(self.value, str(self.version))
+
+        def path(
+            self,
+            *subdirs,  # type: str
+            **kwargs  # type: Union[str, Variables]
+        ):
+            # type: (...) -> str
+            pex_root = kwargs.get("pex_root", ENV)
+            return os.path.join(
+                pex_root.PEX_ROOT if isinstance(pex_root, Variables) else pex_root,
+                self.rel_path,
+                *subdirs
+            )
+
+        def iter_transitive_dependents(self):
+            # type: () -> Iterator[CacheDir.Value]
+            for cache_dir in CacheDir.values():
+                if self in cache_dir.dependencies:
+                    yield cache_dir
+                    for dependent in cache_dir.iter_transitive_dependents():
+                        yield dependent
+
+    BOOTSTRAP_ZIPS = Value(
+        "bootstrap_zips",
+        version=0,
+        name="Packed Bootstraps",
+        description="PEX runtime bootstrap code, zipped up for `--layout packed` PEXes.",
+    )
+
+    BOOTSTRAPS = Value(
+        "bootstraps",
+        version=0,
+        name="Bootstraps",
+        description="PEX runtime bootstrap code.",
+    )
+
+    BUILT_WHEELS = Value(
+        "built_wheels",
+        version=0,
+        name="Built Wheels",
+        description="Wheels built by Pex from resolved sdists when creating PEX files.",
+    )
+
+    DOCS = Value(
+        "docs",
+        version=0,
+        name="Pex Docs",
+        description="Artifacts used in serving Pex docs via `pex --docs` and `pex3 docs`.",
+    )
+
+    DOWNLOADS = Value(
+        "downloads",
+        version=0,
+        name="Lock Artifact Downloads",
+        description="Distributions downloaded when resolving from a Pex lock file.",
+    )
+
+    INSTALLED_WHEELS = Value(
+        "installed_wheels",
+        version=0,
+        name="Pre-installed Wheels",
+        description=(
+            "Pre-installed wheel chroots used to both build PEXes and serve as runtime `sys.path` "
+            "entries."
+        ),
+    )
+
+    INTERPRETERS = Value(
+        "interpreters",
+        version=0,
+        name="Interpreters",
+        description="Information about interpreters found on the system.",
+    )
+
+    ISOLATED = Value(
+        "isolated",
+        version=0,
+        name="Isolated Pex Code",
+        description="The Pex codebase isolated for internal use in subprocesses.",
+    )
+
+    PACKED_WHEELS = Value(
+        "packed_wheels",
+        version=0,
+        name="Packed Wheels",
+        description=(
+            "The same content as {installed_wheels!r}, but zipped up for `--layout packed` "
+            "PEXes.".format(installed_wheels=INSTALLED_WHEELS.rel_path)
+        ),
+    )
+
+    PIP = Value(
+        "pip",
+        version=0,
+        name="Pip Versions",
+        description="Isolated Pip caches and Pip PEXes Pex uses to resolve distributions.",
+    )
+
+    PLATFORMS = Value(
+        "platforms",
+        version=0,
+        name="Abbreviated Platforms",
+        description=(
+            "Information calculated about abbreviated platforms specified via `--platform`."
+        ),
+    )
+
+    SCIES = Value(
+        "scies",
+        version=0,
+        name="Scie Tools",
+        description="Tools and caches used when building PEX scies via `--scie {eager,lazy}`.",
+    )
+
+    TOOLS = Value(
+        "tools",
+        version=0,
+        name="Pex Tools",
+        description="Caches for the various `PEX_TOOLS=1` / `pex-tools` subcommands.",
+    )
+
+    USER_CODE = Value(
+        "user_code",
+        version=0,
+        name="User Code",
+        description=(
+            "User code added to PEX files using `-D` / `--sources-directory`, `-P` / `--package` "
+            "and `-M` / `--module`."
+        ),
+    )
+
+    UNZIPPED_PEXES = Value(
+        "unzipped_pexes",
+        version=0,
+        name="Unzipped PEXes",
+        description="The unzipped PEX files executed on this machine.",
+        dependencies=[BOOTSTRAPS, USER_CODE, INSTALLED_WHEELS],
+    )
+
+    VENVS = Value(
+        "venvs",
+        version=0,
+        name="Virtual Environments",
+        description="Virtual environments generated at runtime for `--venv` mode PEXes.",
+        dependencies=[INSTALLED_WHEELS],
+    )

--- a/pex/cache/root.py
+++ b/pex/cache/root.py
@@ -9,8 +9,6 @@ from pex.compatibility import commonpath
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Iterable
-
     import appdirs  # vendor:skip
 else:
     from pex.third_party import appdirs
@@ -20,13 +18,9 @@ _USER_DIR = os.path.expanduser("~")
 _CACHE_DIR = appdirs.user_cache_dir(appauthor="pex-tool.org", appname="pex")  # type: str
 
 
-def cache_path(
-    sub_path=(),  # type: Iterable[str]
-    expand_user=True,  # type: bool
-):
-    # type: (...) -> str
+def path(expand_user=True):
+    # type: (bool) -> str
 
-    path = os.path.join(_CACHE_DIR, *sub_path)
-    if expand_user or _USER_DIR != commonpath((_USER_DIR, path)):
-        return path
-    return os.path.join("~", os.path.relpath(path, _USER_DIR))
+    if expand_user or _USER_DIR != commonpath((_USER_DIR, _CACHE_DIR)):
+        return _CACHE_DIR
+    return os.path.join("~", os.path.relpath(_CACHE_DIR, _USER_DIR))

--- a/pex/cli/commands/__init__.py
+++ b/pex/cli/commands/__init__.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pex.cli.command import BuildTimeCommand
+from pex.cli.commands.cache.command import Cache
 from pex.cli.commands.docs import Docs
 from pex.cli.commands.interpreter import Interpreter
 from pex.cli.commands.lock import Lock
@@ -14,4 +15,4 @@ if TYPE_CHECKING:
 
 def all_commands():
     # type: () -> Iterable[Type[BuildTimeCommand]]
-    return Docs, Interpreter, Lock, Venv
+    return Cache, Docs, Interpreter, Lock, Venv

--- a/pex/cli/commands/cache/bytes.py
+++ b/pex/cli/commands/cache/bytes.py
@@ -5,13 +5,15 @@ from __future__ import absolute_import
 
 import math
 
-import attr
-
 from pex.enum import Enum
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Callable, Optional, Union
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
 
 
 class ByteUnits(Enum["ByteUnits.Value"]):

--- a/pex/cli/commands/cache/bytes.py
+++ b/pex/cli/commands/cache/bytes.py
@@ -1,0 +1,119 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import math
+
+import attr
+
+from pex.enum import Enum
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Callable, Optional, Union
+
+
+class ByteUnits(Enum["ByteUnits.Value"]):
+    class Value(Enum.Value):
+        def __init__(
+            self,
+            value,  # type: str
+            multiple,  # type: float
+            singular=None,  # type: Optional[str]
+        ):
+            # type: (...) -> None
+            Enum.Value.__init__(self, value)
+            self.multiple = multiple
+            self._singular = singular or value
+
+        def render(self, total_bytes):
+            # type: (Union[int, float]) -> str
+            return self._singular if round(total_bytes) == 1 else self.value
+
+    BYTES = Value("bytes", 1.0, singular="byte")
+    KB = Value("kB", 1000 * BYTES.multiple)
+    MB = Value("MB", 1000 * KB.multiple)
+    GB = Value("GB", 1000 * MB.multiple)
+    TB = Value("TB", 1000 * GB.multiple)
+    PB = Value("PB", 1000 * TB.multiple)
+
+
+@attr.s(frozen=True)
+class ByteAmount(object):
+    @classmethod
+    def bytes(cls, total_bytes):
+        # type: (int) -> ByteAmount
+        return cls(total_bytes=total_bytes, unit=ByteUnits.BYTES)
+
+    @classmethod
+    def kilobytes(cls, total_bytes):
+        # type: (int) -> ByteAmount
+        return cls(total_bytes=total_bytes, unit=ByteUnits.KB)
+
+    @classmethod
+    def megabytes(cls, total_bytes):
+        # type: (int) -> ByteAmount
+        return cls(total_bytes=total_bytes, unit=ByteUnits.MB)
+
+    @classmethod
+    def gigabytes(cls, total_bytes):
+        # type: (int) -> ByteAmount
+        return cls(total_bytes=total_bytes, unit=ByteUnits.GB)
+
+    @classmethod
+    def terabytes(cls, total_bytes):
+        # type: (int) -> ByteAmount
+        return cls(total_bytes=total_bytes, unit=ByteUnits.TB)
+
+    @classmethod
+    def petabytes(cls, total_bytes):
+        # type: (int) -> ByteAmount
+        return cls(total_bytes=total_bytes, unit=ByteUnits.PB)
+
+    @classmethod
+    def human_readable(cls, total_bytes):
+        # type: (int) -> ByteAmount
+
+        def select_unit():
+            for unit in ByteUnits.values():
+                if total_bytes < (1000 * unit.multiple):
+                    return unit
+            return ByteUnits.PB
+
+        return cls(total_bytes=total_bytes, unit=select_unit())
+
+    @classmethod
+    def for_unit(cls, unit):
+        # type: (ByteUnits.Value) -> Callable[[int], ByteAmount]
+        if ByteUnits.BYTES is unit:
+            return cls.bytes
+        elif ByteUnits.KB is unit:
+            return cls.kilobytes
+        elif ByteUnits.MB is unit:
+            return cls.megabytes
+        elif ByteUnits.GB is unit:
+            return cls.gigabytes
+        elif ByteUnits.TB is unit:
+            return cls.terabytes
+        elif ByteUnits.PB is unit:
+            return cls.petabytes
+        raise ValueError(
+            "The unit {unit} has no known corresponding byte amount function".format(unit=unit)
+        )
+
+    total_bytes = attr.ib()  # type: int
+    unit = attr.ib()  # type: ByteUnits.Value
+
+    def __str__(self):
+        # type: () -> str
+        amount = self.total_bytes / self.unit.multiple
+        integer_part = math.trunc(amount)
+        if self.unit is ByteUnits.BYTES or integer_part // 100 > 0:
+            return "{amount} {unit}".format(amount=round(amount), unit=self.unit.render(amount))
+        elif integer_part // 10 > 0:
+            return "{amount:.1f} {unit}".format(amount=amount, unit=self.unit.render(amount))
+        elif integer_part > 0:
+            return "{amount:.2f} {unit}".format(amount=amount, unit=self.unit.render(amount))
+        else:
+            return "{amount:.3f} {unit}".format(amount=amount, unit=self.unit.render(amount))

--- a/pex/cli/commands/cache/command.py
+++ b/pex/cli/commands/cache/command.py
@@ -1,0 +1,391 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, print_function
+
+import os
+from argparse import Action, ArgumentError, _ActionsContainer
+from datetime import datetime
+
+from pex.cache import access as cache_access
+from pex.cache.dirs import CacheDir
+from pex.cli.command import BuildTimeCommand
+from pex.cli.commands.cache.bytes import ByteAmount, ByteUnits
+from pex.cli.commands.cache.du import DiskUsage
+from pex.commands.command import OutputMixin
+from pex.common import pluralize, safe_rmtree
+from pex.exceptions import reportable_unexpected_error_msg
+from pex.jobs import iter_map_parallel, map_parallel
+from pex.orderedset import OrderedSet
+from pex.result import Error, Ok, Result
+from pex.typing import TYPE_CHECKING
+from pex.variables import ENV
+
+if TYPE_CHECKING:
+    from typing import IO, Dict, Iterable, List, Optional, Tuple, Union
+
+
+class HandleAmountAction(Action):
+    def __init__(self, *args, **kwargs):
+        kwargs["nargs"] = 0
+        super(HandleAmountAction, self).__init__(*args, **kwargs)
+
+    def __call__(self, parser, namespace, value, option_str=None):
+        if option_str in ("-H", "--human-readable"):
+            amount_func = ByteAmount.human_readable
+        elif option_str.startswith("--"):
+            amount_func = ByteAmount.for_unit(ByteUnits.for_value(option_str[2:]))
+        else:
+            raise ArgumentError(
+                argument=self,
+                message=reportable_unexpected_error_msg(
+                    "The HandleAmountAction was used in an unexpected place."
+                ),
+            )
+        setattr(namespace, self.dest, amount_func)
+
+
+class Cache(OutputMixin, BuildTimeCommand):
+    """Interact with the Pex cache."""
+
+    @staticmethod
+    def _add_amount_argument(parser):
+        # type: (_ActionsContainer) -> None
+
+        parser.add_argument(
+            "-H",
+            "--human-readable",
+            *["--{unit}".format(unit=unit.value) for unit in ByteUnits.values()],
+            dest="amount_func",
+            action=HandleAmountAction,
+            default=ByteAmount.bytes,
+            help=(
+                "How to display disk usage amounts; defaults to bytes. The -H / --human-readable "
+                "options display amounts in a human readable way and each of the other unit "
+                "options displays amounts with that specified unit."
+            )
+        )
+
+    @classmethod
+    def _add_info_arguments(cls, parser):
+        # type: (_ActionsContainer) -> None
+
+        cls._add_amount_argument(parser)
+        parser.add_argument(
+            "-S",
+            "--sort-size",
+            dest="sort_by_size",
+            action="store_true",
+            help=(
+                "Don't actually purge cache entries; instead, perform a dry run that just prints "
+                "out what actions would be taken"
+            ),
+        )
+        parser.add_argument(
+            "-r",
+            "--reverse",
+            dest="reverse",
+            action="store_true",
+            help=(
+                "Don't actually purge cache entries; instead, perform a dry run that just prints "
+                "out what actions would be taken"
+            ),
+        )
+        cls.add_output_option(parser, entity="Pex cache information")
+
+    @classmethod
+    def _add_purge_arguments(cls, parser):
+        # type: (_ActionsContainer) -> None
+
+        cls._add_amount_argument(parser)
+        parser.add_argument(
+            "--entries",
+            action="append",
+            type=CacheDir.for_value,
+            choices=CacheDir.values(),
+            default=[],
+            help=(
+                "Specific cache entries to purge. By default, all entries are purged, but by "
+                "specifying one or more particular --entries to purge, only those entries (and any "
+                "other cache entries dependent on those) will be purged."
+            ),
+        )
+        parser.add_argument(
+            "-n",
+            "--dry-run",
+            dest="dry_run",
+            action="store_true",
+            help=(
+                "Don't actually purge cache entries; instead, perform a dry run that just prints "
+                "out what actions would be taken"
+            ),
+        )
+        parser.add_argument(
+            "-R",
+            "--report-savings",
+            dest="report_savings",
+            action="store_true",
+            help="Report the disk usage savings from the purge.",
+        )
+
+        cls.add_output_option(parser, entity="Pex purge results")
+
+    @classmethod
+    def add_extra_arguments(cls, parser):
+        subcommands = cls.create_subcommands(
+            parser,
+            description="Interact with the Pex cache via the following subcommands.",
+        )
+
+        with subcommands.parser(
+            name="dir",
+            help="Print the current Pex cache directory path.",
+            func=cls._dir,
+            include_verbosity=False,
+        ) as dir_parser:
+            cls.add_output_option(dir_parser, entity="Pex cache directory")
+
+        with subcommands.parser(
+            name="info",
+            help="Present information about Pex cache status.",
+            func=cls._info,
+            include_verbosity=False,
+        ) as inspect_parser:
+            cls._add_info_arguments(inspect_parser)
+
+        with subcommands.parser(
+            name="purge",
+            help="Purge the Pex cache safely.",
+            func=cls._purge,
+            include_verbosity=False,
+        ) as purge_parser:
+            cls._add_purge_arguments(purge_parser)
+
+    def _dir(self):
+        # type: () -> Result
+
+        with self.output(self.options) as fp:
+            print(ENV.PEX_ROOT, file=fp)
+
+        return Ok()
+
+    @staticmethod
+    def _collect_info(cache_dir):
+        # type: (CacheDir.Value) -> Tuple[CacheDir.Value, DiskUsage]
+        return cache_dir, DiskUsage.collect(cache_dir.path())
+
+    def _render_usage(self, disk_usage):
+        # type: (Union[DiskUsage, Iterable[DiskUsage]]) -> str
+
+        if isinstance(disk_usage, DiskUsage):
+            du = disk_usage
+            prefix = ""
+        else:
+            du = DiskUsage.aggregate(path=ENV.PEX_ROOT, usages=disk_usage)
+            prefix = "Total: "
+
+        return "{prefix}{size} in {subdir_count} {subdirs} and {file_count} {files}.".format(
+            prefix=prefix,
+            size=self.options.amount_func(du.size),
+            subdir_count=du.subdirs,
+            subdirs=pluralize(du.subdirs, "subdirectory"),
+            file_count=du.files,
+            files=pluralize(du.files, "file"),
+        )
+
+    def _info(self):
+        # type: () -> Result
+
+        with self.output(self.options) as fp:
+            print("Path: {path}".format(path=ENV.PEX_ROOT), file=fp)
+            print(file=fp)
+
+            disk_usages = []  # type: List[DiskUsage]
+            for cache_dir, disk_usage in sorted(
+                map_parallel(
+                    inputs=CacheDir.values(), function=self._collect_info, noun="cache directory"
+                ),
+                key=lambda info: (
+                    (info[1].size, info[0].name) if self.options.sort_by_size else info[0].name
+                ),
+                reverse=self.options.reverse,
+            ):
+                disk_usages.append(disk_usage)
+                print(
+                    "{name}: {path}".format(name=cache_dir.name, path=cache_dir.rel_path), file=fp
+                )
+                print(cache_dir.description, file=fp)
+                print(self._render_usage(disk_usage), file=fp)
+                print(file=fp)
+            print(self._render_usage(disk_usages), file=fp)
+            print(file=fp)
+
+        return Ok()
+
+    def _purge_cache_dir(self, cache_dir):
+        # type: (CacheDir.Value) -> Tuple[CacheDir.Value, Optional[DiskUsage]]
+        cache_dir_path = cache_dir.path()
+        du = DiskUsage.collect(cache_dir_path) if self.options.report_savings else None
+        if not self.options.dry_run:
+            safe_rmtree(cache_dir_path)
+        return cache_dir, du
+
+    @staticmethod
+    def _log_delete_start(
+        lock_file,  # type: str
+        out,  # type: IO[str]
+    ):
+        # type: (...) -> None
+
+        try:
+            import psutil  # type: ignore[import]
+
+            # N.B.: the `version_info` tuple was introduced in psutil 0.2.0.
+            psutil_version = getattr(psutil, "version_info", None)
+            if not psutil_version or psutil_version < (5, 3, 0):
+                print(
+                    "The psutil{version} module is available, but it is too old. "
+                    "Need at least version 5.3.0.".format(
+                        version=(
+                            " {version}".format(version=".".join(map(str, psutil_version)))
+                            if psutil_version
+                            else ""
+                        )
+                    ),
+                    file=out,
+                )
+                psutil = None
+        except ImportError as e:
+            print("Failed to import psutil:", e, file=out)
+            psutil = None
+
+        if not psutil:
+            print("Will proceed with basic output.", file=out)
+            print("---", file=out)
+            print(
+                "Note: this process will block until all other running Pex processes have exited.",
+                file=out,
+            )
+            print(
+                "To get information on which processes these are, re-install Pex with the", file=out
+            )
+            print("management extra; e.g.: with requirement pex[management]", file=out)
+            print(file=out)
+            return
+
+        running = []  # type: List[psutil.Process]
+        pid = os.getpid()  # type: int
+        for process in psutil.process_iter(
+            ["pid", "open_files", "username", "create_time", "environ", "cmdline"]
+        ):
+            if pid == process.info["pid"]:
+                continue
+            if any(lock_file == of.path for of in process.info["open_files"] or ()):
+                running.append(process)
+
+        if running:
+            print(
+                "Waiting on {count} in flight {processes} (with shared lock on {lock_file}) to "
+                "complete before deleting:".format(
+                    count=len(running), processes=pluralize(running, "process"), lock_file=lock_file
+                ),
+                file=out,
+            )
+            print("---", file=out)
+            for index, process in enumerate(running, start=1):
+                print(
+                    "{index}. pid {pid} started by {username} at {create_time}".format(
+                        index=index,
+                        pid=process.info["pid"],
+                        username=process.info["username"],
+                        create_time=datetime.fromtimestamp(process.info["create_time"]).strftime(
+                            "%Y-%m-%d %H:%M:%S"
+                        ),
+                    ),
+                    file=out,
+                )
+
+                pex_env = process.info["environ"]  # type: Optional[Dict[str, str]]
+                if pex_env:
+                    pex_env = {k: v for k, v in pex_env.items() if k.startswith("PEX")}
+                if pex_env:
+                    print("   Pex env: {pex_env}".format(pex_env=pex_env), file=out)
+
+                cmdline = process.info["cmdline"]
+                if cmdline:
+                    print("   cmdline: {cmdline}".format(cmdline=cmdline), file=out)
+            print(file=out)
+
+    def _purge(self):
+        # type: () -> Result
+
+        with self.output(self.options) as fp:
+            cache_dirs = OrderedSet()  # type: OrderedSet[CacheDir.Value]
+            if self.options.entries:
+                cache_dirs.update(self.options.entries)
+                print(
+                    "{purging} requested entries from {pex_root}: {cache_dirs}".format(
+                        purging="Would purge" if self.options.dry_run else "Purging",
+                        pex_root=ENV.PEX_ROOT,
+                        cache_dirs=", ".join(cache_dir.rel_path for cache_dir in cache_dirs),
+                    ),
+                    file=fp,
+                )
+
+                dependents = OrderedSet()  # type: OrderedSet[CacheDir.Value]
+                for cache_dir in cache_dirs:
+                    dependents.update(cache_dir.iter_transitive_dependents())
+                if dependents:
+                    print(
+                        "{purging} those entries transitive dependents in: {dependents}".format(
+                            purging="Would also purge" if self.options.dry_run else "Also purging",
+                            dependents=", ".join(dep.rel_path for dep in dependents),
+                        ),
+                        file=fp,
+                    )
+                    cache_dirs.update(dependents)
+            else:
+                print(
+                    "{purging} all cache entries from {pex_root}:".format(
+                        purging="Would purge" if self.options.dry_run else "Purging",
+                        pex_root=ENV.PEX_ROOT,
+                    ),
+                    file=fp,
+                )
+                cache_dirs.update(CacheDir.values())
+            print(file=fp)
+
+            if not self.options.dry_run:
+                try:
+                    with cache_access.await_delete_lock() as lock_file:
+                        self._log_delete_start(lock_file, out=fp)
+                        print(
+                            "Attempting to acquire cache write lock (press CTRL-C to abort) ...",
+                            file=fp,
+                        )
+                except KeyboardInterrupt:
+                    return Error("No cache entries purged.")
+                finally:
+                    print(file=fp)
+
+            disk_usages = []  # type: List[DiskUsage]
+            for cache_dir, du in iter_map_parallel(
+                cache_dirs, self._purge_cache_dir, noun="entries", verb="purge", verb_past="purged"
+            ):
+                print(
+                    "{purged} cache {name} from {rel_path}".format(
+                        purged="Would have purged" if self.options.dry_run else "Purged",
+                        name=cache_dir.name,
+                        rel_path=cache_dir.rel_path,
+                    ),
+                    file=fp,
+                )
+                if du:
+                    disk_usages.append(du)
+                    print(self._render_usage(du), file=fp)
+                    print(file=fp)
+            if disk_usages:
+                print(self._render_usage(disk_usages), file=fp)
+                print(file=fp)
+
+        return Ok()

--- a/pex/cli/commands/cache/command.py
+++ b/pex/cli/commands/cache/command.py
@@ -120,13 +120,6 @@ class Cache(OutputMixin, BuildTimeCommand):
                 "out what actions would be taken"
             ),
         )
-        parser.add_argument(
-            "-R",
-            "--report-savings",
-            dest="report_savings",
-            action="store_true",
-            help="Report the disk usage savings from the purge.",
-        )
 
         cls.add_output_option(parser, entity="Pex purge results")
 
@@ -223,9 +216,9 @@ class Cache(OutputMixin, BuildTimeCommand):
         return Ok()
 
     def _purge_cache_dir(self, cache_dir):
-        # type: (CacheDir.Value) -> Tuple[CacheDir.Value, Optional[DiskUsage]]
+        # type: (CacheDir.Value) -> Tuple[CacheDir.Value, DiskUsage]
         cache_dir_path = cache_dir.path()
-        du = DiskUsage.collect(cache_dir_path) if self.options.report_savings else None
+        du = DiskUsage.collect(cache_dir_path)
         if not self.options.dry_run:
             safe_rmtree(cache_dir_path)
         return cache_dir, du
@@ -380,10 +373,9 @@ class Cache(OutputMixin, BuildTimeCommand):
                     ),
                     file=fp,
                 )
-                if du:
-                    disk_usages.append(du)
-                    print(self._render_usage(du), file=fp)
-                    print(file=fp)
+                disk_usages.append(du)
+                print(self._render_usage(du), file=fp)
+                print(file=fp)
             if disk_usages:
                 print(self._render_usage(disk_usages), file=fp)
                 print(file=fp)

--- a/pex/cli/commands/cache/command.py
+++ b/pex/cli/commands/cache/command.py
@@ -77,8 +77,8 @@ class Cache(OutputMixin, BuildTimeCommand):
             dest="sort_by_size",
             action="store_true",
             help=(
-                "Don't actually purge cache entries; instead, perform a dry run that just prints "
-                "out what actions would be taken"
+                "Sort cache entry information by the total size of the cache entry. "
+                "Entry information is sorted by entry name by default."
             ),
         )
         parser.add_argument(
@@ -86,10 +86,7 @@ class Cache(OutputMixin, BuildTimeCommand):
             "--reverse",
             dest="reverse",
             action="store_true",
-            help=(
-                "Don't actually purge cache entries; instead, perform a dry run that just prints "
-                "out what actions would be taken"
-            ),
+            help="Reverse the sorting of cache entry information.",
         )
         cls.add_output_option(parser, entity="Pex cache information")
 

--- a/pex/cli/commands/cache/du.py
+++ b/pex/cli/commands/cache/du.py
@@ -1,0 +1,68 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import itertools
+import os
+import stat
+
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Iterable, Set
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
+
+
+@attr.s(frozen=True)
+class DiskUsage(object):
+    @classmethod
+    def aggregate(
+        cls,
+        path,  # type: str
+        usages,  # type: Iterable[DiskUsage]
+    ):
+        # type: (...) -> DiskUsage
+        subdirs = 0
+        files = 0
+        size = 0
+        for disk_usage in usages:
+            subdirs += disk_usage.subdirs
+            files += disk_usage.files
+            size += disk_usage.size
+        return cls(path=path, subdirs=subdirs, files=files, size=size)
+
+    @classmethod
+    def collect(cls, path):
+        # type: (str) -> DiskUsage
+        """Collects data with the same default semantics as `du`.
+
+        Does not count directory inode sizes.
+        Only counts hard linked file sizes once.
+        Counts symlink size as the size of the target path string not including the null terminator.
+        """
+        subdir_count = 0
+        file_count = 0
+        size = 0
+        seen = set()  # type: Set[int]
+        for root, dirs, files in os.walk(path):
+            for f in itertools.chain(dirs, files):
+                stat_info = os.lstat(os.path.join(root, f))
+                if stat_info.st_ino in seen:
+                    continue
+                seen.add(stat_info.st_ino)
+                if stat.S_ISDIR(stat_info.st_mode):
+                    subdir_count += 1
+                else:
+                    file_count += 1
+                    size += stat_info.st_size
+
+        return cls(path=path, subdirs=subdir_count, files=file_count, size=size)
+
+    path = attr.ib()  # type: str
+    subdirs = attr.ib()  # type: int
+    files = attr.ib()  # type: int
+    size = attr.ib()  # type: int

--- a/pex/commands/command.py
+++ b/pex/commands/command.py
@@ -16,6 +16,7 @@ from subprocess import CalledProcessError
 
 from pex import pex_warnings
 from pex.argparse import HandleBoolAction
+from pex.cache import access as cache_access
 from pex.common import safe_mkdtemp, safe_open
 from pex.compatibility import shlex_quote
 from pex.result import Error, Ok, Result
@@ -379,6 +380,7 @@ def global_environment(options):
                 pex_root = options.cache_dir or options.pex_root or ENV.PEX_ROOT
 
             with ENV.patch(PEX_ROOT=pex_root, TMPDIR=tmpdir) as env:
+                cache_access.read_write()
                 yield env
 
 

--- a/pex/common.py
+++ b/pex/common.py
@@ -39,9 +39,11 @@ if TYPE_CHECKING:
         Sized,
         Text,
         Tuple,
+        TypeVar,
         Union,
     )
 
+    _Text = TypeVar("_Text", str, Text)
 
 # We use the start of MS-DOS time, which is what zipfiles use (see section 4.4.6 of
 # https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT).
@@ -91,7 +93,9 @@ def pluralize(
     count = subject if isinstance(subject, int) else len(subject)
     if count == 1:
         return noun
-    if noun[-1] in ("s", "x", "z") or noun[-2:] in ("sh", "ch"):
+    if noun[-1] == "y":
+        return noun[:-1] + "ies"
+    elif noun[-1] in ("s", "x", "z") or noun[-2:] in ("sh", "ch"):
         return noun + "es"
     else:
         return noun + "s"
@@ -289,7 +293,7 @@ def register_rmtree(directory):
 
 
 def safe_mkdir(directory, clean=False):
-    # type: (Text, bool) -> Text
+    # type: (_Text, bool) -> _Text
     """Safely create a directory.
 
     Ensures a directory is present.  If it's not there, it is created.  If it is, it's a no-op. If

--- a/pex/docs/server.py
+++ b/pex/docs/server.py
@@ -11,9 +11,9 @@ import subprocess
 import sys
 import time
 
+from pex.cache.dirs import CacheDir
 from pex.common import safe_open
 from pex.typing import TYPE_CHECKING
-from pex.variables import ENV
 from pex.version import __version__
 
 if TYPE_CHECKING:
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 SERVER_NAME = "Pex v{version} docs HTTP server".format(version=__version__)
 
-_SERVER_DIR = os.path.join(ENV.PEX_ROOT, "docs", "server", __version__)
+_SERVER_DIR = CacheDir.DOCS.path("server", __version__)
 
 
 @attr.s(frozen=True)

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -18,6 +18,7 @@ from contextlib import contextmanager
 from textwrap import dedent
 
 from pex import third_party
+from pex.cache.dirs import CacheDir
 from pex.common import is_exe, safe_mkdtemp, safe_rmtree
 from pex.executor import Executor
 from pex.jobs import Job, Retain, SpawnedJob, execute_parallel
@@ -32,7 +33,6 @@ from pex.third_party.packaging import tags
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING, cast, overload
 from pex.util import CacheHelper
-from pex.variables import ENV
 
 if TYPE_CHECKING:
     from typing import (
@@ -1027,7 +1027,7 @@ class PythonInterpreter(object):
             os_digest.update(os_identifier.encode("utf-8"))
         os_hash = os_digest.hexdigest()
 
-        interpreter_cache_dir = os.path.join(ENV.PEX_ROOT, "interpreters")
+        interpreter_cache_dir = CacheDir.INTERPRETERS.path()
         os_cache_dir = os.path.join(interpreter_cache_dir, os_hash)
         if os.path.isdir(interpreter_cache_dir) and not os.path.isdir(os_cache_dir):
             with TRACER.timed("GCing interpreter cache from prior OS version"):

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -9,6 +9,7 @@ import sys
 
 from pex import pex_warnings
 from pex.atomic_directory import atomic_directory
+from pex.cache import access as cache_access
 from pex.cache.dirs import CacheDir
 from pex.common import CopyMode, die, pluralize
 from pex.environment import ResolveError
@@ -518,6 +519,8 @@ def ensure_venv(
             "The PEX_VENV environment variable was set, but this PEX was not built with venv "
             "support (Re-build the PEX file with `pex --venv ...`)"
         )
+
+    cache_access.read_write()
     with atomic_directory(venv_dir) as venv:
         if not venv.is_finalized():
             from pex.venv.virtualenv import Virtualenv
@@ -627,6 +630,7 @@ def bootstrap_pex(
     # ENV.PEX_ROOT is consulted by PythonInterpreter and Platform so set that up as early as
     # possible in the run.
     with ENV.patch(PEX_ROOT=pex_info.pex_root):
+        cache_access.read_write()
         if not execute:
             for location in _activate_pex(entry_point, pex_info, venv_dir=venv_dir):
                 from pex.third_party import VendorImporter

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -520,7 +520,9 @@ def ensure_venv(
             "support (Re-build the PEX file with `pex --venv ...`)"
         )
 
-    cache_access.read_write()
+    if not os.path.exists(venv_dir):
+        with ENV.patch(PEX_ROOT=pex_info.pex_root):
+            cache_access.read_write()
     with atomic_directory(venv_dir) as venv:
         if not venv.is_finalized():
             from pex.venv.virtualenv import Virtualenv

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -9,6 +9,7 @@ import sys
 
 from pex import pex_warnings
 from pex.atomic_directory import atomic_directory
+from pex.cache.dirs import CacheDir
 from pex.common import CopyMode, die, pluralize
 from pex.environment import ResolveError
 from pex.inherit_path import InheritPath
@@ -539,7 +540,7 @@ def ensure_venv(
             collisions = []
             for chars in range(8, len(venv_hash) + 1):
                 entropy = venv_hash[:chars]
-                short_venv_dir = os.path.join(pex_info.pex_root, "venvs", "s", entropy)
+                short_venv_dir = CacheDir.VENVS.path("s", entropy, pex_root=pex_info.pex_root)
                 with atomic_directory(short_venv_dir) as short_venv:
                     if short_venv.is_finalized():
                         collisions.append(short_venv_dir)

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -13,6 +13,7 @@ from zipimport import ZipImportError
 
 from pex import pex_warnings
 from pex.atomic_directory import atomic_directory
+from pex.cache.dirs import CacheDir
 from pex.common import (
     Chroot,
     CopyMode,
@@ -720,13 +721,12 @@ class PEXBuilder(object):
             return os.path.join(path, "un-compressed")
 
         # Zip up the bootstrap which is constant for a given version of Pex.
-        bootstrap_hash = pex_info.bootstrap_hash
-        if bootstrap_hash is None:
+        if pex_info.bootstrap_hash is None:
             raise AssertionError(
                 "Expected bootstrap_hash to be populated for {}.".format(self._pex_info)
             )
         cached_bootstrap_zip_dir = zip_cache_dir(
-            os.path.join(pex_info.pex_root, "bootstrap_zips", bootstrap_hash)
+            CacheDir.BOOTSTRAP_ZIPS.path(pex_info.bootstrap_hash, pex_root=pex_info.pex_root)
         )
         with TRACER.timed("Zipping PEX .bootstrap/ code."):
             with atomic_directory(cached_bootstrap_zip_dir) as atomic_bootstrap_zip_dir:
@@ -762,7 +762,7 @@ class PEXBuilder(object):
                             safe_copy(os.path.join(self._chroot.chroot, path), dest)
                     else:
                         cached_installed_wheel_zip_dir = zip_cache_dir(
-                            os.path.join(pex_info.pex_root, "packed_wheels", fingerprint)
+                            CacheDir.PACKED_WHEELS.path(fingerprint, pex_root=pex_info.pex_root)
                         )
                         with atomic_directory(cached_installed_wheel_zip_dir) as atomic_zip_dir:
                             if not atomic_zip_dir.is_finalized():

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -558,7 +558,7 @@ class PEXBuilder(object):
         )
 
         bootstrap_digest = hashlib.sha1()
-        bootstrap_packages = ["repl", "third_party", "venv"]
+        bootstrap_packages = ["cache", "repl", "third_party", "venv"]
         if self._pex_info.includes_tools:
             bootstrap_packages.extend(["commands", "tools"])
         for root, dirs, files in deterministic_walk(_ABS_PEX_PACKAGE_DIR):

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -7,7 +7,8 @@ import json
 import os
 import zipfile
 
-from pex import cache, layout, pex_warnings, variables
+from pex import layout, pex_warnings, variables
+from pex.cache import root as cache_root
 from pex.common import can_write_dir, open_zip, safe_mkdtemp
 from pex.compatibility import PY2, WINDOWS
 from pex.compatibility import string as compatibility_string
@@ -503,7 +504,7 @@ class PexInfo(object):
     @property
     def raw_pex_root(self):
         # type: () -> str
-        return cast(str, self._pex_info.get("pex_root", cache.cache_path(expand_user=False)))
+        return cast(str, self._pex_info.get("pex_root", cache_root.path(expand_user=False)))
 
     @property
     def pex_root(self):

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -60,8 +60,6 @@ class PexInfo(object):
     """
 
     PATH = layout.PEX_INFO_PATH
-    BOOTSTRAP_CACHE = "bootstraps"
-    INSTALL_CACHE = "installed_wheels"
 
     @classmethod
     def make_build_properties(cls):
@@ -570,25 +568,9 @@ class PexInfo(object):
         return layout.BOOTSTRAP_DIR
 
     @property
-    def bootstrap_cache(self):
-        # type: () -> Optional[str]
-        if self.bootstrap_hash is None:
-            return None
-        return os.path.join(self.pex_root, self.BOOTSTRAP_CACHE, self.bootstrap_hash)
-
-    @property
     def internal_cache(self):
         # type: () -> str
         return layout.DEPS_DIR
-
-    @property
-    def install_cache(self):
-        return os.path.join(self.pex_root, self.INSTALL_CACHE)
-
-    @property
-    def zip_unsafe_cache(self):
-        #: type: () -> str
-        return os.path.join(self.pex_root, "user_code")
 
     def update(self, other):
         # type: (PexInfo) -> None

--- a/pex/pip/installation.py
+++ b/pex/pip/installation.py
@@ -10,6 +10,7 @@ from textwrap import dedent
 
 from pex import pex_warnings, third_party
 from pex.atomic_directory import atomic_directory
+from pex.cache.dirs import CacheDir
 from pex.common import pluralize, safe_mkdtemp
 from pex.dist_metadata import Requirement
 from pex.interpreter import PythonInterpreter
@@ -26,7 +27,6 @@ from pex.third_party import isolated
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 from pex.util import named_temporary_file
-from pex.variables import ENV
 from pex.venv.virtualenv import InstallationChoice, Virtualenv
 
 if TYPE_CHECKING:
@@ -44,7 +44,7 @@ def _pip_installation(
     interpreter=None,  # type: Optional[PythonInterpreter]
 ):
     # type: (...) -> Pip
-    pip_root = os.path.join(ENV.PEX_ROOT, "pip", str(version))
+    pip_root = CacheDir.PIP.path(str(version))
     path = os.path.join(pip_root, "pip.pex")
     pip_interpreter = interpreter or PythonInterpreter.get()
     pip_pex_path = os.path.join(path, isolated().pex_hash, fingerprint)

--- a/pex/platforms.py
+++ b/pex/platforms.py
@@ -10,12 +10,12 @@ from textwrap import dedent
 
 from pex import compatibility
 from pex.atomic_directory import atomic_directory
+from pex.cache.dirs import CacheDir
 from pex.common import safe_open, safe_rmtree
 from pex.pep_425 import CompatibilityTags
 from pex.third_party.packaging import tags
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING, cast
-from pex.variables import ENV
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
@@ -269,7 +269,7 @@ class Platform(object):
         components = [str(self)]
         if manylinux:
             components.append(manylinux)
-        disk_cache_key = os.path.join(ENV.PEX_ROOT, "platforms", self.SEP.join(components))
+        disk_cache_key = CacheDir.PLATFORMS.path(self.SEP.join(components))
         with atomic_directory(target_dir=disk_cache_key) as cache_dir:
             if not cache_dir.is_finalized():
                 # Missed both caches - spawn calculation.

--- a/pex/repl/custom.py
+++ b/pex/repl/custom.py
@@ -55,6 +55,9 @@ def _try_enable_readline(
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
                 readline.read_init_file()
+        except AttributeError:
+            # A PyPy version that has dropped read_init_file support altogether.
+            pass
         except (IOError, OSError):
             # No init file (~/.inputrc for readline or ~/.editrc for libedit).
             pass

--- a/pex/resolve/downloads.py
+++ b/pex/resolve/downloads.py
@@ -8,6 +8,7 @@ import shutil
 
 from pex import hashing
 from pex.atomic_directory import atomic_directory
+from pex.cache.dirs import CacheDir
 from pex.common import safe_mkdir, safe_mkdtemp
 from pex.hashing import Sha256
 from pex.jobs import Job, Raise, SpawnedJob, execute_parallel
@@ -42,7 +43,7 @@ def get_downloads_dir(pex_root=None):
     root_dir = pex_root or ENV.PEX_ROOT
     downloads_dir = _DOWNLOADS_DIRS.get(root_dir)
     if downloads_dir is None:
-        downloads_dir = os.path.join(root_dir, "downloads")
+        downloads_dir = CacheDir.DOWNLOADS.path(pex_root=root_dir)
         safe_mkdir(downloads_dir)
         _DOWNLOADS_DIRS[root_dir] = downloads_dir
     return downloads_dir

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -16,6 +16,7 @@ from collections import OrderedDict, defaultdict
 from pex import targets
 from pex.atomic_directory import AtomicDirectory, atomic_directory
 from pex.auth import PasswordEntry
+from pex.cache.dirs import CacheDir
 from pex.common import pluralize, safe_mkdir, safe_mkdtemp
 from pex.compatibility import url_unquote, urlparse
 from pex.dependency_configuration import DependencyConfiguration
@@ -28,7 +29,6 @@ from pex.pep_376 import InstalledWheel
 from pex.pep_425 import CompatibilityTags
 from pex.pep_427 import InstallableType, WheelError, install_wheel_chroot
 from pex.pep_503 import ProjectName
-from pex.pex_info import PexInfo
 from pex.pip.download_observer import DownloadObserver
 from pex.pip.installation import get_pip
 from pex.pip.tool import PackageIndexConfiguration
@@ -48,7 +48,6 @@ from pex.targets import LocalInterpreter, Target, Targets
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 from pex.util import CacheHelper
-from pex.variables import ENV
 
 if TYPE_CHECKING:
     from typing import (
@@ -583,7 +582,7 @@ class WheelBuilder(object):
             # Nothing to build or install.
             return {}
 
-        built_wheels_dir = os.path.join(ENV.PEX_ROOT, "built_wheels")
+        built_wheels_dir = CacheDir.BUILT_WHEELS.path()
         spawn_wheel_build = functools.partial(self._spawn_wheel_build, built_wheels_dir)
 
         with TRACER.timed(
@@ -889,7 +888,7 @@ class BuildAndInstallRequest(object):
             # Nothing to build or install.
             return ()
 
-        installed_wheels_dir = os.path.join(ENV.PEX_ROOT, PexInfo.INSTALL_CACHE)
+        installed_wheels_dir = CacheDir.INSTALLED_WHEELS.path()
         perform_install = functools.partial(_perform_install, installed_wheels_dir)
 
         installations = []  # type: List[ResolvedDistribution]

--- a/pex/third_party/__init__.py
+++ b/pex/third_party/__init__.py
@@ -407,6 +407,7 @@ def _isolate_pex_from_dir(
     isolate_to_dir,  # type: str
     exclude_files,  # type: Container[str]
 ):
+    # type: (...) -> None
     from pex.common import is_pyc_dir, is_pyc_file, is_pyc_temporary_file, safe_copy
 
     for root, dirs, files in os.walk(pex_directory):
@@ -432,6 +433,7 @@ def _isolate_pex_from_zip(
     isolate_to_dir,  # type: str
     exclude_files,  # type: Container[str]
 ):
+    # type: (...) -> None
     from pex.common import open_zip, safe_open
 
     with open_zip(pex_zip) as zf:
@@ -462,8 +464,8 @@ def isolated(interpreter=None):
     if _ISOLATED is None:
         from pex import layout, vendor
         from pex.atomic_directory import atomic_directory
+        from pex.cache.dirs import CacheDir
         from pex.util import CacheHelper
-        from pex.variables import ENV
 
         module = "pex"
 
@@ -503,7 +505,7 @@ def isolated(interpreter=None):
                 pex_zip_paths = (zip_path, pex_package_relpath)
                 pex_hash = CacheHelper.zip_hash(zip_path, relpath=pex_package_relpath)
 
-        isolated_dir = os.path.join(ENV.PEX_ROOT, "isolated", pex_hash)
+        isolated_dir = CacheDir.ISOLATED.path(pex_hash)
         with _tracer().timed("Isolating pex"):
             with atomic_directory(isolated_dir) as chroot:
                 if not chroot.is_finalized():

--- a/pex/tools/commands/repository.py
+++ b/pex/tools/commands/repository.py
@@ -16,6 +16,7 @@ from threading import Thread
 
 from pex import dist_metadata
 from pex.atomic_directory import atomic_directory
+from pex.cache.dirs import CacheDir
 from pex.commands.command import JsonMixin, OutputMixin
 from pex.common import (
     DETERMINISTIC_DATETIME_TIMESTAMP,
@@ -33,7 +34,6 @@ from pex.pex import PEX
 from pex.result import Error, Ok, Result
 from pex.tools.command import PEXCommand
 from pex.typing import TYPE_CHECKING, cast
-from pex.variables import ENV
 from pex.venv.virtualenv import InstallationChoice, Virtualenv
 
 if TYPE_CHECKING:
@@ -55,7 +55,7 @@ def spawn_python_job_with_setuptools_and_wheel(
     **subprocess_kwargs  # type: Any
 ):
     # type: (...) -> Job
-    venv_dir = os.path.join(ENV.PEX_ROOT, "tools", "repository", str(interpreter.platform))
+    venv_dir = CacheDir.TOOLS.path("repository", str(interpreter.platform))
     with atomic_directory(venv_dir) as atomic_dir:
         if not atomic_dir.is_finalized():
             Virtualenv.create_atomic(

--- a/pex/tools/main.py
+++ b/pex/tools/main.py
@@ -73,7 +73,6 @@ def main(pex=None):
                     interpreter_test=InterpreterTest(entry_point=pex_file_path, pex_info=pex_info)
                 )
                 pex = PEX(pex_file_path, interpreter=interpreter)
-
             result = catch(pex_command.run, pex)
             result.maybe_display()
             return result.exit_code

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -165,9 +165,9 @@ def _default_pex_root():
     # N.B.: We need lazy import gymnastics here since cache uses appdirs which is pex.third_party
     # and the pex.third_party mechanism uses ENV.PEX_VERBOSE indirectly via TRACER to log certain
     # third party import lifecycle events.
-    from pex import cache
+    from pex.cache import root as cache_root
 
-    return cache.cache_path(expand_user=False)
+    return cache_root.path(expand_user=False)
 
 
 class Variables(object):

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -800,19 +800,18 @@ def _expand_pex_root(pex_root):
     return os.path.expanduser(Variables.PEX_ROOT.value_or(ENV, fallback=fallback))
 
 
-def unzip_dir_relpath(pex_hash):
-    # type: (str) -> str
-    return os.path.join("unzipped_pexes", pex_hash)
-
-
 def unzip_dir(
     pex_root,  # type: str
     pex_hash,  # type: str
     expand_pex_root=True,  # type: bool
 ):
     # type: (...) -> str
+
+    # N.B.: We need lazy import gymnastics here since CacheType uses Variables for PEX_ROOT.
+    from pex.cache.dirs import CacheDir
+
     pex_root = _expand_pex_root(pex_root) if expand_pex_root else pex_root
-    return os.path.join(pex_root, unzip_dir_relpath(pex_hash))
+    return CacheDir.UNZIPPED_PEXES.path(pex_hash, pex_root=pex_root)
 
 
 def venv_dir(
@@ -825,6 +824,9 @@ def venv_dir(
     expand_pex_root=True,  # type: bool
 ):
     # type: (...) -> str
+
+    # N.B.: We need lazy import gymnastics here since CacheType uses Variables for PEX_ROOT.
+    from pex.cache.dirs import CacheDir
 
     # The venv contents are affected by which PEX files are in play as well as which interpreter
     # is selected. The former is influenced via PEX_PATH and the latter is influenced by interpreter
@@ -887,7 +889,7 @@ def venv_dir(
         json.dumps(venv_contents, sort_keys=True).encode("utf-8")
     ).hexdigest()
     pex_root = _expand_pex_root(pex_root) if expand_pex_root else pex_root
-    venv_path = os.path.join(pex_root, "venvs", pex_hash, venv_contents_hash)
+    venv_path = CacheDir.VENVS.path(pex_hash, venv_contents_hash, pex_root=pex_root)
 
     def warn(message):
         # type: (str) -> None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,11 @@ classifiers = [
 subprocess = [
   "subprocess32>=3.2.7; python_version < '3'"
 ]
+management = [
+  # N.B.: Released on 2017-09-01 and added support for the `process_iter(attrs, ad_value)` API we
+  # use in `pex.cache.access`.
+  "psutil>=5.3"
+]
 
 [project.scripts]
 pex = "pex.bin.pex:main"

--- a/tests/integration/cli/commands/test_lock.py
+++ b/tests/integration/cli/commands/test_lock.py
@@ -11,6 +11,7 @@ from textwrap import dedent
 
 import pytest
 
+from pex.cache.dirs import CacheDir
 from pex.common import safe_open
 from pex.dist_metadata import Constraint, Requirement
 from pex.interpreter import PythonInterpreter
@@ -123,8 +124,8 @@ def test_create_style(
         locked_resolve = lock.locked_resolves[0]
         assert 1 == len(locked_resolve.locked_requirements)
         locked_requirement = locked_resolve.locked_requirements[0]
-        download_dir = os.path.join(
-            pex_root, "downloads", locked_requirement.artifact.fingerprint.hash
+        download_dir = CacheDir.DOWNLOADS.path(
+            locked_requirement.artifact.fingerprint.hash, pex_root=pex_root
         )
         downloaded_artifact = DownloadedArtifact.load(download_dir)
         assert os.path.exists(downloaded_artifact.path), (

--- a/tests/integration/cli/commands/test_vcs_lock.py
+++ b/tests/integration/cli/commands/test_vcs_lock.py
@@ -12,6 +12,7 @@ from textwrap import dedent
 import colors  # vendor:skip
 import pytest
 
+from pex.cache.dirs import CacheDir
 from pex.common import safe_open
 from pex.resolve.locked_resolve import VCSArtifact
 from pex.resolve.lockfile import json_codec
@@ -168,7 +169,7 @@ def test_subdir(test_tool):
             args=[pex, "-c", "import sdev_logging_utils; print(sdev_logging_utils.__file__)"]
         )
         .decode("utf-8")
-        .startswith(os.path.join(test_tool.pex_root, "installed_wheels"))
+        .startswith(CacheDir.INSTALLED_WHEELS.path(pex_root=test_tool.pex_root))
     )
 
 

--- a/tests/integration/scie/test_pex_scie.py
+++ b/tests/integration/scie/test_pex_scie.py
@@ -15,6 +15,7 @@ from typing import Optional
 
 import pytest
 
+from pex.cache.dirs import CacheDir
 from pex.common import chmod_plus_x, is_exe, safe_open
 from pex.fetcher import URLFetcher
 from pex.layout import Layout
@@ -289,7 +290,12 @@ def test_specified_science_binary(tmpdir):
     )
 
     cached_science_binaries = glob.glob(
-        os.path.join(pex_root, "scies", "science", "*", "bin", "science")
+        os.path.join(
+            CacheDir.SCIES.path("science", pex_root=pex_root),
+            "*",
+            "bin",
+            "science",
+        )
     )
     assert 0 == len(
         cached_science_binaries

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -17,6 +17,7 @@ from textwrap import dedent
 import pexpect  # type: ignore[import]  # MyPy can't see the types under Python 2.7.
 import pytest
 
+from pex.cache.dirs import CacheDir
 from pex.common import is_exe, safe_mkdir, safe_open, safe_rmtree, temporary_dir, touch
 from pex.compatibility import WINDOWS, commonpath
 from pex.dist_metadata import Distribution, Requirement
@@ -55,7 +56,7 @@ from testing.mitmproxy import Proxy
 from testing.pep_427 import get_installable_type_flag
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Iterator, List, Optional, Text, Tuple
+    from typing import Any, Callable, Iterator, List, Optional, Tuple
 
 
 def test_pex_execute():
@@ -72,21 +73,22 @@ def test_pex_raise():
 
 
 def assert_interpreters(label, pex_root):
-    # type: (Text, Text) -> None
-    assert "interpreters" in os.listdir(
-        pex_root
+    # type: (str, str) -> None
+    assert os.listdir(
+        CacheDir.INTERPRETERS.path(pex_root=pex_root)
     ), "Expected {label} pex root to be populated with interpreters.".format(label=label)
 
 
 def assert_installed_wheels(label, pex_root):
-    # type: (Text, Text) -> None
-    assert "installed_wheels" in os.listdir(
-        pex_root
-    ), "Expected {label} pex root to be populated with buildtime artifacts.".format(label=label)
+    # type: (str, str) -> None
+
+    assert os.listdir(
+        CacheDir.INSTALLED_WHEELS.path(pex_root=pex_root)
+    ), "Expected {label} pex root to be populated with build time artifacts.".format(label=label)
 
 
 def assert_empty_home_dir(home_dir):
-    # type: (Text) -> None
+    # type: (str) -> None
     pip_cache_dir = "Library" if IS_MAC else ".cache"
     rust_cache_dir = ".rustup"
     home_dir_contents = [

--- a/tests/integration/test_issue_1232.py
+++ b/tests/integration/test_issue_1232.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 
+from pex.cache.dirs import CacheDir
 from pex.typing import TYPE_CHECKING
 from testing import PY38, PY310, ensure_python_interpreter, make_env, run_pex_command
 
@@ -47,7 +48,7 @@ def test_isolated_pex_zip(tmpdir):
                 if ext == ".py":
                     yield module
 
-        isolated_root = os.path.join(pex_root, "isolated")
+        isolated_root = CacheDir.ISOLATED.path(pex_root=pex_root)
         vendored_by_isolated = {}
         for entry in os.listdir(isolated_root):
             path = os.path.join(isolated_root, entry)
@@ -130,7 +131,7 @@ def test_isolated_pex_zip(tmpdir):
     # 4. Isolate modified Pex PEX at run-time.
     # ===
     # Force the bootstrap to run interpreter identification which will force a Pex isolation.
-    shutil.rmtree(os.path.join(pex_root, "interpreters"))
+    shutil.rmtree(CacheDir.INTERPRETERS.path(pex_root=pex_root))
     subprocess.check_call(args=[python310, ansicolors_pex, "-c", "import colors"], env=pex_env)
     ansicolors_pex_isolated_vendoreds = tally_isolated_vendoreds()
     ansicolors_pex_isolation = set(modified_pex_isolated_vendoreds.keys()) ^ set(
@@ -159,7 +160,7 @@ def test_isolated_pex_zip(tmpdir):
     )
 
     # Force the bootstrap to run interpreter identification which will force a Pex isolation.
-    shutil.rmtree(os.path.join(pex_root, "interpreters"))
+    shutil.rmtree(CacheDir.INTERPRETERS.path(pex_root=pex_root))
     subprocess.check_call(args=[python310, ansicolors_pex, "-c", "import colors"], env=pex_env)
     assert (
         ansicolors_pex_isolated_vendoreds == tally_isolated_vendoreds()

--- a/tests/integration/test_issue_1520.py
+++ b/tests/integration/test_issue_1520.py
@@ -8,6 +8,7 @@ from textwrap import dedent
 
 import pytest
 
+from pex.cache.dirs import CacheDir
 from pex.typing import TYPE_CHECKING
 from testing import IS_LINUX, IS_MAC, PY_VER, run_pex_command
 
@@ -63,7 +64,7 @@ def test_hermetic_console_scripts(tmpdir):
 
     scripts = [
         os.path.join(root, f)
-        for root, dirs, files in os.walk(os.path.join(pex_root, "installed_wheels"))
+        for root, dirs, files in os.walk(CacheDir.INSTALLED_WHEELS.path(pex_root=pex_root))
         for f in files
         if "protoc-gen-mypy" == f
     ]

--- a/tests/integration/test_issue_1598.py
+++ b/tests/integration/test_issue_1598.py
@@ -3,7 +3,7 @@
 
 import os
 
-from pex import cache
+from pex.cache import root as cache_root
 from pex.typing import TYPE_CHECKING
 from testing import make_env, run_pex_command
 
@@ -19,7 +19,7 @@ def test_mount_respects_env(
 
     home = os.path.join(str(tmpdir), "home")
 
-    rel_pex_root = os.path.relpath(cache.cache_path(expand_user=False), "~")
+    rel_pex_root = os.path.relpath(cache_root.path(expand_user=False), "~")
     pex_root = os.path.join(home, rel_pex_root)
     os.makedirs(pex_root)
     os.chmod(pex_root, 0o555)

--- a/tests/integration/test_issue_1861.py
+++ b/tests/integration/test_issue_1861.py
@@ -3,6 +3,7 @@
 
 import os
 
+from pex.cache.dirs import CacheDir
 from pex.typing import TYPE_CHECKING
 from testing import make_env, run_pex_command
 
@@ -30,4 +31,4 @@ def test_confounding_site_packages_directory(tmpdir):
         env=make_env(LOCALAPPDATA=local_app_data),
     )
     result.assert_success()
-    assert result.output.startswith(os.path.join(pex_root, "installed_wheels"))
+    assert result.output.startswith(CacheDir.INSTALLED_WHEELS.path(pex_root=pex_root))

--- a/tests/integration/test_issue_1933.py
+++ b/tests/integration/test_issue_1933.py
@@ -52,7 +52,7 @@ def test_musllinux_wheels_resolved(
     assert (
         # N.B.: Since docker gives us a fixed user / home dir and pinned platform, and we use a
         # pinned wheel-only requirement, we can be assured this path is stable.
-        b"/root/.cache/pex/installed_wheels/"
+        b"/root/.cache/pex/installed_wheels/0/"
         b"c3ae8e75eb7160851e59adc77b3a19a976e50622e44fd4fd47b8b18208189d42/"
         b"psycopg2_binary-2.9.3-cp310-cp310-musllinux_1_1_x86_64.whl/psycopg2/__init__.py"
     ) == stdout.strip()

--- a/tests/integration/test_issue_2088.py
+++ b/tests/integration/test_issue_2088.py
@@ -6,6 +6,7 @@ import sys
 
 import pytest
 
+from pex.cache.dirs import CacheDir
 from pex.common import safe_rmtree
 from pex.compatibility import commonpath
 from pex.layout import Layout
@@ -78,7 +79,9 @@ def test_venv_symlink_site_packages(
     assert os.path.islink(ansicolors_venv_package_dir_realpath) == symlinks_expected
 
     if symlinks_expected:
-        installed_wheels_dir_realpath = os.path.realpath(os.path.join(pex_root, "installed_wheels"))
+        installed_wheels_dir_realpath = os.path.realpath(
+            CacheDir.INSTALLED_WHEELS.path(pex_root=pex_root)
+        )
         assert installed_wheels_dir_realpath == commonpath(
             (installed_wheels_dir_realpath, colors_module_realpath)
         )

--- a/tests/integration/test_pex_bootstrapper.py
+++ b/tests/integration/test_pex_bootstrapper.py
@@ -9,6 +9,7 @@ from textwrap import dedent
 
 import pytest
 
+from pex.cache.dirs import CacheDir
 from pex.common import safe_open
 from pex.compatibility import commonpath
 from pex.interpreter import PythonInterpreter
@@ -107,7 +108,7 @@ def test_ensure_venv_short_link(
     full_hash1_dir = os.path.basename(os.path.dirname(expected_venv_dir))
     full_hash2_dir = os.path.basename(expected_venv_dir)
 
-    venvs_dir = os.path.join(pex_root, "venvs")
+    venvs_dir = CacheDir.VENVS.path(pex_root=pex_root)
     assert {"s", full_hash1_dir} == set(os.listdir(venvs_dir))
     short_listing = os.listdir(os.path.join(venvs_dir, "s"))
     assert 1 == len(short_listing)
@@ -214,7 +215,7 @@ def test_ensure_venv_namespace_packages(tmpdir):
     package_file_installed_wheel_dirs = {
         os.path.dirname(os.path.dirname(p)) for p in symlink_package_paths
     }
-    assert os.path.realpath(os.path.join(pex_root, PexInfo.INSTALL_CACHE)) == os.path.realpath(
+    assert os.path.realpath(CacheDir.INSTALLED_WHEELS.path(pex_root=pex_root)) == os.path.realpath(
         commonpath(list(package_file_installed_wheel_dirs))
     ), "Expected contributing wheel content to be symlinked from the installed wheel cache."
     assert {

--- a/tests/integration/test_pex_import.py
+++ b/tests/integration/test_pex_import.py
@@ -9,6 +9,7 @@ import colors  # vendor:skip
 import pytest
 
 from pex import targets
+from pex.cache.dirs import CacheDir
 from pex.common import safe_open
 from pex.layout import DEPS_DIR, Layout
 from pex.resolve.pex_repository_resolver import resolve_from_pex
@@ -91,11 +92,11 @@ def test_import_from_pex(
 
     def get_third_party_prefix():
         if is_venv:
-            return os.path.join(pex_root, "venvs")
+            return CacheDir.VENVS.path(pex_root=pex_root)
         elif layout is Layout.LOOSE:
             return os.path.join(pex, DEPS_DIR)
         else:
-            return os.path.join(pex_root, "installed_wheels")
+            return CacheDir.INSTALLED_WHEELS.path(pex_root=pex_root)
 
     # Verify 3rd party code can be imported hermetically from the PEX.
     alternate_pex_root = os.path.join(str(tmpdir), "alternate_pex_root")
@@ -140,9 +141,9 @@ def test_import_from_pex(
     if not is_venv and layout is Layout.LOOSE:
         assert os.path.join(pex, "first_party.py") == first_party_path
     else:
-        expected_prefix = os.path.join(pex_root, "venvs" if is_venv else "unzipped_pexes")
+        expected_cache_type = CacheDir.VENVS if is_venv else CacheDir.UNZIPPED_PEXES
         assert first_party_path.startswith(
-            expected_prefix
+            expected_cache_type.path(pex_root=pex_root)
         ), "Expected 1st party first_party.py path {path} to start with {expected_prefix}".format(
             path=first_party_path, expected_prefix=expected_prefix
         )

--- a/tests/integration/test_shebang_length_limit.py
+++ b/tests/integration/test_shebang_length_limit.py
@@ -13,6 +13,7 @@ from textwrap import dedent
 import colors  # vendor:skip
 import pytest
 
+from pex.cache.dirs import CacheDir
 from pex.common import chmod_plus_x, safe_open, touch
 from pex.typing import TYPE_CHECKING
 from testing import IS_PYPY, make_project, run_pex_command
@@ -134,20 +135,18 @@ def too_deep_pex_root(
     # type: (...) -> str
 
     # The short venv python used in --venv shebangs is of the form:
-    #   <PEX_ROOT>/venvs/s/592c68dc/venv/bin/python
+    #   <PEX_ROOT>/venvs/0/s/592c68dc/venv/bin/python
     # With no collisions, the hash dir is 8 characters, and we expect no collisions in this bespoke
     # new empty temporary dir PEX_ROOT>
     padding_dirs_length = shebang_length_limit - len(
         "#!"
-        + os.path.join(
-            str(tmpdir),
-            "pex_root",
-            "venvs",
+        + CacheDir.VENVS.path(
             "s",
             "12345678",
             "venv",
             "bin",
             "pypy" if IS_PYPY else "python",
+            pex_root=os.path.join(str(tmpdir), "pex_root"),
         )
         + "\n"
     )

--- a/tests/integration/venv_ITs/test_issue_1630.py
+++ b/tests/integration/venv_ITs/test_issue_1630.py
@@ -5,6 +5,7 @@ import json
 import os
 import subprocess
 
+from pex.cache.dirs import CacheDir
 from pex.dist_metadata import Distribution
 from pex.interpreter import PythonInterpreter
 from pex.pep_376 import InstalledWheel
@@ -42,7 +43,7 @@ def test_data_files(tmpdir):
     assert 1 == len(pex_info.distributions)
     nbconvert_wheel_name, fingerprint = next(iter(pex_info.distributions.items()))
     nbconvert_dist = Distribution.load(
-        os.path.join(pex_info.install_cache, fingerprint, nbconvert_wheel_name)
+        CacheDir.INSTALLED_WHEELS.path(fingerprint, nbconvert_wheel_name, pex_root=pex_root)
     )
 
     pex_venv = Virtualenv.create(

--- a/tests/integration/venv_ITs/test_issue_1637.py
+++ b/tests/integration/venv_ITs/test_issue_1637.py
@@ -8,6 +8,7 @@ from textwrap import dedent
 import pytest
 from colors import yellow  # vendor:skip
 
+from pex.cache.dirs import CacheDir
 from pex.common import safe_open, touch
 from pex.typing import TYPE_CHECKING
 from testing import make_env, run_pex_command
@@ -53,7 +54,7 @@ def create_pex(
                         if not entry.startswith({unzipped_pexes_dir!r}):
                             print(entry)
                     """.format(
-                        unzipped_pexes_dir=os.path.join(pex_root, "unzipped_pexes")
+                        unzipped_pexes_dir=CacheDir.UNZIPPED_PEXES.path(pex_root=pex_root)
                     )
                 )
             )

--- a/tests/resolve/lockfile/test_download_manager.py
+++ b/tests/resolve/lockfile/test_download_manager.py
@@ -8,6 +8,7 @@ from io import BytesIO
 import pytest
 
 from pex import hashing
+from pex.cache.dirs import CacheDir
 from pex.hashing import Sha1Fingerprint, Sha256Fingerprint
 from pex.pep_503 import ProjectName
 from pex.resolve.locked_resolve import FileArtifact
@@ -178,7 +179,7 @@ def test_fingerprint_checking(
 
     # But when the artifact hash is marked verified, no hash checking should occur.
     verified_artifact = attr.evolve(artifact, verified=True)
-    expected_artifact_dir = os.path.join(pex_root, "downloads", expected_sha1_hash)
+    expected_artifact_dir = CacheDir.DOWNLOADS.path(expected_sha1_hash, pex_root=pex_root)
     downloaded_artifact = download_manager.store(verified_artifact, project_name)
     assert (
         DownloadedArtifact(

--- a/tests/test_dependency_manager.py
+++ b/tests/test_dependency_manager.py
@@ -55,7 +55,7 @@ class DistFactory(object):
 @pytest.fixture
 def dist_factory(tmpdir):
     # type: (Any) -> DistFactory
-    return DistFactory(os.path.join(str(tmpdir), "installed_wheels"))
+    return DistFactory(os.path.join(str(tmpdir), "dists"))
 
 
 @attr.s(frozen=True)

--- a/tests/test_execution_mode.py
+++ b/tests/test_execution_mode.py
@@ -10,6 +10,7 @@ from subprocess import CalledProcessError
 
 import pytest
 
+from pex.cache.dirs import CacheDir
 from pex.layout import Layout
 from pex.pep_427 import InstallableType
 from pex.typing import TYPE_CHECKING
@@ -139,4 +140,4 @@ def test_execution_mode(
             execute_colors_pex(pex_app, {"PEX_VENV": "1"})
     else:
         output, pex_root = execute_colors_pex(pex_app, {"PEX_VENV": "1"})
-        assert output.startswith(os.path.join(pex_root, "venvs"))
+        assert output.startswith(CacheDir.VENVS.path(pex_root=pex_root))

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -13,6 +13,7 @@ from zipfile import ZipFile
 
 import pytest
 
+from pex.cache.dirs import CacheDir
 from pex.common import CopyMode, open_zip, safe_open, temporary_dir, touch
 from pex.compatibility import WINDOWS, commonpath
 from pex.executor import Executor
@@ -270,8 +271,8 @@ def test_pex_builder_packed(tmpdir):
     spread_dist_bootstrap = os.path.join(pex_app, pb.info.bootstrap)
     assert zipfile.is_zipfile(spread_dist_bootstrap)
 
-    cached_bootstrap_zip = os.path.join(
-        pex_root, "bootstrap_zips", pb.info.bootstrap_hash, pb.info.bootstrap
+    cached_bootstrap_zip = CacheDir.BOOTSTRAP_ZIPS.path(
+        pb.info.bootstrap_hash, pb.info.bootstrap, pex_root=pex_root
     )
     assert zipfile.is_zipfile(cached_bootstrap_zip)
 
@@ -294,7 +295,7 @@ def test_pex_builder_packed(tmpdir):
     spread_dist_zip = os.path.join(pex_app, pb.info.internal_cache, location)
     assert zipfile.is_zipfile(spread_dist_zip)
 
-    cached_dist_zip = os.path.join(pex_root, "packed_wheels", sha, location)
+    cached_dist_zip = CacheDir.PACKED_WHEELS.path(sha, location, pex_root=pex_root)
     assert zipfile.is_zipfile(cached_dist_zip)
 
     assert filecmp.cmp(spread_dist_zip, cached_dist_zip, shallow=False)


### PR DESCRIPTION
Re-structure the Pex cache to both support versioning as well as adding
access tracking for shared (normal) use and for exclusive use when 
portions of the cache need to be deleted. With this new ground work, add
a new `pex3 cache {dir,info,purge}` family of commands for inspecting
and safely trimming the Pex cache.

Closes #1176
Closes #1655
Closes #2201