### PR TITLE
Add the ability to specify the `--pip-log` path.

### DIFF
--- a/pex/cli/commands/lock.py
+++ b/pex/cli/commands/lock.py
@@ -656,7 +656,7 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
         resolver_options.register_network_options(resolver_options_parser)
         resolver_options.register_max_jobs_option(resolver_options_parser)
         resolver_options.register_use_pip_config(resolver_options_parser)
-        resolver_options.register_preserve_pip_download_log(resolver_options_parser)
+        resolver_options.register_pip_log(resolver_options_parser)
 
     @classmethod
     def add_update_lock_options(
@@ -1087,7 +1087,7 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
             max_jobs=resolver_options.get_max_jobs_value(self.options),
             use_pip_config=resolver_options.get_use_pip_config_value(self.options),
             dependency_configuration=dependency_config,
-            preserve_log=resolver_options.get_preserve_pip_download_log(self.options),
+            pip_log=resolver_options.get_pip_log(self.options),
         )
 
         target_configuration = target_options.configure(self.options)

--- a/pex/resolve/configured_resolve.py
+++ b/pex/resolve/configured_resolve.py
@@ -125,7 +125,7 @@ def resolve(
                 compile=compile_pyc,
                 max_parallel_jobs=resolver_configuration.max_jobs,
                 ignore_errors=ignore_errors,
-                preserve_log=resolver_configuration.preserve_log,
+                pip_log=resolver_configuration.log,
                 pip_version=resolver_configuration.version,
                 resolver=ConfiguredResolver(pip_configuration=resolver_configuration),
                 use_pip_config=resolver_configuration.use_pip_config,

--- a/pex/resolve/lockfile/create.py
+++ b/pex/resolve/lockfile/create.py
@@ -421,7 +421,7 @@ def create(
             max_parallel_jobs=pip_configuration.max_jobs,
             observer=lock_observer,
             dest=download_dir,
-            preserve_log=pip_configuration.preserve_log,
+            pip_log=pip_configuration.log,
             pip_version=pip_configuration.version,
             resolver=configured_resolver,
             use_pip_config=pip_configuration.use_pip_config,

--- a/pex/resolve/lockfile/updater.py
+++ b/pex/resolve/lockfile/updater.py
@@ -619,7 +619,7 @@ class LockUpdater(object):
         max_jobs,  # type: int
         use_pip_config,  # type: bool
         dependency_configuration,  # type: DependencyConfiguration
-        preserve_log,  # type: bool
+        pip_log,  # type: Optional[str]
     ):
         # type: (...) -> LockUpdater
 
@@ -638,7 +638,7 @@ class LockUpdater(object):
             network_configuration=network_configuration,
             max_jobs=max_jobs,
             use_pip_config=use_pip_config,
-            preserve_log=preserve_log,
+            log=pip_log,
         )
         return cls(
             lock_file=lock_file,

--- a/pex/resolve/resolver_configuration.py
+++ b/pex/resolve/resolver_configuration.py
@@ -185,7 +185,7 @@ class PipConfiguration(object):
     allow_prereleases = attr.ib(default=False)  # type: bool
     transitive = attr.ib(default=True)  # type: bool
     max_jobs = attr.ib(default=DEFAULT_MAX_JOBS)  # type: int
-    preserve_log = attr.ib(default=False)  # type: bool
+    log = attr.ib(default=None)  # type: Optional[str]
     version = attr.ib(default=None)  # type: Optional[PipVersionValue]
     resolver_version = attr.ib(default=None)  # type: Optional[ResolverVersion.Value]
     allow_version_fallback = attr.ib(default=True)  # type: bool

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -490,16 +490,14 @@ def run_simple_pex_test(
 
 def bootstrap_python_installer(dest):
     # type: (str) -> None
-    for _ in range(3):
+    for index in range(3):
         try:
-            subprocess.check_call(["git", "clone", "https://github.com/pyenv/pyenv.git", dest])
+            subprocess.check_call(args=["git", "clone", "https://github.com/pyenv/pyenv", dest])
+            return
         except subprocess.CalledProcessError as e:
-            print("caught exception: %r" % e)
+            print("Error cloning pyenv on attempt", index + 1, "of 3:", e, file=sys.stderr)
             continue
-        else:
-            break
-    else:
-        raise RuntimeError("Helper method could not clone pyenv from git after 3 tries")
+    raise RuntimeError("Could not clone pyenv from git after 3 tries.")
 
 
 # NB: We keep the pool of bootstrapped interpreters as small as possible to avoid timeouts in CI
@@ -508,7 +506,7 @@ def bootstrap_python_installer(dest):
 # minutes for a shard.
 # N.B.: Make sure to stick to versions that have binary releases for all supported platforms to
 # support use of pyenv-win which does not build from source, just running released installers
-# robotically instead.
+# instead.
 PY27 = "2.7.18"
 PY38 = "3.8.10"
 PY39 = "3.9.13"
@@ -539,14 +537,15 @@ def ensure_python_distribution(version):
 
     pip = os.path.join(interpreter_location, "bin", "pip")
 
+    with atomic_directory(target_dir=pyenv_root) as pyenv_root_atomic_dir:
+        if not pyenv_root_atomic_dir.is_finalized():
+            bootstrap_python_installer(pyenv_root_atomic_dir.work_dir)
+
     with atomic_directory(target_dir=interpreter_location) as interpreter_target_dir:
         if not interpreter_target_dir.is_finalized():
-            with atomic_directory(target_dir=pyenv_root) as pyenv_root_target_dir:
-                if pyenv_root_target_dir.is_finalized():
-                    with pyenv_root_target_dir.locked():
-                        subprocess.check_call(args=["git", "pull", "--ff-only"], cwd=pyenv_root)
-                else:
-                    bootstrap_python_installer(pyenv_root_target_dir.work_dir)
+            with pyenv_root_atomic_dir.locked():
+                subprocess.check_call(args=["git", "pull", "--ff-only"], cwd=pyenv_root)
+
             env = pyenv_env.copy()
             if sys.platform.lower().startswith("linux"):
                 env["CONFIGURE_OPTS"] = "--enable-shared"


### PR DESCRIPTION
Although `--pip-log` is just an alias for the pre-existing
`--preserve-pip-download-log` option, the option gains the ability to
accept an optional log path value. In addition to this pro-active means
of starting a debuggable Pex session with Pip, the log is also made more
useful in the face of a multi-target resolve by serializing the log on
targets and prefixing log lines per target. The log now also includes
the compatibility tags calculated via `pip -v debug ...` for any 
abbreviated `--platform`s used in the resolve.