### PR TITLE
Get unit tests running stably under xdist.

### DIFF
--- a/testing/bin/run_tests.py
+++ b/testing/bin/run_tests.py
@@ -151,15 +151,14 @@ def main():
     else:
         logger.info("No test control environment variables set.")
 
+    args = [sys.executable, "-m", "pytest", "-n", "auto"]
     if options.it:
-        pytest_args = ["-n", "auto", "tests/integration"]
+        args.append("tests/integration")
     else:
-        pytest_args = ["tests", "--ignore", "tests/integration"]
+        args.extend(["tests", "--ignore", "tests/integration"])
+    args.extend(passthrough_args or ["-vvs"])
 
-    return subprocess.call(
-        args=[sys.executable, "-m", "pytest"] + pytest_args + passthrough_args or ["-vvs"],
-        cwd=pex_project_dir(),
-    )
+    return subprocess.call(args=args, cwd=pex_project_dir())
 
 
 if __name__ == "__main__":

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -370,7 +370,11 @@ def check_resolve_venv(real_interpreter):
     ):
         # type: (...) -> List[str]
         venv_dir = os.path.join(tmpdir, rel_path)
-        interpreter.execute(["-m", "venv", venv_dir])
+
+        # N.B.: We don't need pip in the venv for this test and sometimes system interpreters
+        # don't have ensurepip support.
+        interpreter.execute(["-m", "venv", "--without-pip", venv_dir])
+
         return glob.glob(os.path.join(venv_dir, "bin", "python*"))
 
     assert not real_interpreter.is_venv

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -6,6 +6,7 @@ import os
 import site
 import subprocess
 import sys
+import sysconfig
 import tempfile
 import textwrap
 from contextlib import contextmanager
@@ -230,8 +231,13 @@ def test_site_libs(tmpdir):
 def test_site_libs_symlink(tmpdir):
     # type: (Any) -> None
 
-    sys_path_entry = os.path.join(str(tmpdir), "lib")
-    os.mkdir(sys_path_entry)
+    # N.B.: PythonIdentity.get() used below in the core test ends up consulting
+    # `packaging.tags.sys_tags()` which in turn consults `sysconfig`; so we need to make sure that
+    # bit of stdlib is on the sys.path. We get this by grabbing its sys.path entry, which contains
+    # the whole stdlib in addition to it.
+    assert sysconfig.__file__
+    sys_path_entry = os.path.dirname(sysconfig.__file__)
+
     sys_path_entry_link = os.path.join(str(tmpdir), "lib-link")
     os.symlink(sys_path_entry, sys_path_entry_link)
 

--- a/tox.ini
+++ b/tox.ini
@@ -26,16 +26,17 @@ install_command =
     # minimal setup.py since hatchling is buying us less and less and getting in the way more and
     # more.
     py{py27,py35,27,35}: python -m pip install {opts} {toxinidir} {packages}
-
-    docs,check,typecheck,py{py36,py37,py38,py39,py310,36,37,38,39,310,311,312,313}: \
-        python -m pip install {opts} -e {toxinidir} {packages}
+    !py{py27,py35,27,35}: python -m pip install {opts} -e {toxinidir} {packages}
 
 
 commands =
     !integration: python testing/bin/run_tests.py {posargs:-vvs}
     integration: python testing/bin/run_tests.py --it {posargs:-vvs}
 deps =
-    integration: pytest-xdist==1.34.0
+    pytest-xdist==1.34.0; python_version == "2.7"
+    pytest-xdist==2.2.1; python_version == "3.5"
+    pytest-xdist==2.5.0; python_version >= "3.6" and python_version < "3.8"
+    pytest-xdist==3.6.1; python_version >= "3.8"
     ansicolors==1.1.8
     coloredlogs==15.0.1
     # The more-itertools project is an indirect requirement of pytest and its broken for


### PR DESCRIPTION
This was mostly already working save for a few tests that needed
adjustment to be able to run consistently in isolation or under xdist
or both.