### PR TITLE
Ensure that the PEX_ROOT is always a realpath.

### DIFF
--- a/pex/variables.py
+++ b/pex/variables.py
@@ -660,7 +660,7 @@ class Variables(object):
 
     @PEX_ROOT.validator
     def _ensure_writeable_pex_root(self, raw_pex_root):
-        pex_root = os.path.expanduser(raw_pex_root)
+        pex_root = os.path.realpath(os.path.expanduser(raw_pex_root))
         if not can_write_dir(pex_root):
             tmp_root = os.path.realpath(safe_mkdtemp())
             pex_warnings.warn(


### PR DESCRIPTION
In almost all codepaths, a `pex_root` will be a realpath. See, e.g.,

https://github.com/pex-tool/pex/blob/06b8850f35ae67377ad2fe31d62ee1f71ba61eea/pex/pex_info.py#L511
https://github.com/pex-tool/pex/blob/06b8850f35ae67377ad2fe31d62ee1f71ba61eea/pex/variables.py#L320

However there was one codepath by which a non-realpath could
be obtained, namely `boot()` calling`Variables.PEX_ROOT.value_or()` 
with a `raw_pex_root` given as the fallback value.

This change ensures that `Variables.PEX_ROOT` is always a realpath.

This manifested as a bug at pex boot time in the presence of a
symlinked cache dir: https://github.com/pantsbuild/pants/issues/21321

