### PR TITLE
Re-structure PEP-691 fingerprints db.

### DIFF
--- a/pex/cache/dirs.py
+++ b/pex/cache/dirs.py
@@ -22,12 +22,14 @@ class CacheDir(Enum["CacheDir.Value"]):
             version,  # type: int
             description,  # type: str
             dependencies=(),  # type: Iterable[CacheDir.Value]
+            can_purge=True,  # type: bool
         ):
             Enum.Value.__init__(self, value)
             self.name = name
             self.version = version
             self.description = description
             self.dependencies = tuple(dependencies)
+            self.can_purge = can_purge
 
         @property
         def rel_path(self):
@@ -74,6 +76,14 @@ class CacheDir(Enum["CacheDir.Value"]):
         version=0,
         name="Built Wheels",
         description="Wheels built by Pex from resolved sdists when creating PEX files.",
+    )
+
+    DBS = Value(
+        "dbs",
+        version=0,
+        name="Pex Internal Databases",
+        description="Databases Pex uses for caches and to track cache structure.",
+        can_purge=False,
     )
 
     DOCS = Value(

--- a/pex/cli/commands/cache/command.py
+++ b/pex/cli/commands/cache/command.py
@@ -99,7 +99,7 @@ class Cache(OutputMixin, BuildTimeCommand):
             "--entries",
             action="append",
             type=CacheDir.for_value,
-            choices=CacheDir.values(),
+            choices=[cache_dir for cache_dir in CacheDir.values() if cache_dir.can_purge],
             default=[],
             help=(
                 "Specific cache entries to purge. By default, all entries are purged, but by "


### PR DESCRIPTION
Use a `dbs` cache entry for all databases starting with PEP-691
fingerprints and hide this cache entry as a choice when purging
individual entries using `pex3 cache purge`.

Work towards #2528.