### PR TITLE
Support custom setuptools & wheel versions.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## 2.17.0
+
+This release brings support for overriding the versions of setuptools
+and wheel Pex bootstraps for non-vendored Pip versions (the modern ones
+you select with `--pip-version`) using the existing
+`--extra-pip-requirement` option introduced in the [2.10.0 release](
+https://github.com/pex-tool/pex/releases/tag/v2.10.0).
+
+* Support custom setuptools & wheel versions. (#2514)
+
 ## 2.16.2
 
 This release brings a slew of small fixes across the code base.

--- a/pex/build_system/pep_517.py
+++ b/pex/build_system/pep_517.py
@@ -45,7 +45,7 @@ def _default_build_system(
             resolved_reqs = set()  # type: Set[str]
             resolved_dists = []  # type: List[Distribution]
             if selected_pip_version is PipVersion.VENDORED:
-                requires = ["setuptools", selected_pip_version.wheel_requirement]
+                requires = ["setuptools", str(selected_pip_version.wheel_requirement)]
                 resolved_dists.extend(
                     Distribution.load(dist_location)
                     for dist_location in third_party.expose(
@@ -56,8 +56,8 @@ def _default_build_system(
                 extra_env.update(__PEX_UNVENDORED__="setuptools")
             else:
                 requires = [
-                    selected_pip_version.setuptools_requirement,
-                    selected_pip_version.wheel_requirement,
+                    str(selected_pip_version.setuptools_requirement),
+                    str(selected_pip_version.wheel_requirement),
                 ]
             unresolved = [
                 requirement for requirement in requires if requirement not in resolved_reqs

--- a/pex/pip/tool.py
+++ b/pex/pip/tool.py
@@ -293,6 +293,11 @@ class Pip(object):
     version = attr.ib()  # type: PipVersionValue
     _pip_cache = attr.ib()  # type: str
 
+    @property
+    def venv_dir(self):
+        # type: () -> str
+        return self._pip.venv_dir
+
     @staticmethod
     def _calculate_resolver_version(package_index_configuration=None):
         # type: (Optional[PackageIndexConfiguration]) -> ResolverVersion.Value
@@ -643,7 +648,7 @@ class Pip(object):
             if not atomic_dir.is_finalized():
                 self.spawn_download_distributions(
                     download_dir=atomic_dir.work_dir,
-                    requirements=[self.version.wheel_requirement],
+                    requirements=[str(self.version.wheel_requirement)],
                     package_index_configuration=package_index_configuration,
                     build_configuration=BuildConfiguration.create(allow_builds=False),
                 ).wait()

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.16.2"
+__version__ = "2.17.0"

--- a/tests/integration/cli/commands/test_lock_sync.py
+++ b/tests/integration/cli/commands/test_lock_sync.py
@@ -89,8 +89,8 @@ def session_fixtures(shared_integration_test_tmpdir):
             # itself if needed.
             host_requirements(
                 "cowsay==5.0.0",
-                pip_version.setuptools_requirement,
-                pip_version.wheel_requirement,
+                str(pip_version.setuptools_requirement),
+                str(pip_version.wheel_requirement),
             )
             find_links_repo.make_sdist("spam", version="1")
             find_links_repo.make_wheel("spam", version="1")

--- a/tests/integration/cli/commands/test_lock_update.py
+++ b/tests/integration/cli/commands/test_lock_update.py
@@ -80,8 +80,8 @@ def find_links(
     repository_pex = os.path.join(str(tmpdir), "repository.pex")
     run_pex_command(
         args=[
-            pip_version.setuptools_requirement,
-            pip_version.wheel_requirement,
+            str(pip_version.setuptools_requirement),
+            str(pip_version.wheel_requirement),
             "--include-tools",
             "-o",
             repository_pex,

--- a/tests/integration/test_issue_2343.py
+++ b/tests/integration/test_issue_2343.py
@@ -41,8 +41,8 @@ def find_links(shared_integration_test_tmpdir):
             result = find_links_repo.resolver.resolve_requirements(
                 [
                     "ansicolors==1.1.8",
-                    pip_version.setuptools_requirement,
-                    pip_version.wheel_requirement,
+                    str(pip_version.setuptools_requirement),
+                    str(pip_version.wheel_requirement),
                 ],
                 result_type=InstallableType.WHEEL_FILE,
             )

--- a/tests/integration/test_keyring_support.py
+++ b/tests/integration/test_keyring_support.py
@@ -201,7 +201,7 @@ def download_pip_requirements(
     extra_requirements=(),  # type: Iterable[str]
 ):
     # type: (...) -> None
-    requirements = list(pip_version.requirements)
+    requirements = list(map(str, pip_version.requirements))
     requirements.extend(extra_requirements)
     get_pip(resolver=ConfiguredResolver.version(pip_version)).spawn_download_distributions(
         download_dir=download_dir, requirements=requirements

--- a/tests/test_bdist_pex.py
+++ b/tests/test_bdist_pex.py
@@ -219,7 +219,7 @@ def test_unwriteable_contents():
         wheels.extend(
             fingerprinted_dist.distribution.location
             for fingerprinted_dist in resolve(
-                requirements=[PipVersion.VENDORED.wheel_requirement],
+                requirements=[str(PipVersion.VENDORED.wheel_requirement)],
                 result_type=InstallableType.WHEEL_FILE,
             ).distributions
         )

--- a/tests/tools/commands/test_repository.py
+++ b/tests/tools/commands/test_repository.py
@@ -221,7 +221,7 @@ def test_extract_lifecycle(pex, pex_tools_env, tmpdir):
     vendored_pip_dists_dir = os.path.join(str(tmpdir), "vendored-pip-dists")
     get_pip(resolver=ConfiguredResolver.default()).spawn_download_distributions(
         download_dir=vendored_pip_dists_dir,
-        requirements=[PipVersion.VENDORED.wheel_requirement],
+        requirements=[str(PipVersion.VENDORED.wheel_requirement)],
         build_configuration=BuildConfiguration.create(allow_builds=False),
     ).wait()
 


### PR DESCRIPTION
When using non-vendored Pip (i.e.: specifying a custom `--pip-version`),
you can now override the versions of setuptools and wheel Pex bootstraps
for Pip with the existing `--extra-pip-requirement` option and the
override will be respected. Trying to override setuptools or wheel for
vendored Pip will raise an error however since its versions are
specialized to support all Pex resolve features under Python 2.7.

Fixes #1895