### PR TITLE
Upgrade `science` minimum requirement to 0.10.1.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## 2.28.1
+
+This release upgrades `science` for use in building PEX scies with
+`--scie {eager,lazy}`. The upgraded `science` fixes issues dealing
+handling failed Python distribution downloads and should now be more
+robust and clear when downloads fail.
+
+* Upgrade `science` minimum requirement to 0.10.1. (#2637)
+
 ## 2.28.0
 
 This release adds Pex `--scie {eager,lazy}` support for Linux ppc64le

--- a/pex/scie/science.py
+++ b/pex/scie/science.py
@@ -64,7 +64,7 @@ class Manifest(object):
 
 
 SCIENCE_RELEASES_URL = "https://github.com/a-scie/lift/releases"
-MIN_SCIENCE_VERSION = Version("0.10.0")
+MIN_SCIENCE_VERSION = Version("0.10.1")
 SCIENCE_REQUIREMENT = SpecifierSet("~={min_version}".format(min_version=MIN_SCIENCE_VERSION))
 
 

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.28.0"
+__version__ = "2.28.1"

--- a/tests/integration/scie/test_pex_scie.py
+++ b/tests/integration/scie/test_pex_scie.py
@@ -310,7 +310,7 @@ def test_specified_science_binary(tmpdir):
 
     local_science_binary = os.path.join(str(tmpdir), "science")
     with open(local_science_binary, "wb") as write_fp, URLFetcher().get_body_stream(
-        "https://github.com/a-scie/lift/releases/download/v0.10.0/{binary}".format(
+        "https://github.com/a-scie/lift/releases/download/v0.10.1/{binary}".format(
             binary=SciePlatform.CURRENT.qualified_binary_name("science")
         )
     ) as read_fp:
@@ -354,7 +354,7 @@ def test_specified_science_binary(tmpdir):
         cached_science_binaries
     ), "Expected the local science binary to be used but not cached."
     assert (
-        "0.10.0"
+        "0.10.1"
         == subprocess.check_output(args=[local_science_binary, "--version"]).decode("utf-8").strip()
     )
 


### PR DESCRIPTION
Related to https://github.com/a-scie/lift/issues/116/