### PR TITLE
Pre-emptively cull unsatisfiable interpreter constraints.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 This release fixes Pex `--interpreter-constraint` handling such that
 any supplied interpreter constraints which are in principle
-unstaisfiable either raise an error or else cause a warning to be issued
+unsatisfiable either raise an error or else cause a warning to be issued
 when other viable interpreter constraints have also been specified. For
 example, `--interpreter-constraint ==3.11.*,==3.12.*` now errors and
 `--interpreter-constraint '>=3.8,<3.8' --interpreter-constraint ==3.9.*`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## 2.20.1
+
+This release fixes Pex `--interpreter-constraint` handling such that
+any supplied interpreter constraints which are in principle
+unstaisfiable either raise an error or else cause a warning to be issued
+when other viable interpreter constraints have also been specified. For
+example, `--interpreter-constraint ==3.11.*,==3.12.*` now errors and
+`--interpreter-constraint '>=3.8,<3.8' --interpreter-constraint ==3.9.*`
+now warns, culling `>3.8,<3.8` and continuing using only `==3.9.*`.
+
+* Pre-emptively cull unsatisfiable interpreter constraints. (#2542)
+
 ## 2.20.0
 
 This release adds the `--pip-log` alias for the existing

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.20.0"
+__version__ = "2.20.1"

--- a/tests/resolve/test_target_options.py
+++ b/tests/resolve/test_target_options.py
@@ -326,7 +326,6 @@ def test_configure_interpreter_constraints(
             )
 
     assert_interpreter_constraint_not_satisfied(["==3.9.*"])
-    assert_interpreter_constraint_not_satisfied(["==3.8.*,!=3.8.*"])
     assert_interpreter_constraint_not_satisfied(["==3.9.*", "==2.6.*"])
 
 

--- a/tests/test_specifier_sets.py
+++ b/tests/test_specifier_sets.py
@@ -8,9 +8,17 @@ import sys
 import pytest
 
 from pex.pep_440 import Version
-from pex.specifier_sets import ExcludedRange, LowerBound, Range, UpperBound, as_range, includes
+from pex.specifier_sets import (
+    ExcludedRange,
+    LowerBound,
+    Range,
+    UnsatisfiableSpecifierSet,
+    UpperBound,
+    as_range,
+    includes,
+)
 from pex.third_party.packaging.specifiers import InvalidSpecifier
-from pex.typing import TYPE_CHECKING
+from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     pass
@@ -302,3 +310,19 @@ def test_wildcard_version_suffix_handling():
 
     # Local-release specifiers.
     assert_wildcard_handling("+bob")
+
+
+def test_unsatisfiable():
+    # type: () -> None
+
+    assert isinstance(as_range(">3,<2"), UnsatisfiableSpecifierSet)
+
+    assert isinstance(as_range(">=2.7,<2.7"), UnsatisfiableSpecifierSet)
+    assert isinstance(as_range(">2.7,<=2.7"), UnsatisfiableSpecifierSet)
+    assert isinstance(as_range(">2.7,<2.7"), UnsatisfiableSpecifierSet)
+    assert cast(Range, as_range("==2.7")) in cast(Range, as_range(">=2.7,<=2.7"))
+
+    assert isinstance(as_range(">=3.8,!=3.8.*,!=3.9.*,<3.10"), UnsatisfiableSpecifierSet)
+
+    assert not includes(">2,<3", ">=2.7,<2.7")
+    assert not includes(">=2.7,<2.7", ">2,<3")


### PR DESCRIPTION
When `--interpreter-constraint`s are specified that are unsatisfiable,
Pex now either errors if all given interpreter constraints are
unsatisfiable or else warns and continues with only the remaining valid
interpreter constraints after culling the unsatisfiable ones.

Fixes #432