### PR TITLE
Use the default multiprocessing pool configuration.

### DIFF
--- a/pex/commands/command.py
+++ b/pex/commands/command.py
@@ -17,7 +17,7 @@ from subprocess import CalledProcessError
 from pex import pex_warnings
 from pex.argparse import HandleBoolAction
 from pex.cache import access as cache_access
-from pex.common import safe_mkdtemp, safe_open
+from pex.common import environment_as, safe_mkdtemp, safe_open
 from pex.compatibility import shlex_quote
 from pex.result import Error, Ok, Result
 from pex.typing import TYPE_CHECKING, Generic, cast
@@ -379,7 +379,7 @@ def global_environment(options):
             else:
                 pex_root = options.cache_dir or options.pex_root or ENV.PEX_ROOT
 
-            with ENV.patch(PEX_ROOT=pex_root, TMPDIR=tmpdir) as env:
+            with ENV.patch(PEX_ROOT=pex_root, TMPDIR=tmpdir) as env, environment_as(**env):
                 cache_access.read_write()
                 yield env
 

--- a/pex/jobs.py
+++ b/pex/jobs.py
@@ -17,7 +17,7 @@ from threading import BoundedSemaphore, Event, Thread
 from pex.common import pluralize
 from pex.compatibility import Queue, cpu_count
 from pex.tracer import TRACER
