### PR TITLE
Fix Zip extraction UTF-8 handling for Python 2.7.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## 2.20.2
+
+This release fixes an old bug handling certain sdist zips under
+Python 2.7 as well missing support for Python 3.13's `PYTHON_COLORS`
+env var.
+
+* Fix Zip extraction UTF-8 handling for Python 2.7. (#2546)
+* Add repl support for `PYTHON_COLORS`. (#2545)
+
 ## 2.20.1
 
 This release fixes Pex `--interpreter-constraint` handling such that

--- a/pex/common.py
+++ b/pex/common.py
@@ -278,15 +278,11 @@ class ZipFileEx(ZipFile):
         efs_bit = 1 << 11  # type: ignore[unreachable]
 
         target_path = path or os.getcwd()
-        encoded_target_path = target_path.encode("utf-8")
         for member in members or self.infolist():
             info = member if isinstance(member, ZipInfo) else self.getinfo(member)
-            if info.flag_bits & efs_bit:
-                member_path = info.filename.encode("utf-8")  # type: Union[Text, bytes]
-                target = encoded_target_path  # type: Union[Text, bytes]
-            else:
-                member_path = info.filename
-                target = target_path
+            encoding = "utf-8" if info.flag_bits & efs_bit else "cp437"
+            member_path = info.filename.encode(encoding)
+            target = target_path.encode(encoding)
 
             rel_dir = os.path.dirname(member_path)
             abs_dir = os.path.join(target, rel_dir)

--- a/pex/layout.py
+++ b/pex/layout.py
@@ -11,14 +11,7 @@ from contextlib import contextmanager
 from pex.atomic_directory import atomic_directory
 from pex.cache import access as cache_access
 from pex.cache.dirs import CacheDir
-from pex.common import (
-    PermPreservingZipFile,
-    is_script,
-    open_zip,
-    safe_copy,
-    safe_mkdir,
-    safe_mkdtemp,
-)
+from pex.common import ZipFileEx, is_script, open_zip, safe_copy, safe_mkdir, safe_mkdtemp
 from pex.enum import Enum
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
@@ -395,7 +388,7 @@ class _ZipAppPEX(_Layout):
     def open(self):
         # type: () -> zipfile.ZipFile
         if self._zfp is None:
-            self._zfp = PermPreservingZipFile(self.path)
+            self._zfp = ZipFileEx(self.path)
         return self._zfp
 
     def __getstate__(self):

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.20.1"
+__version__ = "2.20.2"

--- a/tests/integration/test_issue_298.py
+++ b/tests/integration/test_issue_298.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os.path
+import shutil
+import subprocess
+from textwrap import dedent
+
+from pex.common import safe_open
+from pex.fetcher import URLFetcher
+from pex.typing import TYPE_CHECKING
+from testing.docker import skip_unless_docker
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+@skip_unless_docker
+def test_confounding_encoding(
+    tmpdir,  # type: Any
+    pex_project_dir,  # type: str
+):
+    # type: (...) -> None
+
+    sdists = os.path.join(str(tmpdir), "sdists")
+    with safe_open(
+        os.path.join(sdists, "CherryPy-7.1.0.zip"), "wb"
+    ) as write_fp, URLFetcher().get_body_stream(
+        "https://files.pythonhosted.org/packages/"
+        "b7/dd/e95de2d7042bd53009e8673ca489effebd4a35d9b64b75ecfcca160efaf6/CherryPy-7.1.0.zip"
+    ) as read_fp:
+        shutil.copyfileobj(read_fp, write_fp)
+
+    dest = os.path.join(str(tmpdir), "dest")
+    subprocess.check_call(
+        args=[
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            "{code}:/code".format(code=pex_project_dir),
+            "-w",
+            "/code",
+            "-v",
+            "{sdists}:/sdists".format(sdists=sdists),
+            "-v",
+            "{dest}:/dest".format(dest=dest),
+            "-e",
+            "LANG=en_US.ISO-8859-1",
+            "python:2.7-slim",
+            "python2.7",
+            "-c",
+            dedent(
+                """\
+                from __future__ import absolute_import
+
+                import os
+                import zipfile
+
+                from pex.common import open_zip
+
+
+                with zipfile.ZipFile("/sdists/CherryPy-7.1.0.zip") as zf:
+                    try:
+                        zf.extractall("/dest")
+                        raise AssertionError(
+                            "Expected standard Python 2.7 ZipFile.extractall to fail."
+                        )
+                    except UnicodeEncodeError as e:
+                        pass
+
+                with open_zip("/sdists/CherryPy-7.1.0.zip") as zf:
+                    zf.extractall("/dest")
+                """
+            ),
+        ]
+    )
+
+    assert os.path.isfile(
+        os.path.join(dest, "CherryPy-7.1.0", "cherrypy", "test", "static", "Слава Україні.html")
+    )

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -9,7 +9,7 @@ import pytest
 
 from pex.common import (
     Chroot,
-    PermPreservingZipFile,
+    ZipFileEx,
     can_write_dir,
     chmod_plus_x,
     deterministic_walk,
@@ -51,7 +51,7 @@ def zip_fixture():
         assert extract_perms(one) != extract_perms(two)
 
         zip_file = os.path.join(target_dir, "test.zip")
-        with contextlib.closing(PermPreservingZipFile(zip_file, "w")) as zf:
+        with contextlib.closing(ZipFileEx(zip_file, "w")) as zf:
             zf.write(one, "one")
             zf.write(two, "two")
 
@@ -61,7 +61,7 @@ def zip_fixture():
 def test_perm_preserving_zipfile_extractall():
     # type: () -> None
     with zip_fixture() as (zip_file, extract_dir, one, two):
-        with contextlib.closing(PermPreservingZipFile(zip_file)) as zf:
+        with contextlib.closing(ZipFileEx(zip_file)) as zf:
             zf.extractall(extract_dir)
 
             assert extract_perms(one) == extract_perms(os.path.join(extract_dir, "one"))
@@ -71,7 +71,7 @@ def test_perm_preserving_zipfile_extractall():
 def test_perm_preserving_zipfile_extract():
     # type: () -> None
     with zip_fixture() as (zip_file, extract_dir, one, two):
-        with contextlib.closing(PermPreservingZipFile(zip_file)) as zf:
+        with contextlib.closing(ZipFileEx(zip_file)) as zf:
             zf.extract("one", path=extract_dir)
             zf.extract("two", path=extract_dir)
 
@@ -98,7 +98,7 @@ def assert_chroot_perms(copyfn):
             zip_path = os.path.join(src, "chroot.zip")
             chroot.zip(zip_path)
             with temporary_dir() as extract_dir:
-                with contextlib.closing(PermPreservingZipFile(zip_path)) as zf:
+                with contextlib.closing(ZipFileEx(zip_path)) as zf:
                     zf.extractall(extract_dir)
 
                     assert extract_perms(one) == extract_perms(os.path.join(extract_dir, "one"))

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -5,7 +5,7 @@ import re
 import pytest
 
 from pex.atomic_directory import AtomicDirectory
-from pex.common import PermPreservingZipFile
+from pex.common import ZipFileEx
 from pex.compatibility import PY2
 from pex.enum import Enum, qualified_name
 
@@ -116,9 +116,9 @@ def test_qualified_name():
         AtomicDirectory.work_dir
     ), "Expected @property to be handled."
 
-    expected_prefix = "pex.common." if PY2 else "pex.common.PermPreservingZipFile."
+    expected_prefix = "pex.common." if PY2 else "pex.common.ZipFileEx."
     assert expected_prefix + "zip_entry_from_file" == qualified_name(
-        PermPreservingZipFile.zip_entry_from_file
+        ZipFileEx.zip_entry_from_file
     ), "Expected @classmethod to be handled."
 
     class Test(object):


### PR DESCRIPTION
Previously, zips with non-ASCII file names could cause extraction errors
under Python 2.7 on Linux.

Fixes #298