### PR TITLE
Fix `--venv` cached Python interpreter info.

### DIFF
--- a/pex/cache/dirs.py
+++ b/pex/cache/dirs.py
@@ -112,7 +112,7 @@ class CacheDir(Enum["CacheDir.Value"]):
 
     INTERPRETERS = Value(
         "interpreters",
-        version=0,
+        version=1,
         name="Interpreters",
         description="Information about interpreters found on the system.",
     )


### PR DESCRIPTION
Previously, the work dir path of the `atomic_directory` used to create
the venv would leak into various cached paths in the `PythonInterpreter`
`INTERP-INFO` file. Now, these paths are corrected at creation time.

This is work towards `pex3 cache prune --last-access` which will need to
iterate cached interpreters to find any associated with venvs such that
the interpreter can be pruned when the venv is pruned.