### PR TITLE
Add `--elide-unused-requires-dist` lock option.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## 2.25.0
+
+This release adds support for
+`pex3 lock {create,sync} --elide-unused-requires-dist`. This new lock
+option causes any dependencies of a locked requirement that can never
+be activated to be elided from the lock file. This leads to no material
+difference in lock file use, but it does cut down on the lock file size.
+
+* Add `--elide-unused-requires-dist` lock option. (#2613)
+
 ## 2.24.3
 
 This release fixes a long-standing bug in resolve checking. Previously,

--- a/package/pex-scie.lock
+++ b/package/pex-scie.lock
@@ -4,6 +4,7 @@
   "allow_wheels": true,
   "build_isolation": true,
   "constraints": [],
+  "elide_unused_requires_dist": true,
   "excluded": [],
   "locked_resolves": [
     {
@@ -17,13 +18,7 @@
             }
           ],
           "project_name": "psutil",
-          "requires_dists": [
-            "enum34; python_version <= \"3.4\" and extra == \"test\"",
-            "ipaddress; python_version < \"3.0\" and extra == \"test\"",
-            "mock; python_version < \"3.0\" and extra == \"test\"",
-            "pywin32; sys_platform == \"win32\" and extra == \"test\"",
-            "wmi; sys_platform == \"win32\" and extra == \"test\""
-          ],
+          "requires_dists": [],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
           "version": "6.0.0"
         }
@@ -45,13 +40,7 @@
             }
           ],
           "project_name": "psutil",
-          "requires_dists": [
-            "enum34; python_version <= \"3.4\" and extra == \"test\"",
-            "ipaddress; python_version < \"3.0\" and extra == \"test\"",
-            "mock; python_version < \"3.0\" and extra == \"test\"",
-            "pywin32; sys_platform == \"win32\" and extra == \"test\"",
-            "wmi; sys_platform == \"win32\" and extra == \"test\""
-          ],
+          "requires_dists": [],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
           "version": "6.0.0"
         }
@@ -73,13 +62,7 @@
             }
           ],
           "project_name": "psutil",
-          "requires_dists": [
-            "enum34; python_version <= \"3.4\" and extra == \"test\"",
-            "ipaddress; python_version < \"3.0\" and extra == \"test\"",
-            "mock; python_version < \"3.0\" and extra == \"test\"",
-            "pywin32; sys_platform == \"win32\" and extra == \"test\"",
-            "wmi; sys_platform == \"win32\" and extra == \"test\""
-          ],
+          "requires_dists": [],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
           "version": "6.0.0"
         }
@@ -101,13 +84,7 @@
             }
           ],
           "project_name": "psutil",
-          "requires_dists": [
-            "enum34; python_version <= \"3.4\" and extra == \"test\"",
-            "ipaddress; python_version < \"3.0\" and extra == \"test\"",
-            "mock; python_version < \"3.0\" and extra == \"test\"",
-            "pywin32; sys_platform == \"win32\" and extra == \"test\"",
-            "wmi; sys_platform == \"win32\" and extra == \"test\""
-          ],
+          "requires_dists": [],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
           "version": "6.0.0"
         }
@@ -123,8 +100,8 @@
   "only_wheels": [],
   "overridden": [],
   "path_mappings": {},
-  "pex_version": "2.17.0",
-  "pip_version": "24.2",
+  "pex_version": "2.24.3",
+  "pip_version": "24.3.1",
   "prefer_older_binary": false,
   "requirements": [
     "psutil>=5.3"
@@ -134,5 +111,6 @@
   "style": "strict",
   "target_systems": [],
   "transitive": true,
-  "use_pep517": null
+  "use_pep517": null,
+  "use_system_time": false
 }

--- a/pex/resolve/lock_downloader.py
+++ b/pex/resolve/lock_downloader.py
@@ -25,7 +25,6 @@ from pex.resolve.locked_resolve import (
     DownloadableArtifact,
     FileArtifact,
     LocalProjectArtifact,
-    LockConfiguration,
     VCSArtifact,
 )
 from pex.resolve.lockfile.download_manager import DownloadedArtifact, DownloadManager
