### PR TITLE
Plumb `--pip-version` to Platform tag calculation.

### DIFF
--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -545,9 +545,10 @@ class PythonIdentity(object):
             version=self.version_str,
             version_info=self.version,
             abi=self.abi_tag,
+            supported_tags=self._supported_tags,
         )
-        for tag in self._supported_tags:
-            yield Platform.from_tag(tag)
+        for index in range(len(self._supported_tags)):
+            yield Platform.from_tags(self._supported_tags[index:])
 
     def binary_name(self, version_components=2):
         # type: (int) -> str

--- a/pex/pep_425.py
+++ b/pex/pep_425.py
@@ -84,7 +84,7 @@ class CompatibilityTags(object):
         return cls(tags=tuple(itertools.chain.from_iterable(parse_tag(tag) for tag in tags)))
 
     _tags = attr.ib(converter=_prepare_tags)  # type: Tuple[Tag, ...]
-    __rankings = attr.ib(eq=False, factory=dict)  # type: MutableMapping[Tag, TagRank]
+    _rankings = attr.ib(eq=False, factory=dict)  # type: MutableMapping[Tag, TagRank]
 
     @_tags.validator
     def _validate_tags(
@@ -120,11 +120,11 @@ class CompatibilityTags(object):
         return [str(tag) for tag in self._tags]
 
     @property
-    def _rankings(self):
+    def __rankings(self):
         # type: () -> Mapping[Tag, TagRank]
-        if not self.__rankings:
-            self.__rankings.update(TagRank.ranked(self._tags))
-        return self.__rankings
+        if not self._rankings:
+            self._rankings.update(TagRank.ranked(self._tags))
+        return self._rankings
 
     @property
     def lowest_rank(self):
@@ -133,7 +133,7 @@ class CompatibilityTags(object):
 
     def rank(self, tag):
         # type: (Tag) -> Optional[TagRank]
-        return self._rankings.get(tag)
+        return self.__rankings.get(tag)
 
     def best_match(self, tags):
         # type: (Iterable[Tag]) -> Optional[RankedTag]
@@ -160,18 +160,30 @@ class CompatibilityTags(object):
         # type: (int) -> Tag
         pass
 
+    # MyPy claims this overload collides with the one below even though slice / Tag are disjoint
+    # input types and CompatibilityTags / TagRank are disjoint return types; thus the ignore[misc].
+    @overload
+    def __getitem__(self, slice_):  # type: ignore[misc]
+        # type: (slice) -> CompatibilityTags
+        pass
+
     @overload
     def __getitem__(self, tag):
         # type: (Tag) -> TagRank
         pass
 
-    def __getitem__(self, index_or_tag):
-        # type: (Union[int, Tag]) -> Union[Tag, TagRank]
+    def __getitem__(self, index_or_slice_or_tag):
+        # type: (Union[int, slice, Tag]) -> Union[Tag, CompatibilityTags, TagRank]
         """Retrieve tag by its rank or a tags rank.
 
         Ranks are 0-based with the 0-rank tag being the most specific (best match).
         """
-        if isinstance(index_or_tag, Tag):
-            return self._rankings[index_or_tag]
+        if isinstance(index_or_slice_or_tag, Tag):
+            return self.__rankings[index_or_slice_or_tag]
+        elif isinstance(index_or_slice_or_tag, slice):
+            tags = self._tags[index_or_slice_or_tag]
+            return CompatibilityTags(
+                tags=tags, rankings={tag: self.__rankings[tag] for tag in tags}
+            )
         else:
-            return self._tags[index_or_tag]
+            return self._tags[index_or_slice_or_tag]

--- a/pex/pip/foreign_platform/__init__.py
+++ b/pex/pip/foreign_platform/__init__.py
@@ -10,7 +10,7 @@ from pex.common import safe_mkdtemp
 from pex.interpreter_constraints import iter_compatible_versions
 from pex.pep_425 import CompatibilityTags
 from pex.pip.download_observer import DownloadObserver, Patch, PatchSet
-from pex.platforms import Platform
+from pex.platforms import PlatformSpec
 from pex.targets import AbbreviatedPlatform, CompletePlatform, Target
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
@@ -20,12 +20,12 @@ if TYPE_CHECKING:
 
 
 def iter_platform_args(
-    platform,  # type: Platform
+    platform_spec,  # type: PlatformSpec
     manylinux=None,  # type: Optional[str]
 ):
     # type: (...) -> Iterator[str]
 
-    plat = platform.platform
+    platform = platform_spec.platform
     # N.B.: Pip supports passing multiple --platform and --abi. We pass multiple --platform to
     # support the following use case 1st surfaced by Twitter in 2018:
     #
@@ -41,21 +41,21 @@ def iter_platform_args(
     # consume both its own custom-built wheels as well as other manylinux-compliant wheels in
     # the same application, it needs to advertise that the target machine supports both
     # `linux_x86_64` wheels and `manylinux2014_x86_64` wheels (for example).
-    if manylinux and plat.startswith("linux"):
+    if manylinux and platform.startswith("linux"):
         yield "--platform"
-        yield plat.replace("linux", manylinux, 1)
+        yield platform.replace("linux", manylinux, 1)
 
     yield "--platform"
-    yield plat
+    yield platform
 
     yield "--implementation"
-    yield platform.impl
+    yield platform_spec.impl
 
     yield "--python-version"
-    yield platform.version
+    yield platform_spec.version
 
     yield "--abi"
-    yield platform.abi
+    yield platform_spec.abi
 
 
 class EvaluationEnvironment(dict):

--- a/pex/pip/tool.py
+++ b/pex/pip/tool.py
@@ -28,7 +28,7 @@ from pex.pip.download_observer import DownloadObserver, PatchSet
 from pex.pip.log_analyzer import ErrorAnalyzer, ErrorMessage, LogAnalyzer, LogScrapeJob
 from pex.pip.tailer import Tailer
 from pex.pip.version import PipVersion, PipVersionValue
-from pex.platforms import Platform
+from pex.platforms import PlatformSpec
 from pex.resolve.resolver_configuration import (
     BuildConfiguration,
     ReposConfiguration,
@@ -698,7 +698,7 @@ class Pip(object):
 
     def spawn_debug(
         self,
-        platform,  # type: Platform
+        platform_spec,  # type: PlatformSpec
         manylinux=None,  # type: Optional[str]
         log=None,  # type: Optional[str]
     ):
@@ -713,7 +713,9 @@ class Pip(object):
         # only if the Pip command fails, which is what we want.
 
         debug_command = ["debug"]
-        debug_command.extend(foreign_platform.iter_platform_args(platform, manylinux=manylinux))
+        debug_command.extend(
+            foreign_platform.iter_platform_args(platform_spec, manylinux=manylinux)
+        )
         return self._spawn_pip_isolated_job(
             debug_command, log=log, pip_verbosity=1, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )

--- a/pex/resolve/abbreviated_platforms.py
+++ b/pex/resolve/abbreviated_platforms.py
@@ -1,0 +1,200 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, print_function
+
+import json
+import os
+import re
+
+from pex import compatibility
+from pex.atomic_directory import atomic_directory
+from pex.cache.dirs import CacheDir
+from pex.common import safe_open, safe_rmtree
+from pex.exceptions import production_assert
+from pex.jobs import SpawnedJob
+from pex.pep_425 import CompatibilityTags
+from pex.pip.installation import get_pip
+from pex.platforms import Platform, PlatformSpec
+from pex.resolve.configured_resolver import ConfiguredResolver
+from pex.resolve.resolver_configuration import PipConfiguration
+from pex.third_party.packaging import tags
+from pex.tracer import TRACER
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Iterator, List, Optional
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
+
+
+def _calculate_tags(
+    pip_configuration,  # type: PipConfiguration
+    platform_spec,  # type: PlatformSpec
+    manylinux=None,  # type: Optional[str]
+):
+    # type: (...) -> Iterator[tags.Tag]
+
+    def parse_tags(output):
+        # type: (bytes) -> Iterator[tags.Tag]
+        count = None  # type: Optional[int]
+        try:
+            for line in output.decode("utf-8").splitlines():
+                if count is None:
+                    match = re.match(r"^Compatible tags: (?P<count>\d+)\s+", line)
+                    if match:
+                        count = int(match.group("count"))
+                    continue
+                count -= 1
+                if count < 0:
+                    raise AssertionError("Expected {} tags but got more.".format(count))
+                for tag in tags.parse_tag(line.strip()):
+                    yield tag
+        finally:
+            if count != 0:
+                raise AssertionError("Finished with count {}.".format(count))
+
+    pip = get_pip(
+        version=pip_configuration.version,
+        resolver=ConfiguredResolver(pip_configuration=pip_configuration),
+    )
+    job = SpawnedJob.stdout(
+        job=pip.spawn_debug(
+            platform_spec=platform_spec, manylinux=manylinux, log=pip_configuration.log
+        ),
+        result_func=parse_tags,
+    )
+    return job.await_result()
+
+
+class CompatibilityTagsParseError(ValueError):
+    pass
+
+
+def _parse_tags(path):
+    # type: (str) -> CompatibilityTags
+
+    with open(path) as fp:
+        try:
+            data = json.load(fp)
+        except ValueError as e:
+            raise CompatibilityTagsParseError(
+                "Regenerating the platform info file at {} since it did not contain parsable "
+                "JSON data: {}".format(fp.name, e)
+            )
+
+    if not isinstance(data, dict):
+        raise CompatibilityTagsParseError(
+            "Regenerating the platform info file at {} since it did not contain a "
+            "configuration object. Found: {!r}".format(fp.name, data)
+        )
+
+    sup_tags = data.get("supported_tags")
+    if not isinstance(sup_tags, list):
+        raise CompatibilityTagsParseError(
+            "Regenerating the platform info file at {} since it was missing a valid "
+            "`supported_tags` list. Found: {!r}".format(fp.name, sup_tags)
+        )
+
+    count = len(sup_tags)
+
+    def parse_tag(
+        index,  # type: int
+        tag,  # type: List[Any]
+    ):
+        # type: (...) -> tags.Tag
+        if len(tag) != 3 or not all(
+            isinstance(component, compatibility.string) for component in tag
+        ):
+            raise CompatibilityTagsParseError(
+                "Serialized platform tags should be lists of three strings. Tag {index} of "
+                "{count} was: {tag!r}.".format(index=index, count=count, tag=tag)
+            )
+        interpreter, abi, platform = tag
+        return tags.Tag(interpreter=interpreter, abi=abi, platform=platform)
+
+    try:
+        return CompatibilityTags(tags=[parse_tag(index, tag) for index, tag in enumerate(sup_tags)])
+    except ValueError as e:
+        raise CompatibilityTagsParseError(
+            "Regenerating the platform info file at {} since it did not contain parsable "
+            "tag data: {}".format(fp.name, e)
+        )
+
+
+PLAT_INFO_FILE = "PLAT-INFO"
+
+
+def create(
+    platform,  # type: str
+    manylinux=None,  # type: Optional[str]
+    pip_configuration=PipConfiguration(),  # type: PipConfiguration
+):
+    # type: (...) -> Platform
+
+    platform_spec = PlatformSpec.parse(platform)
+    components = [str(platform_spec)]
+    if manylinux:
+        components.append(manylinux)
+    disk_cache_key = CacheDir.PLATFORMS.path(
+        "pip-{version}".format(version=pip_configuration.version), PlatformSpec.SEP.join(components)
+    )
+
+    with atomic_directory(target_dir=disk_cache_key) as cache_dir:
+        if cache_dir.is_finalized():
+            cached = True
+        else:
+            cached = False
+            plat_info = attr.asdict(platform_spec)
+            plat_info.update(
+                supported_tags=[
+                    (tag.interpreter, tag.abi, tag.platform)
+                    for tag in _calculate_tags(
+                        pip_configuration, platform_spec, manylinux=manylinux
+                    )
+                ],
+            )
+            with safe_open(os.path.join(cache_dir.work_dir, PLAT_INFO_FILE), "w") as fp:
+                json.dump(plat_info, fp)
+
+    platform_info_file = os.path.join(disk_cache_key, PLAT_INFO_FILE)
+    try:
+        compatibility_tags = _parse_tags(path=platform_info_file)
+    except CompatibilityTagsParseError as e:
+        production_assert(
+            cached,
+            (
+                "Unexpectedly generated invalid abbreviated platform compatibility tags from "
+                "{platform}: {err}".format(platform=platform, err=e)
+            ),
+        )
+        TRACER.log(str(e))
+        safe_rmtree(disk_cache_key)
+        return create(platform, manylinux=manylinux, pip_configuration=pip_configuration)
+
+    if cached and pip_configuration.log:
+        # When not cached and the Pip log is being retained, the tags are logged directly by our
+        # call to `pip -v debug ...` in _calculate_tags above. We do the same for the cached case
+        # since this can be very useful information when investigating why Pip did not select a
+        # particular wheel for an abbreviated --platform.
+        with safe_open(pip_configuration.log, "a") as fp:
+            print(
+                "Read {count} compatible tags for abbreviated --platform {platform} from:".format(
+                    count=len(compatibility_tags), platform=platform
+                ),
+                file=fp,
+            )
+            print("    {cache_file}".format(cache_file=platform_info_file), file=fp)
+            for tag in compatibility_tags:
+                print(tag, file=fp)
+
+    return Platform(
+        platform=platform_spec.platform,
+        impl=platform_spec.impl,
+        version=platform_spec.version,
+        version_info=platform_spec.version_info,
+        abi=platform_spec.abi,
+        supported_tags=compatibility_tags,
+    )

--- a/pex/resolve/lockfile/create.py
+++ b/pex/resolve/lockfile/create.py
@@ -461,9 +461,7 @@ def create(
         targets.platforms or targets.complete_platforms
     ):
         check_targets = Targets(
-            platforms=targets.platforms,
-            complete_platforms=targets.complete_platforms,
-            assume_manylinux=targets.assume_manylinux,
+            platforms=targets.platforms, complete_platforms=targets.complete_platforms
         )
         with TRACER.timed(
             "Checking lock can resolve for platforms: {targets}".format(targets=check_targets)

--- a/pex/resolve/resolver_configuration.py
+++ b/pex/resolve/resolver_configuration.py
@@ -196,13 +196,22 @@ class PipConfiguration(object):
 @attr.s(frozen=True)
 class PexRepositoryConfiguration(object):
     pex_repository = attr.ib()  # type: str
-    network_configuration = attr.ib(default=NetworkConfiguration())  # type: NetworkConfiguration
-    transitive = attr.ib(default=True)  # type: bool
+    pip_configuration = attr.ib()  # type: PipConfiguration
 
     @property
     def repos_configuration(self):
         # type: () -> ReposConfiguration
-        return ReposConfiguration()
+        return self.pip_configuration.repos_configuration
+
+    @property
+    def network_configuration(self):
+        # type: () -> NetworkConfiguration
+        return self.pip_configuration.network_configuration
+
+    @property
+    def transitive(self):
+        # type: () -> bool
+        return self.pip_configuration.transitive
 
 
 @attr.s(frozen=True)

--- a/pex/resolve/resolver_options.py
+++ b/pex/resolve/resolver_options.py
@@ -547,6 +547,8 @@ def configure(options):
     :raise: :class:`InvalidConfigurationError` if the resolver configuration is invalid.
     """
 
+    pip_configuration = create_pip_configuration(options)
+
     pex_repository = getattr(options, "pex_repository", None)
     if pex_repository:
         if options.indexes or options.find_links:
@@ -555,12 +557,9 @@ def configure(options):
                 '"--find-links" options.'
             )
         return PexRepositoryConfiguration(
-            pex_repository=pex_repository,
-            network_configuration=create_network_configuration(options),
-            transitive=options.transitive,
+            pex_repository=pex_repository, pip_configuration=pip_configuration
         )
 
-    pip_configuration = create_pip_configuration(options)
     lock = getattr(options, "lock", None)
     if lock:
         return LockRepositoryConfiguration(

--- a/pex/resolve/target_configuration.py
+++ b/pex/resolve/target_configuration.py
@@ -162,7 +162,6 @@ class TargetConfiguration(object):
 
     complete_platforms = attr.ib(default=())  # type: Tuple[CompletePlatform, ...]
     platforms = attr.ib(default=())  # type: Tuple[Optional[Platform], ...]
-    assume_manylinux = attr.ib(default="manylinux2014")  # type: Optional[str]
     resolve_local_platforms = attr.ib(default=False)  # type: bool
 
     def resolve_targets(self):
@@ -238,5 +237,4 @@ class TargetConfiguration(object):
             interpreters=tuple(interpreters),
             complete_platforms=tuple(requested_complete_platforms),
             platforms=tuple(requested_platforms),
-            assume_manylinux=self.assume_manylinux,
         )

--- a/tests/bin/test_sh_boot.py
+++ b/tests/bin/test_sh_boot.py
@@ -11,7 +11,7 @@ from pex.interpreter_constraints import InterpreterConstraints, iter_compatible_
 from pex.orderedset import OrderedSet
 from pex.pep_425 import CompatibilityTags
 from pex.pep_508 import MarkerEnvironment
-from pex.platforms import Platform
+from pex.resolve import abbreviated_platforms
 from pex.sh_boot import PythonBinaryName
 from pex.targets import CompletePlatform, Targets
 from pex.typing import TYPE_CHECKING, cast
@@ -120,8 +120,8 @@ def test_calculate_platforms_no_ics(requires_python):
     ) == calculate_binary_names(
         Targets(
             platforms=(
-                Platform.create("macosx-10.13-x86_64-cp-36-cp36m"),
-                Platform.create("linux-x86_64-pp-27-pypy_73"),
+                abbreviated_platforms.create("macosx-10.13-x86_64-cp-36-cp36m"),
+                abbreviated_platforms.create("linux-x86_64-pp-27-pypy_73"),
             )
         )
     )

--- a/tests/integration/cli/commands/test_lock.py
+++ b/tests/integration/cli/commands/test_lock.py
@@ -19,7 +19,7 @@ from pex.interpreter_constraints import InterpreterConstraint
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.pip.version import PipVersion
-from pex.platforms import Platform
+from pex.resolve import abbreviated_platforms
 from pex.resolve.locked_resolve import Artifact, LockedRequirement
 from pex.resolve.lockfile import json_codec
 from pex.resolve.lockfile.download_manager import DownloadedArtifact
@@ -255,7 +255,9 @@ def test_create_universal_platform_check(tmpdir):
     foreign_platform_310 = (
         "macosx_10.9_x86_64-cp-310-cp310" if IS_LINUX else "linux_x86_64-cp-310-cp310"
     )
-    abbreviated_platform_310 = AbbreviatedPlatform.create(Platform.create(foreign_platform_310))
+    abbreviated_platform_310 = AbbreviatedPlatform.create(
+        abbreviated_platforms.create(foreign_platform_310)
+    )
 
     complete_platform = os.path.join(str(tmpdir), "complete-platform.json")
     run_pex3("interpreter", "inspect", "--markers", "--tags", "-v", "-i2", "-o", complete_platform)
@@ -388,7 +390,9 @@ def test_create_universal_platform_check(tmpdir):
         "psutil==5.9.1",
     )
     result.assert_failure()
-    abbreviated_platform_311 = AbbreviatedPlatform.create(Platform.create(foreign_platform_311))
+    abbreviated_platform_311 = AbbreviatedPlatform.create(
+        abbreviated_platforms.create(foreign_platform_311)
+    )
     assert re.search(
         r"No pre-built wheel was available for psutil 5\.9\.1\.{eol}"
         r"Successfully built the wheel psutil-5\.9\.1-\S+\.whl from the sdist "

--- a/tests/integration/cli/commands/test_venv_create.py
+++ b/tests/integration/cli/commands/test_venv_create.py
@@ -22,7 +22,7 @@ from pex.interpreter import PythonInterpreter
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.pex import PEX
-from pex.platforms import Platform
+from pex.resolve import abbreviated_platforms
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import Virtualenv
 from testing import IS_MAC, PY39, PY310, ensure_python_interpreter, make_env, run_pex_command
@@ -483,7 +483,7 @@ def test_foreign_target(
     result.assert_failure()
     assert (
         "Cannot create a local venv for foreign platform {platform}.".format(
-            platform=Platform.create(foreign_platform)
+            platform=abbreviated_platforms.create(foreign_platform)
         )
         == result.error.strip()
     )
@@ -523,7 +523,7 @@ def test_venv_update_target_mismatch(
     result.assert_failure()
     assert (
         "Cannot update a local venv using a foreign platform. Given: {foreign_platform}.".format(
-            foreign_platform=Platform.create(foreign_platform)
+            foreign_platform=abbreviated_platforms.create(foreign_platform)
         )
         == result.error.strip()
     ), result.error

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -17,7 +17,6 @@ from textwrap import dedent
 import pexpect  # type: ignore[import]  # MyPy can't see the types under Python 2.7.
 import pytest
 
-from pex import targets
 from pex.cache.dirs import CacheDir
 from pex.common import is_exe, safe_mkdir, safe_open, safe_rmtree, temporary_dir, touch
 from pex.compatibility import WINDOWS, commonpath

--- a/tests/integration/test_issue_2073.py
+++ b/tests/integration/test_issue_2073.py
@@ -5,7 +5,7 @@ import os.path
 import re
 import subprocess
 
-from pex.platforms import Platform
+from pex.resolve import abbreviated_platforms
 from pex.targets import AbbreviatedPlatform
 from pex.typing import TYPE_CHECKING
 from testing import IS_LINUX, IntegResults, run_pex_command
@@ -18,7 +18,9 @@ if TYPE_CHECKING:
 FOREIGN_PLATFORM_311 = (
     "macosx_10.9_x86_64-cp-311-cp311" if IS_LINUX else "linux_x86_64-cp-311-cp311"
 )
-ABBREVIATED_FOREIGN_PLATFORM_311 = AbbreviatedPlatform.create(Platform.create(FOREIGN_PLATFORM_311))
+ABBREVIATED_FOREIGN_PLATFORM_311 = AbbreviatedPlatform.create(
+    abbreviated_platforms.create(FOREIGN_PLATFORM_311)
+)
 
 
 def assert_psutil_cross_build_failure(result):

--- a/tests/integration/test_issue_455.py
+++ b/tests/integration/test_issue_455.py
@@ -26,8 +26,6 @@ def test_exclude(tmpdir):
     pex = os.path.join(str(tmpdir), "pex")
     run_pex_command(
         args=[
-            "--pip-version",
-            "latest",
             "--platform",
             "macosx_10.12-x86_64-cp-310-cp310",
             "--platform",

--- a/tests/resolve/test_locked_resolve.py
+++ b/tests/resolve/test_locked_resolve.py
@@ -12,8 +12,8 @@ from pex.pep_425 import CompatibilityTags, TagRank
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.pep_508 import MarkerEnvironment
-from pex.platforms import Platform
 from pex.requirements import VCS
+from pex.resolve import abbreviated_platforms
 from pex.resolve.locked_resolve import (
     Artifact,
     DownloadableArtifact,
@@ -272,7 +272,7 @@ def assert_error(
 
 def platform(plat):
     # type: (str) -> AbbreviatedPlatform
-    return AbbreviatedPlatform.create(Platform.create(plat))
+    return AbbreviatedPlatform.create(abbreviated_platforms.create(plat))
 
 
 def test_platform_resolve(ansicolors_exotic):

--- a/tests/test_pep_508.py
+++ b/tests/test_pep_508.py
@@ -4,7 +4,7 @@
 import pytest
 
 from pex.pep_508 import MarkerEnvironment
-from pex.platforms import Platform
+from pex.resolve import abbreviated_platforms
 from pex.third_party.packaging import markers
 from pex.typing import TYPE_CHECKING, cast
 
@@ -35,7 +35,7 @@ def assert_unknown_marker(
 
 def test_platform_marker_environment():
     # type: () -> None
-    platform = Platform.create("linux-x86_64-cp-37-cp37m")
+    platform = abbreviated_platforms.create("linux-x86_64-cp-37-cp37m")
     marker_environment = MarkerEnvironment.from_platform(platform)
     env = marker_environment.as_dict()
 
@@ -57,7 +57,7 @@ def test_platform_marker_environment():
 
 def test_extended_platform_marker_environment():
     # type: () -> None
-    platform = Platform.create("linux-x86_64-cp-3.10.1-cp310")
+    platform = abbreviated_platforms.create("linux-x86_64-cp-3.10.1-cp310")
     marker_environment = MarkerEnvironment.from_platform(platform)
     env = marker_environment.as_dict()
 
@@ -84,7 +84,7 @@ def test_platform_marker_environment_issue_1488():
         expected,  # type: str
         platform,  # type: str
     ):
-        marker_environment = MarkerEnvironment.from_platform(Platform.create(platform))
+        marker_environment = MarkerEnvironment.from_platform(abbreviated_platforms.create(platform))
         assert expected == marker_environment.platform_machine
 
     assert_platform_machine("x86_64", "linux-x86_64-cp-37-cp37m")

--- a/tests/test_pex_binary.py
+++ b/tests/test_pex_binary.py
@@ -18,6 +18,7 @@ from pex.common import safe_copy, temporary_dir
 from pex.compatibility import to_bytes
 from pex.interpreter import PythonInterpreter
 from pex.resolve import requirement_options, resolver_options, target_options
+from pex.resolve.resolver_configuration import PipConfiguration
 from pex.typing import TYPE_CHECKING
 from pex.venv.bin_path import BinPath
 from testing import PY39, built_wheel, ensure_python_interpreter, run_pex_command, run_simple_pex
@@ -70,7 +71,7 @@ def test_clp_preamble_file():
 
         requirement_configuration = requirement_options.configure(options)
         resolver_configuration = resolver_options.configure(options)
-        target_config = target_options.configure(options)
+        target_config = target_options.configure(options, pip_configuration=PipConfiguration())
         targets = target_config.resolve_targets()
         pex_builder = build_pex(
             requirement_configuration=requirement_configuration,
@@ -123,7 +124,7 @@ def test_clp_prereleases_resolver():
         assert not options.allow_prereleases
 
         with pytest.raises(SystemExit):
-            target_config = target_options.configure(options)
+            target_config = target_options.configure(options, pip_configuration=PipConfiguration())
             build_pex(
                 requirement_configuration=requirement_options.configure(options),
                 resolver_configuration=resolver_options.configure(options),
@@ -154,7 +155,7 @@ def test_clp_prereleases_resolver():
         #     dep==1.2.3b1, dep
         #
         # With a correct behavior the assert line is reached and pex_builder object created.
-        target_config = target_options.configure(options)
+        target_config = target_options.configure(options, pip_configuration=PipConfiguration())
         pex_builder = build_pex(
             requirement_configuration=requirement_options.configure(options),
             resolver_configuration=resolver_options.configure(options),

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -22,7 +22,7 @@ from pex.pep_503 import ProjectName
 from pex.pip.installation import _PIP, PipInstallation, get_pip
 from pex.pip.tool import PackageIndexConfiguration, Pip
 from pex.pip.version import PipVersion, PipVersionValue
-from pex.platforms import Platform
+from pex.resolve import abbreviated_platforms
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.resolver_configuration import ResolverVersion
 from pex.targets import AbbreviatedPlatform, LocalInterpreter, Target
@@ -107,9 +107,7 @@ def test_no_duplicate_constraints_pex_warnings(
 ):
     # type: (...) -> None
     with warnings.catch_warnings(record=True) as events:
-        pip = create_pip(current_interpreter, version=version)
-
-    pip.spawn_debug(platform=current_interpreter.platform).wait()
+        create_pip(current_interpreter, version=version)
 
     assert 0 == len([event for event in events if "constraints.txt" in str(event)]), (
         "Expected no duplicate constraints warnings to be emitted when creating a Pip venv but "
@@ -177,7 +175,7 @@ def test_download_platform_issues_1355(
     assert_pyarrow_downloaded(
         "pyarrow-4.0.1-cp38-cp38-manylinux2010_x86_64.whl",
         target=AbbreviatedPlatform.create(
-            Platform.create("linux-x86_64-cp-38-cp38"), manylinux="manylinux2010"
+            abbreviated_platforms.create("linux-x86_64-cp-38-cp38", manylinux="manylinux2010")
         ),
     )
 
@@ -191,7 +189,7 @@ def assert_download_platform_markers_issue_1366(
     python310_interpreter = PythonInterpreter.from_binary(ensure_python_interpreter(PY310))
     pip = create_pip(python310_interpreter, version=version)
 
-    python27_platform = Platform.create("manylinux_2_33_x86_64-cp-27-cp27mu")
+    python27_platform = abbreviated_platforms.create("manylinux_2_33_x86_64-cp-27-cp27mu")
     download_dir = os.path.join(str(tmpdir), "downloads")
     pip.spawn_download_distributions(
         target=AbbreviatedPlatform.create(python27_platform),
@@ -242,7 +240,9 @@ def test_download_platform_markers_issue_1366_indeterminate(
     python310_interpreter = PythonInterpreter.from_binary(ensure_python_interpreter(PY310))
     pip = create_pip(python310_interpreter, version=version)
 
-    target = AbbreviatedPlatform.create(Platform.create("manylinux_2_33_x86_64-cp-27-cp27mu"))
+    target = AbbreviatedPlatform.create(
+        abbreviated_platforms.create("manylinux_2_33_x86_64-cp-27-cp27mu")
+    )
     download_dir = os.path.join(str(tmpdir), "downloads")
 
     with pytest.raises(Job.Error) as exc_info:
@@ -275,9 +275,11 @@ def test_download_platform_markers_issue_1488(
 
     download_dir = os.path.join(str(tmpdir), "downloads")
 
-    python39_platform = Platform.create("linux-x86_64-cp-39-cp39")
+    python39_platform = abbreviated_platforms.create(
+        "linux-x86_64-cp-39-cp39", manylinux="manylinux2014"
+    )
     create_pip(None, version=version).spawn_download_distributions(
-        target=AbbreviatedPlatform.create(python39_platform, manylinux="manylinux2014"),
+        target=AbbreviatedPlatform.create(python39_platform),
         requirements=["SQLAlchemy==1.4.25"],
         constraint_files=[constraints_file],
         download_dir=download_dir,

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -17,7 +17,7 @@ from pex.build_system.pep_517 import build_sdist
 from pex.common import safe_copy, safe_mkdtemp, temporary_dir
 from pex.dist_metadata import Distribution, Requirement
 from pex.interpreter import PythonInterpreter
-from pex.platforms import Platform
+from pex.resolve import abbreviated_platforms
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.resolver_configuration import BuildConfiguration, ResolverVersion
 from pex.resolve.resolvers import ResolvedDistribution, ResolveResult, Unsatisfiable
@@ -335,7 +335,7 @@ def test_resolve_current_and_foreign_platforms(p537_resolve_cache):
 
         # N.B.: None stands in for the "current" platform at higher layers that parse platform
         # strings to Platform objects.
-        platforms = (None, Platform.create(foreign_platform))
+        platforms = (None, abbreviated_platforms.create(foreign_platform))
         return resolve_p537_wheel_names(
             cache_dir=p537_resolve_cache,
             targets=Targets(platforms=platforms, interpreters=tuple(interpreters)),
@@ -356,14 +356,14 @@ def test_resolve_current_and_foreign_platforms(p537_resolve_cache):
     assert 3 == len(resolve_current_and_foreign(interpreters=[current_python, other_python]))
 
 
-def test_resolve_foreign_abi3():
-    # type: () -> None
+def test_resolve_foreign_abi3(tmpdir):
+    # type: (Any) -> None
     # For version 2.8, cryptography publishes the following abi3 wheels for linux and macosx:
     # cryptography-2.8-cp34-abi3-macosx_10_6_intel.whl
     # cryptography-2.8-cp34-abi3-manylinux1_x86_64.whl
     # cryptography-2.8-cp34-abi3-manylinux2010_x86_64.whl
 
-    cryptogrpahy_resolve_cache = safe_mkdtemp()
+    cryptogrpahy_resolve_cache = os.path.join(str(tmpdir), "pex_root")
     foreign_ver = "37" if PY_VER == (3, 6) else "36"
 
     def resolve_cryptography_wheel_names(manylinux):
@@ -372,10 +372,13 @@ def test_resolve_foreign_abi3():
                 requirements=["cryptography==2.8"],
                 targets=Targets(
                     platforms=(
-                        Platform.create("linux_x86_64-cp-{}-m".format(foreign_ver)),
-                        Platform.create("macosx_10.11_x86_64-cp-{}-m".format(foreign_ver)),
+                        abbreviated_platforms.create(
+                            "linux_x86_64-cp-{}-m".format(foreign_ver), manylinux=manylinux
+                        ),
+                        abbreviated_platforms.create(
+                            "macosx_10.11_x86_64-cp-{}-m".format(foreign_ver), manylinux=manylinux
+                        ),
                     ),
-                    assume_manylinux=manylinux,
                 ),
                 transitive=False,
                 build_configuration=BuildConfiguration.create(allow_builds=False),

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -14,6 +14,7 @@ from pex.orderedset import OrderedSet
 from pex.pep_425 import CompatibilityTags
 from pex.pep_508 import MarkerEnvironment
 from pex.platforms import Platform
+from pex.resolve import abbreviated_platforms
 from pex.targets import (
     AbbreviatedPlatform,
     CompletePlatform,
@@ -156,7 +157,9 @@ def test_requires_python_current():
 
 
 def test_requires_python_abbreviated_platform():
-    abbreviated_platform = AbbreviatedPlatform.create(Platform.create("linux-x86_64-cp-37-m"))
+    abbreviated_platform = AbbreviatedPlatform.create(
+        abbreviated_platforms.create("linux-x86_64-cp-37-m")
+    )
 
     def assert_requires_python(
         expected_result,  # type: bool
@@ -245,9 +248,7 @@ def test_from_target_local_interpreter():
 def test_from_target_abbreviated_platform(current_platform):
     # type: (Platform) -> None
 
-    abbreviated_platform = AbbreviatedPlatform.create(
-        platform=current_platform, manylinux="manylinux1"
-    )
+    abbreviated_platform = AbbreviatedPlatform.create(platform=current_platform)
     tgts = Targets.from_target(abbreviated_platform)
     assert tgts.interpreter is None
     assert OrderedSet([abbreviated_platform]) == tgts.unique_targets(only_explicit=False)
@@ -312,6 +313,7 @@ def test_compatible_shebang(
         version_info=incompatible_version_info,
         version=".".join(map(str, incompatible_version_info)),
         abi=current_platform.abi,
+        supported_tags=current_platform.supported_tags,
     )
     assert (
         Targets(platforms=(current_platform, incompatible_platform_version)).compatible_shebang()
@@ -324,6 +326,7 @@ def test_compatible_shebang(
         version_info=current_platform.version_info,
         version=current_platform.version,
         abi=current_platform.abi,
+        supported_tags=current_platform.supported_tags,
     )
     assert (
         Targets(platforms=(current_platform, incompatible_platform_impl)).compatible_shebang()


### PR DESCRIPTION
This fixes a long-standing discrepency between the selected
`--pip-version` and the Pip actually used to determine abbreviated
`--platform` compatibility tags. With the `--pip-log` enhancement
from #2536 the calculated abbreviated platform tags are now always
logged to the Pip log, which is very useful for debugging failed
resolves using abbreviated platforms.

Fixes #1894