### PR TITLE
Support `--project` extras.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -1030,7 +1030,8 @@ def build_pex(
         else:
             pip_configuration = resolver_configuration
 
-        built_projects = project.get_projects(options).build(
+        projects = project.get_projects(options)
+        built_projects = projects.build(
             targets=targets,
             pip_configuration=pip_configuration,
             compile_pyc=options.compile,
@@ -1043,9 +1044,10 @@ def build_pex(
             dependency_config=dependency_config,
         )
         for built_project in built_projects:
-            dependency_manager.add_requirement(built_project.as_requirement())
+            for req in built_project.satisfied_direct_requirements:
+                dependency_manager.add_requirement(req)
             dependency_manager.add_distribution(built_project.fingerprinted_distribution)
-            project_dependencies.update(built_project.requires_dists)
+            project_dependencies.update(built_project.iter_requirements())
 
         requirements = OrderedSet(requirement_configuration.requirements)
         requirements.update(str(req) for req in project_dependencies)

--- a/pex/resolve/project.py
+++ b/pex/resolve/project.py
@@ -3,10 +3,11 @@
 
 from __future__ import absolute_import
 
-import os.path
 from argparse import Namespace, _ActionsContainer
 
+from pex import requirements
 from pex.build_system import pep_517
+from pex.common import pluralize
 from pex.dependency_configuration import DependencyConfiguration
 from pex.dist_metadata import DistMetadata, Requirement
 from pex.fingerprinted_distribution import FingerprintedDistribution
@@ -14,66 +15,70 @@ from pex.interpreter import PythonInterpreter
 from pex.jobs import Raise, SpawnedJob, execute_parallel
 from pex.pep_427 import InstallableType
 from pex.pip.version import PipVersionValue
+from pex.requirements import LocalProjectRequirement, ParseError
 from pex.resolve.configured_resolve import resolve
 from pex.resolve.requirement_configuration import RequirementConfiguration
 from pex.resolve.resolver_configuration import PipConfiguration
 from pex.resolve.resolvers import Resolver, Untranslatable
+from pex.sorted_tuple import SortedTuple
 from pex.targets import LocalInterpreter, Target, Targets
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Iterator, List, Optional, Set, Tuple
+    from typing import Iterable, Iterator, List, Optional, Set, Tuple
 
     import attr  # vendor:skip
 else:
     from pex.third_party import attr
 
 
+def _iter_requirements(
+    target,  # type: Target
+    dist_metadata,  # type: DistMetadata
+    extras,  # type: Iterable[str]
+):
+    # type: (...) -> Iterator[Requirement]
+    for req in dist_metadata.requires_dists:
+        if not target.requirement_applies(requirement=req, extras=extras):
+            continue
+        yield attr.evolve(req, marker=None)
+
+
 @attr.s(frozen=True)
 class BuiltProject(object):
     target = attr.ib()  # type: Target
     fingerprinted_distribution = attr.ib()  # type: FingerprintedDistribution
+    satisfied_direct_requirements = attr.ib()  # type: SortedTuple[Requirement]
 
-    def as_requirement(self):
-        # type: () -> Requirement
-        return self.fingerprinted_distribution.distribution.as_requirement()
+    def iter_requirements(self):
+        # type: () -> Iterator[Requirement]
+        seen = set()  # type: Set[Requirement]
+        for satisfied_direct_requirement in self.satisfied_direct_requirements:
+            for req in _iter_requirements(
+                target=self.target,
+                dist_metadata=self.fingerprinted_distribution.distribution.metadata,
+                extras=satisfied_direct_requirement.extras,
+            ):
+                if req not in seen:
+                    seen.add(req)
+                    yield req
+
+
+@attr.s(frozen=True)
+class Project(object):
+    path = attr.ib()  # type: str
+    requirement = attr.ib()  # type: LocalProjectRequirement
 
     @property
-    def requires_dists(self):
-        # type: () -> Tuple[Requirement, ...]
-        return self.fingerprinted_distribution.distribution.metadata.requires_dists
+    def requirement_str(self):
+        # type: () -> str
+        # N.B.: Requirements are ASCII text. See: https://peps.python.org/pep-0508/#grammar
+        return str(self.requirement.line.processed_text)
 
 
 @attr.s(frozen=True)
 class Projects(object):
-    paths = attr.ib(default=())  # type: Tuple[str, ...]
-
-    @paths.validator
-    def _is_project_dir(
-        self,
-        attribute,  # type: attr.Attribute
-        value,  # type: Tuple[str, ...]
-    ):
-        # type: (...) -> None
-        invalid_paths = []  # type: List[str]
-        for path in value:
-            if os.path.isfile(os.path.join(path, "pyproject.toml")):
-                continue
-            if os.path.isfile(os.path.join(path, "setup.py")):
-                continue
-            invalid_paths.append(path)
-
-        if invalid_paths:
-            raise ValueError(
-                "The following --project paths do not appear to point to directories containing "
-                "Python projects:\n"
-                "{invalid_paths}".format(
-                    invalid_paths="\n".join(
-                        "{index}. {path}".format(index=index, path=path)
-                        for index, path in enumerate(invalid_paths, start=1)
-                    )
-                )
-            )
+    projects = attr.ib(default=())  # type: Tuple[Project, ...]
 
     def build(
         self,
@@ -88,7 +93,9 @@ class Projects(object):
 
         resolve_result = resolve(
             targets=targets,
-            requirement_configuration=RequirementConfiguration(requirements=self.paths),
+            requirement_configuration=RequirementConfiguration(
+                requirements=[project.requirement_str for project in self.projects]
+            ),
             resolver_configuration=attr.evolve(pip_configuration, transitive=False),
             compile_pyc=compile_pyc,
             ignore_errors=ignore_errors,
@@ -99,6 +106,7 @@ class Projects(object):
             yield BuiltProject(
                 target=resolved_distribution.target,
                 fingerprinted_distribution=resolved_distribution.fingerprinted_distribution,
+                satisfied_direct_requirements=resolved_distribution.direct_requirements,
             )
 
     def collect_requirements(
@@ -112,27 +120,32 @@ class Projects(object):
 
         target = LocalInterpreter.create(interpreter)
 
-        def spawn_func(project_directory):
-            # type: (str) -> SpawnedJob[DistMetadata]
+        def spawn_func(project):
+            # type: (Project) -> SpawnedJob[DistMetadata]
             return pep_517.spawn_prepare_metadata(
-                project_directory, target, resolver, pip_version=pip_version
+                project.path, target, resolver, pip_version=pip_version
             )
 
         seen = set()  # type: Set[Requirement]
-        for dist_metadata in execute_parallel(
-            self.paths,
-            spawn_func=spawn_func,
-            error_handler=Raise[str, DistMetadata](Untranslatable),
-            max_jobs=max_jobs,
+        for local_project, dist_metadata in zip(
+            self.projects,
+            execute_parallel(
+                self.projects,
+                spawn_func=spawn_func,
+                error_handler=Raise[Project, DistMetadata](Untranslatable),
+                max_jobs=max_jobs,
+            ),
         ):
-            for req in dist_metadata.requires_dists:
+            for req in _iter_requirements(
+                target=target, dist_metadata=dist_metadata, extras=local_project.requirement.extras
+            ):
                 if req not in seen:
                     seen.add(req)
                     yield req
 
     def __len__(self):
         # type: () -> int
-        return len(self.paths)
+        return len(self.projects)
 
 
 def register_options(
@@ -154,4 +167,43 @@ def register_options(
 
 def get_projects(options):
     # type: (Namespace) -> Projects
-    return Projects(paths=tuple(options.projects))
+
+    projects = []  # type: List[Project]
+    errors = []  # type: List[str]
+    for project in options.projects:
+        try:
+            parsed = requirements.parse_requirement_string(project)
+        except (ParseError, ValueError) as e:
+            errors.append(
+                "The --project {project} is not a valid local project requirement: {err}".format(
+                    project=project, err=e
+                )
+            )
+        else:
+            if isinstance(parsed, LocalProjectRequirement):
+                if parsed.marker:
+                    errors.append(
+                        "The --project {project} has a marker, which is not supported. "
+                        "Remove marker: ;{marker}".format(project=project, marker=parsed.marker)
+                    )
+                else:
+                    projects.append(Project(path=parsed.path, requirement=parsed))
+            else:
+                errors.append(
+                    "The --project {project} does not appear to point to a directory containing a "
+                    "Python project.".format(project=project)
+                )
+
+    if errors:
+        raise ValueError(
+            "Found {count} invalid --project {specifiers}:\n{errors}".format(
+                count=len(errors),
+                specifiers=pluralize(errors, "specifier"),
+                errors="\n".join(
+                    "{index}. {error}".format(index=index, error=error)
+                    for index, error in enumerate(errors, start=1)
+                ),
+            )
+        )
+
+    return Projects(projects=tuple(projects))


### PR DESCRIPTION
When specifying `--project` as a source of requirements, you can now
include extras; e.g. `--project this/project-dir[extra1,extra2]`.