@@ -233,11 +232,7 @@ class LockDownloader(object):
                 file_lock_style=file_lock_style,
                 downloader=ArtifactDownloader(
                     resolver=resolver,
-                    lock_configuration=LockConfiguration(
-                        style=lock.style,
-                        requires_python=lock.requires_python,
-                        target_systems=lock.target_systems,
-                    ),
+                    lock_configuration=lock.lock_configuration(),
                     target=target,
                     package_index_configuration=PackageIndexConfiguration.create(
                         pip_version=pip_version,

--- a/pex/resolve/locked_resolve.py
+++ b/pex/resolve/locked_resolve.py
@@ -87,6 +87,7 @@ class LockConfiguration(object):
     style = attr.ib()  # type: LockStyle.Value
     requires_python = attr.ib(default=())  # type: Tuple[str, ...]
     target_systems = attr.ib(default=())  # type: Tuple[TargetSystem.Value, ...]
+    elide_unused_requires_dist = attr.ib(default=False)  # type: bool
 
     @requires_python.validator
     @target_systems.validator

--- a/pex/resolve/lockfile/create.py
+++ b/pex/resolve/lockfile/create.py
@@ -341,9 +341,11 @@ class LockObserver(ResolveObserver):
                     package_index_configuration=self.package_index_configuration,
                     max_parallel_jobs=self.max_parallel_jobs,
                 ),
-                platform_tag=None
-                if self.lock_configuration.style == LockStyle.UNIVERSAL
-                else target.platform.tag,
+                platform_tag=(
+                    None
+                    if self.lock_configuration.style == LockStyle.UNIVERSAL
+                    else target.platform.tag
+                ),
             )
             for target, resolved_requirements in resolved_requirements_by_target.items()
         )
