### PR TITLE
Regularize dogfood PEX cache use.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -23,7 +23,7 @@ from pex.commands.command import (
     global_environment,
     register_global_arguments,
 )
-from pex.common import CopyMode, die, is_pyc_dir, is_pyc_file, safe_mkdtemp
+from pex.common import CopyMode, die, is_pyc_dir, is_pyc_file
 from pex.dependency_configuration import DependencyConfiguration
 from pex.dependency_manager import DependencyManager
 from pex.dist_metadata import Requirement
@@ -923,10 +923,7 @@ def build_pex(
             preamble = preamble_fd.read()
 
     pex_builder = PEXBuilder(
-        path=safe_mkdtemp(),
-        interpreter=targets.interpreter,
-        preamble=preamble,
-        copy_mode=CopyMode.SYMLINK,
+        interpreter=targets.interpreter, preamble=preamble, copy_mode=CopyMode.SYMLINK
     )
 
     if options.resources_directory:

--- a/pex/build_system/pep_517.py
+++ b/pex/build_system/pep_517.py
@@ -47,7 +47,7 @@ def _default_build_system(
                 requires = ["setuptools", str(selected_pip_version.wheel_requirement)]
                 resolved_dists.extend(
                     Distribution.load(dist_location)
-                    for dist_location in third_party.expose(
+                    for dist_location in third_party.expose_installed_wheels(
                         ["setuptools"], interpreter=target.get_interpreter()
                     )
                 )

--- a/pex/build_system/pep_518.py
+++ b/pex/build_system/pep_518.py
@@ -7,7 +7,7 @@ import os.path
 import subprocess
 
 from pex.build_system import DEFAULT_BUILD_BACKEND
-from pex.common import REPRODUCIBLE_BUILDS_ENV
+from pex.common import REPRODUCIBLE_BUILDS_ENV, CopyMode
 from pex.dist_metadata import Distribution
 from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
@@ -85,7 +85,7 @@ class BuildSystem(object):
         **extra_env  # type: str
     ):
         # type: (...) -> Union[BuildSystem, Error]
-        pex_builder = PEXBuilder()
+        pex_builder = PEXBuilder(copy_mode=CopyMode.SYMLINK)
         pex_builder.info.venv = True
         pex_builder.info.venv_site_packages_copies = True
         pex_builder.info.venv_bin_path = BinPath.PREPEND

--- a/pex/pep_376.py
+++ b/pex/pep_376.py
@@ -19,7 +19,7 @@ from pex.interpreter import PythonInterpreter
 from pex.typing import TYPE_CHECKING, cast
 from pex.util import CacheHelper
 from pex.venv.virtualenv import Virtualenv
-from pex.wheel import WHEEL, WheelMetadataLoadError
+from pex.wheel import WHEEL, Wheel, WheelMetadataLoadError
 
 if TYPE_CHECKING:
     from typing import Callable, Iterable, Iterator, Optional, Protocol, Text, Tuple, Union
@@ -240,6 +240,10 @@ class InstalledWheel(object):
     record_relpath = attr.ib()  # type: Text
     fingerprint = attr.ib()  # type: Optional[str]
     root_is_purelib = attr.ib()  # type: bool
+
+    def wheel_file_name(self):
+        # type: () -> str
+        return Wheel.load(self.prefix_dir).wheel_file_name
 
     def stashed_path(self, *components):
         # type: (*str) -> str

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -179,31 +179,6 @@ class PEXBuilder(object):
         # type: () -> Chroot
         return self._chroot
 
-    def clone(self, into=None):
-        """Clone this PEX environment into a new PEXBuilder.
-
-        :keyword into: (optional) An optional destination directory to clone this PEXBuilder into.  If
-          not specified, a temporary directory will be created.
-
-        Clones PEXBuilder into a new location.  This is useful if the PEXBuilder has been frozen and
-        rendered immutable.
-
-        .. versionchanged:: 0.8
-          The temporary directory created when ``into`` is not specified is now garbage collected on
-          interpreter exit.
-        """
-        chroot_clone = self._chroot.clone(into=into)
-        clone = self.__class__(
-            chroot=chroot_clone,
-            interpreter=self._interpreter,
-            pex_info=self._pex_info.copy(),
-            preamble=self._preamble,
-            copy_mode=self._copy_mode,
-        )
-        clone.set_shebang(self._shebang)
-        clone._distributions = self._distributions.copy()
-        return clone
-
     def path(self):
         # type: () -> str
         return self.chroot().path()


### PR DESCRIPTION
The internal PEP-517/518 build system PEXes and the Pip PEXes now both
uniformly use the equivalent of `--layout loose --venv` where
distribution dependencies are always symlinks to the `installed_wheels`
cache. This helps cut down on overall cache size slightly, but also
improves the uniformity of the dogfood.