### PR TITLE
Fix Pex REPL prompt.

### DIFF
--- a/pex/repl/custom.py
+++ b/pex/repl/custom.py
@@ -107,11 +107,10 @@ def repl_loop(
     custom_commands=None,  # type: Optional[Mapping[str, Tuple[Callable, str]]]
     history=False,  # type: bool
     history_file=None,  # type: Optional[str]
-    use_libedit_color_prompt_workaround=False,  # type: bool
 ):
     # type: (...) -> Callable[[], Dict[str, Any]]
 
-    libedit = _try_enable_readline(history=history, history_file=history_file)
+    _try_enable_readline(history=history, history_file=history_file)
 
     _custom_commands = custom_commands or {}
 
@@ -147,20 +146,6 @@ def repl_loop(
 
         if not use_color:
             text = _ANSI_RE.sub("", text)
-        elif prompt and libedit and use_libedit_color_prompt_workaround:
-            # Most versions of libedit do not support ansi terminal escape sequences, but they do
-            # support a readline back door where you can bracket characters that should be ignored
-            # for prompt width calculation but otherwise passed through unaltered to the terminal.
-            # This back door is defined in readline.h, which libedit implements, with the
-            # RL_PROMPT_START_IGNORE and RL_PROMPT_END_IGNORE character constants which we use
-            # below to bracket ansi terminal escape sequences.
-            #
-            # See:
-            # + https://tiswww.cwru.edu/php/chet/readline/readline.html#index-rl_005fexpand_005fprompt
-            # + https://git.savannah.gnu.org/cgit/readline.git/tree/readline.h?id=037d85f199a8c6e5b16689a46c8bc31b586a0c94#n884
-            text = _ANSI_RE.sub(
-                lambda match: "\001{ansi_sequence}\002".format(ansi_sequence=match.group(0)), text
-            )
         return text + " " if prompt else text
 
     repl_banner = fixup_ansi(banner) if banner else banner

--- a/pex/repl/pex_repl.py
+++ b/pex/repl/pex_repl.py
@@ -130,11 +130,6 @@ def _create_pex_repl(
         },
         history=history,
         history_file=history_file,
-        # The PBS Linux CPythons used by PEX scies use a version of libedit that needs workarounds
-        # to support color prompts.
-        use_libedit_color_prompt_workaround=(
-            os.environ.get("SCIE") is not None and sys.platform.lower().startswith("linux")
-        ),
     )
 
 
@@ -246,8 +241,8 @@ def _create_repl_data(
     return _REPLData(
         banner=banner,
         pex_info_summary=os.linesep.join(pex_info_summary),
-        ps1=colors.yellow(">>>"),
-        ps2=colors.yellow("..."),
+        ps1=">>>",
+        ps2="...",
     )
 
 

--- a/tests/integration/test_issue_157.py
+++ b/tests/integration/test_issue_157.py
@@ -72,9 +72,7 @@ def expect_banner_footer(
         "information.".format(pex=colors.yellow("pex") if expect_color else "pex").encode("utf-8"),
         timeout=timeout,
     )
-    process.expect_exact(
-        (colors.yellow(">>>") + " " if expect_color else ">>> ").encode("utf-8"), timeout=timeout
-    )
+    process.expect_exact(b">>> ", timeout=timeout)
 
 
 @attr.s(frozen=True)


### PR DESCRIPTION
Previously both PS1 and PS2 incorporated color. This interfered with
readline support in some configurations and did not provide much value
otherwise; so the color is removed to give working readline support in
all configurations.