@@ -456,6 +458,7 @@ def create(
         excluded=dependency_configuration.excluded,
         overridden=dependency_configuration.all_overrides(),
         locked_resolves=locked_resolves,
+        elide_unused_requires_dist=lock_configuration.elide_unused_requires_dist,
     )
 
     if lock_configuration.style is LockStyle.UNIVERSAL and (

--- a/pex/resolve/lockfile/json_codec.py
+++ b/pex/resolve/lockfile/json_codec.py
@@ -209,6 +209,8 @@ def loads(
         for index, target_system in enumerate(get("target_systems", list, optional=True) or ())
     ]
 
+    elide_unused_requires_dist = get("elide_unused_requires_dist", bool, optional=True) or False
+
     only_wheels = [
         parse_project_name(project_name, path=".only_wheels[{index}]".format(index=index))
         for index, project_name in enumerate(get("only_wheels", list, optional=True) or ())
@@ -231,7 +233,7 @@ def loads(
         for index, constraint in enumerate(get("constraints", list))
     ]
 
-    use_system_time = get("use_system_time", bool, optional=True)
+    use_system_time = get("use_system_time", bool, optional=True) or False
 
     excluded = [
         parse_requirement(req, path=".excluded[{index}]".format(index=index))
@@ -337,6 +339,7 @@ def loads(
         style=get_enum_value(LockStyle, "style"),
         requires_python=get("requires_python", list),
         target_systems=target_systems,
+        elide_unused_requires_dist=elide_unused_requires_dist,
         pip_version=get_enum_value(
             PipVersion,
             "pip_version",
@@ -354,10 +357,7 @@ def loads(
             prefer_older_binary=get("prefer_older_binary", bool),
             use_pep517=get("use_pep517", bool, optional=True),
             build_isolation=get("build_isolation", bool),
-            # N.B.: Although locks are now always generated under SOURCE_DATE_EPOCH=fixed and
-            # PYTHONHASHSEED=0 (aka: `use_system_time=False`), that did not use to be the case. In
-            # those old locks there was no "use_system_time" field.
-            use_system_time=use_system_time if use_system_time is not None else True,
+            use_system_time=use_system_time,
         ),
         transitive=get("transitive", bool),
         excluded=excluded,
@@ -391,6 +391,7 @@ def as_json_data(
         "style": str(lockfile.style),
         "requires_python": list(lockfile.requires_python),
         "target_systems": [str(target_system) for target_system in lockfile.target_systems],
+        "elide_unused_requires_dist": lockfile.elide_unused_requires_dist,
         "pip_version": str(lockfile.pip_version),
         "resolver_version": str(lockfile.resolver_version),
         "requirements": [

--- a/pex/resolve/lockfile/requires_dist.py
+++ b/pex/resolve/lockfile/requires_dist.py
@@ -1,0 +1,162 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import operator
+from collections import defaultdict, deque
+
+from pex.dist_metadata import Requirement
+from pex.exceptions import production_assert
+from pex.orderedset import OrderedSet
+from pex.pep_503 import ProjectName
+from pex.resolve.locked_resolve import LockedRequirement, LockedResolve
+from pex.sorted_tuple import SortedTuple
+from pex.third_party.packaging.markers import Marker, Variable
+from pex.typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from typing import Callable, DefaultDict, Dict, Iterable, List, Optional, Tuple, Union
+
+    import attr  # vendor:skip
+
+    EvalExtra = Callable[[ProjectName], bool]
+else:
+    from pex.third_party import attr
+
+
+_OPERATORS = {
+    "in": lambda lhs, rhs: lhs in rhs,
+    "not in": lambda lhs, rhs: lhs not in rhs,
+    "<": operator.lt,
+    "<=": operator.le,
+    "==": operator.eq,
+    "!=": operator.ne,
+    ">=": operator.ge,
+    ">": operator.gt,
+}
+
+
+class _Op(object):
+    def __init__(self, lhs):
+        self.lhs = lhs  # type: EvalExtra
+        self.rhs = None  # type: Optional[EvalExtra]
+
+
+class _And(_Op):
+    def __call__(self, extra):
+        # type: (ProjectName) -> bool
+        production_assert(self.rhs is not None)
+        return self.lhs(extra) and cast("EvalExtra", self.rhs)(extra)
+
+
+class _Or(_Op):
+    def __call__(self, extra):
+        # type: (ProjectName) -> bool
+        production_assert(self.rhs is not None)
+        return self.lhs(extra) or cast("EvalExtra", self.rhs)(extra)
+
+
+def _parse_extra_item(
+    stack,  # type: List[EvalExtra]
+    item,  # type: Union[str, List, Tuple]
+    marker,  # type: Marker
+):
+    # type: (...) -> None
+
+    if item == "and":
+        stack.append(_And(stack.pop()))
+    elif item == "or":
+        stack.append(_Or(stack.pop()))
+    elif isinstance(item, list):
+        for element in item:
+            _parse_extra_item(stack, element, marker)
+    elif isinstance(item, tuple):
+        lhs, op, rhs = item
+        if isinstance(lhs, Variable) and "extra" == str(lhs):
+            check = lambda extra: _OPERATORS[str(op)](extra, ProjectName(str(rhs)))
+        elif isinstance(rhs, Variable) and "extra" == str(rhs):
+            check = lambda extra: _OPERATORS[str(op)](extra, ProjectName(str(lhs)))
+        else:
+            # Any other condition could potentially be true.
+            check = lambda _: True
+        if stack:
+            production_assert(isinstance(stack[-1], _Op))
+            cast(_Op, stack[-1]).rhs = check
+        else:
+            stack.append(check)
+    else:
+        raise ValueError("Marker is invalid: {marker}".format(marker=marker))
+
+
+def _parse_extra_check(marker):
+    # type: (Marker) -> EvalExtra
+    checks = []  # type: List[EvalExtra]
+    for item in marker._markers:
+        _parse_extra_item(checks, item, marker)
+    production_assert(len(checks) == 1)
+    return checks[0]
+
+
+_EXTRA_CHECKS = {}  # type: Dict[str, EvalExtra]
+
+
+def _parse_marker_for_extra_check(marker):
+    # type: (Marker) -> EvalExtra
+    maker_str = str(marker)
+    eval_extra = _EXTRA_CHECKS.get(maker_str)
+    if not eval_extra:
+        eval_extra = _parse_extra_check(marker)
+        _EXTRA_CHECKS[maker_str] = eval_extra
+    return eval_extra
+
+
+def _evaluate_for_extras(
+    marker,  # type: Optional[Marker]
+    extras,  # type: Iterable[str]
+):
+    # type: (...) -> bool
+    if not marker:
+        return True
+    eval_extra = _parse_marker_for_extra_check(marker)
+    return any(eval_extra(ProjectName(extra)) for extra in (extras or [""]))
+
+
+def remove_unused_requires_dist(
+    resolve_requirements,  # type: Iterable[Requirement]
+    locked_resolve,  # type: LockedResolve
+):
+    # type: (...) -> LockedResolve
+
+    locked_req_by_project_name = {
+        locked_req.pin.project_name: locked_req for locked_req in locked_resolve.locked_requirements
+    }
+    requires_dist_by_locked_req = defaultdict(
+        OrderedSet
+    )  # type: DefaultDict[LockedRequirement, OrderedSet[Requirement]]
+    seen = set()
+    requirements = deque(resolve_requirements)
+    while requirements:
+        requirement = requirements.popleft()
+        if requirement in seen:
+            continue
+
+        seen.add(requirement)
+        locked_req = locked_req_by_project_name[requirement.project_name]
+        for dep in locked_req.requires_dists:
+            if _evaluate_for_extras(dep.marker, requirement.extras):
+                requires_dist_by_locked_req[locked_req].add(dep)
+                requirements.append(dep)
+
+    return attr.evolve(
+        locked_resolve,
+        locked_requirements=SortedTuple(
+            attr.evolve(
+                locked_requirement,
+                requires_dists=SortedTuple(
+                    requires_dist_by_locked_req[locked_requirement], key=str
+                ),
+            )
+            for locked_requirement in locked_resolve.locked_requirements
+        ),
+    )

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.24.3"
+__version__ = "2.25.0"

--- a/tests/integration/cli/commands/test_export.py
+++ b/tests/integration/cli/commands/test_export.py
@@ -45,6 +45,7 @@ UNIVERSAL_ANSICOLORS = Lockfile(
     style=LockStyle.UNIVERSAL,
     requires_python=SortedTuple(),
     target_systems=SortedTuple(),
+    elide_unused_requires_dist=False,
     pip_version=PipVersion.DEFAULT,
     resolver_version=ResolverVersion.PIP_2020,
     requirements=SortedTuple([Requirement.parse("ansicolors")]),

--- a/tests/integration/cli/commands/test_lock.py
+++ b/tests/integration/cli/commands/test_lock.py
@@ -494,7 +494,15 @@ UPDATE_LOCKFILE_CONTENTS = """\
             }
           ],
           "project_name": "urllib3",
-          "requires_dists": [],
+          "requires_dists": [
+            "brotlipy>=0.6.0; extra == \\"brotli\\"",
+            "pyOpenSSL>=0.14; extra == \\"secure\\"",
+            "cryptography>=1.3.4; extra == \\"secure\\"",
+            "idna>=2.0.0; extra == \\"secure\\"",
+            "certifi; extra == \\"secure\\"",
+            "ipaddress; python_version == \\"2.7\\" and extra == \\"secure\\"",
+            "PySocks!=1.5.7,<2.0,>=1.5.6; extra == \\"socks\\""
+          ],
           "requires_python": null,
           "version": "1.25.11"
         }

--- a/tests/integration/cli/commands/test_lock_elide_unused_requires_dist.py
+++ b/tests/integration/cli/commands/test_lock_elide_unused_requires_dist.py
@@ -1,0 +1,96 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from typing import Dict
+
+from pex.pep_503 import ProjectName
+from pex.resolve.locked_resolve import LockedRequirement
+from pex.resolve.lockfile import json_codec
+from pex.resolve.lockfile.model import Lockfile
+from testing.cli import run_pex3
+from testing.pytest.tmp import Tempdir
+
+
+def index_locked_reqs(lockfile):
+    # type: (Lockfile) -> Dict[ProjectName, LockedRequirement]
+    return {
+        locked_req.pin.project_name: locked_req
+        for locked_resolve in lockfile.locked_resolves
+        for locked_req in locked_resolve.locked_requirements
+    }
+
+
+def test_lock_elide_unused_requires_dist(tmpdir):
+    # type: (Tempdir) -> None
+
+    lock = tmpdir.join("lock.json")
+    run_pex3(
+        "lock",
+        "create",
+        "requests==2.31.0",
+        "--style",
+        "universal",
+        "--interpreter-constraint",
+        ">=3.7,<3.14",
+        "--indent",
+        "2",
+        "-o",
+        lock,
+    ).assert_success()
+    lockfile = json_codec.load(lock)
+
+    elided_lock = tmpdir.join("elided_lock.json")
+    run_pex3(
+        "lock",
+        "create",
+        "requests==2.31.0",
+        "--style",
+        "universal",
+        "--interpreter-constraint",
+        ">=3.7,<3.14",
+        "--elide-unused-requires-dist",
+        "--indent",
+        "2",
+        "-o",
+        elided_lock,
+    ).assert_success()
+    elided_lockfile = json_codec.load(elided_lock)
+
+    assert lockfile != elided_lockfile
+
+    locked_reqs = index_locked_reqs(lockfile)
+    requests = locked_reqs[ProjectName("requests")]
+
+    elided_locked_reqs = index_locked_reqs(elided_lockfile)
+    elided_requests = elided_locked_reqs[ProjectName("requests")]
+
+    assert requests != elided_requests
+
+    assert requests.pin == elided_requests.pin
+    assert list(requests.iter_artifacts()) == list(elided_requests.iter_artifacts())
+    assert requests.requires_python == elided_requests.requires_python
+
+    assert requests.requires_dists != elided_requests.requires_dists
+    assert len(elided_requests.requires_dists) < len(requests.requires_dists)
+    elided_deps = set(requests.requires_dists) - set(elided_requests.requires_dists)
+    assert len(elided_deps) > 0
+    assert not any(
+        elided_dep.project_name in elided_locked_reqs for elided_dep in elided_deps
+    ), "No dependencies that require extra activation should have been locked."
+
+    run_pex3(
+        "lock",
+        "sync",
+        "--style",
+        "universal",
+        "--interpreter-constraint",
+        ">=3.7,<3.14",
+        "--elide-unused-requires-dist",
+        "--indent",
+        "2",
+        "--lock",
+        lock,
+    ).assert_success()
+    assert elided_lockfile == json_codec.load(lock)

--- a/tests/resolve/lockfile/test_requires_dist.py
+++ b/tests/resolve/lockfile/test_requires_dist.py
@@ -1,0 +1,170 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from pex.dist_metadata import Requirement
+from pex.pep_440 import Version
+from pex.pep_503 import ProjectName
+from pex.resolve.locked_resolve import Artifact, LockedRequirement, LockedResolve
+from pex.resolve.lockfile import requires_dist
+from pex.resolve.resolved_requirement import Fingerprint, Pin
+from pex.sorted_tuple import SortedTuple
+
+req = Requirement.parse
+
+
+def locked_req(
+    project_name,  # type: str
+    version,  # type: str
+    *requirements  # type: str
+):
+    # type: (...) -> LockedRequirement
+    return LockedRequirement.create(
+        pin=Pin(project_name=ProjectName(project_name), version=Version(version)),
+        artifact=Artifact.from_url(
+            "https://artifact.store/{project_name}-{version}-py2.py3-none-any.whl".format(
+                project_name=project_name, version=version
+            ),
+            fingerprint=Fingerprint(algorithm="md5", hash="abcd0123"),
+        ),
+        requires_dists=map(req, requirements),
+    )
+
+
+def locked_resolve(*locked_requirements):
+    # type: (*LockedRequirement) -> LockedResolve
+    return LockedResolve(locked_requirements=SortedTuple(locked_requirements))
+
+
+def test_remove_unused_requires_dist_noop():
+    # type: () -> None
+
+    locked_resolve_with_no_extras = locked_resolve(
+        locked_req("foo", "1.0", "bar", "baz"),
+        locked_req("bar", "1.0"),
+        locked_req("baz", "1.0"),
+    )
+    assert locked_resolve_with_no_extras == requires_dist.remove_unused_requires_dist(
+        resolve_requirements=[req("foo")], locked_resolve=locked_resolve_with_no_extras
+    )
+
+
+def test_remove_unused_requires_dist_simple():
+    # type: () -> None
+
+    assert locked_resolve(
+        locked_req("foo", "1.0", "bar", "spam"),
+        locked_req("bar", "1.0"),
+        locked_req("spam", "1.0"),
+    ) == requires_dist.remove_unused_requires_dist(
+        resolve_requirements=[req("foo")],
+        locked_resolve=locked_resolve(
+            locked_req("foo", "1.0", "bar", "baz; extra == 'tests'", "spam"),
+            locked_req("bar", "1.0"),
+            locked_req("spam", "1.0"),
+        ),
+    )
+
+
+def test_remove_unused_requires_dist_mixed_extras():
+    # type: () -> None
+
+    assert locked_resolve(
+        locked_req("foo", "1.0", "bar; extra == 'extra1'", "spam"),
+        locked_req("bar", "1.0"),
+        locked_req("spam", "1.0"),
+    ) == requires_dist.remove_unused_requires_dist(
+        resolve_requirements=[req("foo[extra1]")],
+        locked_resolve=locked_resolve(
+            locked_req("foo", "1.0", "bar; extra == 'extra1'", "baz; extra == 'tests'", "spam"),
+            locked_req("bar", "1.0"),
+            locked_req("spam", "1.0"),
+        ),
+    )
+
+
+def test_remove_unused_requires_dist_mixed_markers():
+    # type: () -> None
+
+    assert locked_resolve(
+        locked_req(
+            "foo",
+            "1.0",
+            "bar; extra == 'extra1'",
+            "baz; extra == 'tests' or python_version > '3.11'",
+            "spam",
+        ),
+        locked_req("bar", "1.0"),
+        locked_req("baz", "1.0"),
+        locked_req("spam", "1.0"),
+    ) == requires_dist.remove_unused_requires_dist(
+        resolve_requirements=[req("foo[extra1]")],
+        locked_resolve=locked_resolve(
+            locked_req(
+                "foo",
+                "1.0",
+                "bar; extra == 'extra1'",
+                "baz; extra == 'tests' or python_version > '3.11'",
+                "spam",
+            ),
+            locked_req("bar", "1.0"),
+            locked_req("baz", "1.0"),
+            locked_req("spam", "1.0"),
+        ),
+    ), (
+        "The python_version marker clause might evaluate to true, which should be enough to retain "
+        "the baz dep even though the 'tests' extra is never activated."
+    )
+
+    assert locked_resolve(
+        locked_req(
+            "foo",
+            "1.0",
+            "bar; extra == 'extra1'",
+            "spam",
+        ),
+        locked_req("bar", "1.0"),
+        locked_req("spam", "1.0"),
+    ) == requires_dist.remove_unused_requires_dist(
+        resolve_requirements=[req("foo[extra1]")],
+        locked_resolve=locked_resolve(
+            locked_req(
+                "foo",
+                "1.0",
+                "bar; extra == 'extra1'",
+                "baz; extra == 'tests' and python_version > '3.11'",
+                "spam",
+            ),
+            locked_req("bar", "1.0"),
+            locked_req("spam", "1.0"),
+        ),
+    ), "The 'tests' extra is never active; so the baz dep should never be reached."
+
+
+def test_remove_unused_requires_dist_complex_markers():
+    # type: () -> None
+
+    assert locked_resolve(
+        locked_req(
+            "foo",
+            "1.0",
+            "bar; python_version < '3' and (extra == 'docs' or python_version >= '3')",
+            "spam",
+        ),
+        locked_req("bar", "1.0"),
+        locked_req("spam", "1.0"),
+    ) == requires_dist.remove_unused_requires_dist(
+        resolve_requirements=[req("foo")],
+        locked_resolve=locked_resolve(
+            locked_req(
+                "foo",
+                "1.0",
+                "bar; python_version < '3' and (extra == 'docs' or python_version >= '3')",
+                "baz; python_version == '3.11.*' and (extra == 'admin' or extra == 'docs')",
+                "spam",
+            ),
+            locked_req("bar", "1.0"),
+            locked_req("spam", "1.0"),
+        ),
+    )


### PR DESCRIPTION
This cuts down lock file size without changing any observable result of
using the lock file. It should cut down on lock subset times since there
is both less to parse and less dependencies to rule out after the parse,
but this effect is unmeasured at present.