### PR TITLE
Fix incorrect regex for PEX_PYTHON precision warning

### DIFF
--- a/pex/variables.py
+++ b/pex/variables.py
@@ -905,7 +905,7 @@ def venv_dir(
     if (
         ENV.PEX_PYTHON
         and not precise_pex_python
-        and not re.match(r".*[^\d][\d]+\.[\d+]$", ENV.PEX_PYTHON)
+        and not re.match(r".*[^\d][\d]+\.[\d]+$", ENV.PEX_PYTHON)
     ):
         warn(
             dedent(


### PR DESCRIPTION
Looks like this + is misplaced, as it means `PEX_PYTHON=3.+` would be accepted but it rejects and warns for `PEX_PYTHON=python3.11`.

Leads to this funky warning message telling us to use the setting we already have :)
```
PEXWarning: Using a venv selected by PEX_PYTHON=python3.11 for <snip>.pex at  ...
To avoid this warning, either specify a Python binary with major and minor version
in its name, like PEX_PYTHON=python3.11 or ...
```