### PR TITLE
Fix `pex3 cache prune` handling of cached Pips.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## 2.24.1
+
+This release fixes `pex3 cache prune` handling of cached Pips.
+Previously, performing a `pex3 cache prune` would bump the last access
+time of all un-pruned cached Pips artificially. If you ran
+`pex3 cache prune` in a daily or weekly cron job, this would mean Pips
+would never be pruned.
+
+* Fix `pex3 cache prune` handling of cached Pips. (#2589)
+
 ## 2.24.0
 
 This release adds `pex3 cache prune` as a likely more useful Pex cache

--- a/pex/cache/dirs.py
+++ b/pex/cache/dirs.py
@@ -189,7 +189,7 @@ class CacheDir(Enum["CacheDir.Value"]):
 
     UNZIPPED_PEXES = Value(
         "unzipped_pexes",
-        version=0,
+        version=1,
         name="Unzipped PEXes",
         description="The unzipped PEX files executed on this machine.",
         dependencies=[BOOTSTRAPS, USER_CODE, INSTALLED_WHEELS],
@@ -197,7 +197,7 @@ class CacheDir(Enum["CacheDir.Value"]):
 
     VENVS = Value(
         "venvs",
-        version=0,
+        version=1,
         name="Virtual Environments",
         description="Virtual environments generated at runtime for `--venv` mode PEXes.",
         dependencies=[INSTALLED_WHEELS],

--- a/pex/cache/prunable.py
+++ b/pex/cache/prunable.py
@@ -42,30 +42,23 @@ else:
 
 
 @attr.s(frozen=True)
-class PrunablePipCache(object):
-    pip = attr.ib()  # type: Pip
-    pex_dir = attr.ib()  # type: Union[UnzipDir, VenvDirs]
-    last_access = attr.ib()  # type: float
-
-
-@attr.s(frozen=True)
 class Pips(object):
     @classmethod
     def scan(cls, pex_dirs_by_hash):
-        # type: (Mapping[str, Tuple[Union[UnzipDir, VenvDirs], float, bool]]) -> Pips
+        # type: (Mapping[str, Tuple[Union[UnzipDir, VenvDirs], bool]]) -> Pips
 
         # True to prune the Pip version completely, False to just prune the Pip PEX.
         pips_to_prune = OrderedDict()  # type: OrderedDict[Pip, bool]
 
         # N.B.: We just need 1 Pip per version (really per paired cache). Whether a Pip has
         # extra requirements installed does not affect cache management.
-        pip_caches_to_prune = OrderedDict()  # type: OrderedDict[PipVersionValue, PrunablePipCache]
-        for pip in iter_all_pips():
-            pex_dir, last_access, prunable = pex_dirs_by_hash[pip.pex_hash]
+        pip_caches_to_prune = OrderedDict()  # type: OrderedDict[PipVersionValue, Pip]
+        for pip in iter_all_pips(record_access=False):
+            pex_dir, prunable = pex_dirs_by_hash[pip.pex_hash]
             if prunable:
                 pips_to_prune[pip] = False
             else:
-                pip_caches_to_prune[pip.version] = PrunablePipCache(pip, pex_dir, last_access)
+                pip_caches_to_prune[pip.version] = pip
         for pip in pips_to_prune:
             if pip.version not in pip_caches_to_prune:
                 pips_to_prune[pip] = True
@@ -74,10 +67,10 @@ class Pips(object):
             (pip.pex_dir.base_dir if prune_version else pip.pex_dir.path)
             for pip, prune_version in pips_to_prune.items()
         )
-        return cls(paths=pip_paths_to_prune, caches=tuple(pip_caches_to_prune.values()))
+        return cls(paths=pip_paths_to_prune, pips=tuple(pip_caches_to_prune.values()))
 
     paths = attr.ib()  # type: Tuple[str, ...]
-    caches = attr.ib()  # type: Tuple[PrunablePipCache, ...]
+    pips = attr.ib()  # type: Tuple[Pip, ...]
 
 
 @attr.s(frozen=True)
@@ -107,7 +100,7 @@ class Prunable(object):
             OrderedSet()
         )  # type: OrderedSet[Union[BootstrapDir, UserCodeDir, InstalledWheelDir]]
         unprunable_deps = []  # type: List[Union[BootstrapDir, UserCodeDir, InstalledWheelDir]]
-        pex_dirs_by_hash = {}  # type: Dict[str, Tuple[Union[UnzipDir, VenvDirs], float, bool]]
+        pex_dirs_by_hash = {}  # type: Dict[str, Tuple[Union[UnzipDir, VenvDirs], bool]]
         for pex_dir, last_access in access.iter_all_cached_pex_dirs():
             prunable = pex_dir in prunable_pex_dirs
             if prunable:
@@ -115,7 +108,7 @@ class Prunable(object):
                 pex_deps.update(pex_dir.iter_deps())
             else:
                 unprunable_deps.extend(pex_dir.iter_deps())
-            pex_dirs_by_hash[pex_dir.pex_hash] = pex_dir, last_access, prunable
+            pex_dirs_by_hash[pex_dir.pex_hash] = pex_dir, prunable
         pips = Pips.scan(pex_dirs_by_hash)
 
         return cls(

--- a/pex/common.py
+++ b/pex/common.py
@@ -532,11 +532,19 @@ def can_write_dir(path):
     return os.path.isdir(path) and os.access(path, os.R_OK | os.W_OK | os.X_OK)
 
 
-def touch(file):
-    # type: (_Text) -> _Text
-    """Equivalent of unix `touch path`."""
+def touch(
+    file,  # type: _Text
+    times=None,  # type: Optional[Union[int, float, Tuple[int, int], Tuple[float, float]]]
+):
+    # type: (...) -> _Text
+    """Equivalent of unix `touch path`.
+
+    If no times is passed, the current time is used to set atime and mtime. If a single int or float
+    is passed for times, it is used for both atime and mtime. If a 2-tuple of ints or floats is
+    passed, the 1st slot is the atime and the 2nd the mtime, just as for `os.utime`.
+    """
     with safe_open(file, "a"):
-        os.utime(file, None)
+        os.utime(file, (times, times) if isinstance(times, (int, float)) else times)
     return file
 
 

--- a/pex/layout.py
+++ b/pex/layout.py
@@ -320,8 +320,6 @@ def _ensure_installed(
         if not os.path.exists(install_to):
             with ENV.patch(PEX_ROOT=pex_root):
                 cache_access.read_write()
-        else:
-            cache_access.record_access(install_to)
         with atomic_directory(install_to) as chroot:
             if not chroot.is_finalized():
                 with ENV.patch(PEX_ROOT=pex_root), TRACER.timed(
@@ -374,6 +372,7 @@ def _ensure_installed(
                     layout.extract_pex_info(chroot.work_dir)
                     layout.extract_main(chroot.work_dir)
                     layout.record(chroot.work_dir)
+        cache_access.record_access(install_to)
         return install_to
 
 

--- a/pex/pex_bootstrapper.py
+++ b/pex/pex_bootstrapper.py
@@ -507,6 +507,7 @@ def ensure_venv(
     pex,  # type: PEX
     collisions_ok=True,  # type: bool
     copy_mode=None,  # type: Optional[CopyMode.Value]
+    record_access=True,  # type: bool
 ):
     # type: (...) -> VenvPex
     pex_info = pex.pex_info()
@@ -524,8 +525,6 @@ def ensure_venv(
     if not os.path.exists(venv_dir):
         with ENV.patch(PEX_ROOT=pex_info.pex_root):
             cache_access.read_write()
-    else:
-        cache_access.record_access(venv_dir)
     with atomic_directory(venv_dir) as venv:
         if not venv.is_finalized():
             from pex.venv.virtualenv import Virtualenv
@@ -626,7 +625,8 @@ def ensure_venv(
                                 )
 
                             break
-
+    if record_access:
+        cache_access.record_access(venv_dir)
     return VenvPex(venv_dir, hermetic_scripts=pex_info.venv_hermetic_scripts)
 
 

--- a/pex/pip/installation.py
+++ b/pex/pip/installation.py
@@ -45,6 +45,7 @@ def _create_pip(
     pip_pex,  # type: PipPexDir
     interpreter=None,  # type: Optional[PythonInterpreter]
     use_system_time=False,  # type: bool
+    record_access=True,  # type: bool
 ):
     # type: (...) -> Pip
 
@@ -52,7 +53,7 @@ def _create_pip(
 
     pip_interpreter = interpreter or PythonInterpreter.get()
     pex = PEX(pip_pex.path, interpreter=pip_interpreter)
-    venv_pex = ensure_venv(pex, copy_mode=CopyMode.SYMLINK)
+    venv_pex = ensure_venv(pex, copy_mode=CopyMode.SYMLINK, record_access=record_access)
     pex_hash = pex.pex_info().pex_hash
     production_assert(pex_hash is not None)
     pip_venv = PipVenv(
@@ -512,8 +513,14 @@ def iter_all(
     interpreter=None,  # type: Optional[PythonInterpreter]
     use_system_time=False,  # type: bool
     pex_root=ENV,  # type: Union[str, Variables]
+    record_access=True,  # type: bool
 ):
     # type: (...) -> Iterator[Pip]
 
     for pip_pex in PipPexDir.iter_all(pex_root=pex_root):
-        yield _create_pip(pip_pex, interpreter=interpreter, use_system_time=use_system_time)
+        yield _create_pip(
+            pip_pex,
+            interpreter=interpreter,
+            use_system_time=use_system_time,
+            record_access=record_access,
+        )

--- a/pex/venv/installer.py
+++ b/pex/venv/installer.py
@@ -10,6 +10,7 @@ from collections import Counter, OrderedDict, defaultdict
 from textwrap import dedent
 
 from pex import layout, pex_warnings, repl
+from pex.cache import access as cache_access
 from pex.common import CopyMode, chmod_plus_x, iter_copytree, pluralize
 from pex.compatibility import is_valid_python_identifier
 from pex.dist_metadata import Distribution
@@ -534,6 +535,7 @@ class PEXSources(object):
                 "__main__.py",
                 "__pex__",
                 "__pycache__",
+                cache_access.LAST_ACCESS_FILE,
                 layout.BOOTSTRAP_DIR,
                 layout.DEPS_DIR,
                 layout.PEX_INFO_PATH,

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.24.0"
+__version__ = "2.24.1"


### PR DESCRIPTION
Previously, performing a `pex3 cache prune` would bump the last access
time of all un-pruned cached Pips artificially. If you ran
`pex3 cache prune` in a daily or weekly cron job, this would mean Pips
would never be pruned.