-from pex.typing import TYPE_CHECKING, Generic, cast
+from pex.typing import TYPE_CHECKING, Generic
 
 if TYPE_CHECKING:
     from typing import (
@@ -679,12 +679,8 @@ if TYPE_CHECKING:
 @contextmanager
 def _mp_pool(size):
     # type: (int) -> Iterator[Pool]
-    try:
-        context = multiprocessing.get_context("fork")  # type: ignore[attr-defined]
-        pool = cast("Pool", context.Pool(processes=size))
-    except (AttributeError, ValueError):
-        pool = multiprocessing.Pool(processes=size)
 
+    pool = multiprocessing.Pool(processes=size)
     try:
         yield pool
     finally:

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -675,25 +675,6 @@ def all_python_venvs(system_site_packages=False):
 
 
 @contextmanager
-def environment_as(**kwargs):
-    # type: (**Any) -> Iterator[None]
-    existing = {key: os.environ.get(key) for key in kwargs}
-
-    def adjust_environment(mapping):
-        for key, value in mapping.items():
-            if value is not None:
-                os.environ[key] = str(value)
-            else:
-                os.environ.pop(key, None)
-
-    adjust_environment(kwargs)
-    try:
-        yield
-    finally:
-        adjust_environment(existing)
-
-
-@contextmanager
 def pushd(directory):
     # type: (Text) -> Iterator[None]
     cwd = os.getcwd()

--- a/tests/integration/cli/commands/test_cache_prune.py
+++ b/tests/integration/cli/commands/test_cache_prune.py
@@ -27,13 +27,13 @@ from pex.cache.dirs import (
     VenvDirs,
 )
 from pex.cli.commands.cache.du import DiskUsage
-from pex.common import safe_open
+from pex.common import environment_as, safe_open
 from pex.pep_503 import ProjectName
 from pex.pex_info import PexInfo
 from pex.pip.version import PipVersion, PipVersionValue
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
-from testing import environment_as, run_pex_command
+from testing import run_pex_command
 from testing.cli import run_pex3
 from testing.pytest.tmp import Tempdir
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -19,7 +19,15 @@ import pytest
 
 from pex import targets
 from pex.cache.dirs import CacheDir, InterpreterDir
-from pex.common import is_exe, safe_mkdir, safe_open, safe_rmtree, temporary_dir, touch
+from pex.common import (
+    environment_as,
+    is_exe,
+    safe_mkdir,
+    safe_open,
+    safe_rmtree,
+    temporary_dir,
+    touch,
+)
 from pex.compatibility import WINDOWS, commonpath
 from pex.dist_metadata import Distribution, Requirement, is_wheel
 from pex.fetcher import URLFetcher
@@ -46,7 +54,6 @@ from testing import (
     IntegResults,
     built_wheel,
     ensure_python_interpreter,
-    environment_as,
     get_dep_dist_names_from_pex,
     make_env,
     run_pex_command,

--- a/tests/integration/test_issue_157.py
+++ b/tests/integration/test_issue_157.py
@@ -14,10 +14,11 @@ import pexpect  # type: ignore[import]  # MyPy can't see the types under Python 
 import pytest
 from colors import color  # vendor:skip
 
+from pex.common import environment_as
 from pex.pex_info import PexInfo
 from pex.typing import TYPE_CHECKING
 from pex.version import __version__
-from testing import IS_PYPY, environment_as, make_env, run_pex_command, scie
+from testing import IS_PYPY, make_env, run_pex_command, scie
 
 if TYPE_CHECKING:
     from typing import Any, Iterable, Iterator, List, Tuple

--- a/tests/resolve/test_target_options.py
+++ b/tests/resolve/test_target_options.py
@@ -10,6 +10,7 @@ from argparse import ArgumentParser, ArgumentTypeError
 import pytest
 
 import pex.resolve.target_configuration
+from pex.common import environment_as
 from pex.interpreter import PythonInterpreter
 from pex.pep_425 import CompatibilityTags
 from pex.pep_508 import MarkerEnvironment
@@ -20,7 +21,7 @@ from pex.resolve.target_configuration import InterpreterConstraintsNotSatisfied
 from pex.targets import CompletePlatform, Targets
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
-from testing import IS_MAC, environment_as
+from testing import IS_MAC
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Iterable, List, Optional, Tuple, Type

--- a/tests/test_atomic_directory.py
+++ b/tests/test_atomic_directory.py
@@ -9,9 +9,8 @@ from contextlib import contextmanager
 import pytest
 
 from pex.atomic_directory import AtomicDirectory, FileLockStyle, _is_bsd_lock, atomic_directory
-from pex.common import temporary_dir, touch
+from pex.common import environment_as, temporary_dir, touch
 from pex.typing import TYPE_CHECKING
-from testing import environment_as
 
 try:
     from unittest import mock

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -14,7 +14,7 @@ from textwrap import dedent
 import pytest
 
 from pex.cache.dirs import InterpreterDir
-from pex.common import chmod_plus_x, safe_mkdir, safe_mkdtemp, temporary_dir, touch
+from pex.common import chmod_plus_x, environment_as, safe_mkdir, safe_mkdtemp, temporary_dir, touch
 from pex.executor import Executor
 from pex.interpreter import PythonInterpreter, create_shebang
 from pex.jobs import Job
@@ -30,7 +30,6 @@ from testing import (
     ensure_python_distribution,
     ensure_python_interpreter,
     ensure_python_venv,
-    environment_as,
     pushd,
 )
 from testing.pytest.tmp import TempdirFactory

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -16,7 +16,7 @@ from types import ModuleType
 import pytest
 
 from pex import resolver
-from pex.common import safe_mkdir, safe_open, temporary_dir
+from pex.common import environment_as, safe_mkdir, safe_open, temporary_dir
 from pex.compatibility import PY2, WINDOWS, to_bytes
 from pex.dist_metadata import Distribution
 from pex.interpreter import PythonIdentity, PythonInterpreter
@@ -33,7 +33,6 @@ from testing import (
     PY_VER,
     WheelBuilder,
     ensure_python_interpreter,
-    environment_as,
     install_wheel,
     make_bdist,
     run_simple_pex,

--- a/tests/test_pip.py
+++ b/tests/test_pip.py
@@ -13,7 +13,7 @@ from typing import Dict
 
 import pytest
 
-from pex.common import safe_rmtree
+from pex.common import environment_as, safe_rmtree
 from pex.dist_metadata import Distribution, Requirement
 from pex.interpreter import PythonInterpreter
 from pex.jobs import Job
@@ -29,7 +29,7 @@ from pex.targets import AbbreviatedPlatform, LocalInterpreter, Target
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
 from pex.venv.virtualenv import Virtualenv
-from testing import IS_LINUX, PY310, ensure_python_interpreter, environment_as
+from testing import IS_LINUX, PY310, ensure_python_interpreter
 from testing.pytest.tmp import Tempdir
 
 if TYPE_CHECKING:

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -8,7 +8,7 @@ from textwrap import dedent
 
 import pytest
 
-from pex.common import safe_open, temporary_dir, touch
+from pex.common import environment_as, safe_open, temporary_dir, touch
 from pex.dist_metadata import Requirement
 from pex.fetcher import URLFetcher
 from pex.requirements import (
@@ -30,7 +30,6 @@ from pex.requirements import (
 )
 from pex.third_party.packaging.markers import Marker
 from pex.typing import TYPE_CHECKING
-from testing import environment_as
 
 if TYPE_CHECKING:
     from typing import Any, Iterable, Iterator, List, Optional, Union

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -7,12 +7,12 @@ import warnings
 import pytest
 
 from pex import pex_warnings
+from pex.common import environment_as
 from pex.compatibility import PY2
 from pex.pex_warnings import PEXWarning
 from pex.typing import TYPE_CHECKING
 from pex.util import named_temporary_file
 from pex.variables import NoValueError, Variables
-from testing import environment_as
 from testing.pytest.tmp import Tempdir
 
 if TYPE_CHECKING:


### PR DESCRIPTION
Previously we were forcing use of fork for all OSes to try to juice
performance at the cost of running into threading issues at some point
when things got more complex. They may have reached that point with CI
lockups happening on macOS. Revert to the default pool setup to attempt
to fix macOS hangs.

To support this, also propagate any CLI global `Variables` adjustments
to subprocesses. Previously these were only propagated for the current
process; now the adjustments propagate through the environment so that
subprocesses see the same adjustments. In particular, this ensures
subprocesses use the same `PEX_ROOT` when a fallback has to be used to
work around lack of write perms.