### PR TITLE
Switch vendoring from RedBaron to libcst.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -39,9 +39,6 @@ ignore_missing_imports = True
 [mypy-coverage]
 ignore_missing_imports = True
 
-[mypy-redbaron]
-ignore_missing_imports = True
-
 # TODO: Once we can upgrade to Pytest 6, turn this off.
 [mypy-pytest]
 ignore_missing_imports = True

--- a/pex/vendor/_vendored/attrs/.layout.json
+++ b/pex/vendor/_vendored/attrs/.layout.json
@@ -1,1 +1,1 @@
-{"fingerprint": "f5dc69d1bcc93115e977855167173724503804e7b4f1a59aeb8c6ddcea8ed2b7", "record_relpath": "attrs-21.5.0.dev0.dist-info/RECORD", "root_is_purelib": true, "stash_dir": ".prefix"}
+{"fingerprint": "f827748f286aa52ec78b7f6d7f0ae069555adff917b19b0097afa8b7ea45389a", "record_relpath": "attrs-21.5.0.dev0.dist-info/RECORD", "root_is_purelib": true, "stash_dir": ".prefix"}

--- a/pex/vendor/_vendored/attrs/attrs/__init__.py
+++ b/pex/vendor/_vendored/attrs/attrs/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 if "attrs" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from attr import (
+    from attr import (
     NOTHING,
     Attribute,
     Factory,
@@ -30,7 +30,7 @@ if "attrs" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
     validate,
 )  # vendor:skip
 else:
-  from pex.third_party.attr import (
+    from pex.third_party.attr import (
     NOTHING,
     Attribute,
     Factory,
@@ -60,9 +60,9 @@ else:
 )
 
 if "attrs" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from attr._next_gen import asdict, astuple  # vendor:skip
+    from attr._next_gen import asdict, astuple  # vendor:skip
 else:
-  from pex.third_party.attr._next_gen import asdict, astuple
+    from pex.third_party.attr._next_gen import asdict, astuple
 
 
 from . import converters, exceptions, filters, setters, validators

--- a/pex/vendor/_vendored/attrs/attrs/converters.py
+++ b/pex/vendor/_vendored/attrs/attrs/converters.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 if "attrs" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from attr.converters import *    # vendor:skip
+    from attr.converters import *  # vendor:skip
 else:
-  from pex.third_party.attr.converters import *  
-# noqa
+    from pex.third_party.attr.converters import *
+  # noqa

--- a/pex/vendor/_vendored/attrs/attrs/exceptions.py
+++ b/pex/vendor/_vendored/attrs/attrs/exceptions.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 if "attrs" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from attr.exceptions import *    # vendor:skip
+    from attr.exceptions import *  # vendor:skip
 else:
-  from pex.third_party.attr.exceptions import *  
-# noqa
+    from pex.third_party.attr.exceptions import *
+  # noqa

--- a/pex/vendor/_vendored/attrs/attrs/filters.py
+++ b/pex/vendor/_vendored/attrs/attrs/filters.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 if "attrs" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from attr.filters import *    # vendor:skip
+    from attr.filters import *  # vendor:skip
 else:
-  from pex.third_party.attr.filters import *  
-# noqa
+    from pex.third_party.attr.filters import *
+  # noqa

--- a/pex/vendor/_vendored/attrs/attrs/setters.py
+++ b/pex/vendor/_vendored/attrs/attrs/setters.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 if "attrs" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from attr.setters import *    # vendor:skip
+    from attr.setters import *  # vendor:skip
 else:
-  from pex.third_party.attr.setters import *  
-# noqa
+    from pex.third_party.attr.setters import *
+  # noqa

--- a/pex/vendor/_vendored/attrs/attrs/validators.py
+++ b/pex/vendor/_vendored/attrs/attrs/validators.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 if "attrs" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from attr.validators import *    # vendor:skip
+    from attr.validators import *  # vendor:skip
 else:
-  from pex.third_party.attr.validators import *  
-# noqa
+    from pex.third_party.attr.validators import *
+  # noqa

--- a/pex/vendor/_vendored/packaging_20_9/.layout.json
+++ b/pex/vendor/_vendored/packaging_20_9/.layout.json
@@ -1,1 +1,1 @@
-{"fingerprint": "3830d960e6ce1c5d375d8b5ca1977d63d784bfa22aa6e3fa6ab8c9a8b710f90b", "record_relpath": "packaging-20.9.dist-info/RECORD", "root_is_purelib": true, "stash_dir": ".prefix"}
+{"fingerprint": "3946db78a8f564b5e0f20648918e6352f64be213519585fe08750b080a1a21c3", "record_relpath": "packaging-20.9.dist-info/RECORD", "root_is_purelib": true, "stash_dir": ".prefix"}

--- a/pex/vendor/_vendored/packaging_20_9/packaging/markers.py
+++ b/pex/vendor/_vendored/packaging_20_9/packaging/markers.py
@@ -9,7 +9,7 @@ import platform
 import sys
 
 if "packaging" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pyparsing import (  # noqa: N817
+    from pyparsing import (  # noqa: N817
     Forward,
     Group,
     Literal as L,
@@ -21,7 +21,7 @@ if "packaging" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
     stringStart,
 )  # vendor:skip
 else:
-  from pex.third_party.pyparsing import (  # noqa: N817
+    from pex.third_party.pyparsing import (  # noqa: N817
     Forward,
     Group,
     Literal as L,

--- a/pex/vendor/_vendored/packaging_20_9/packaging/requirements.py
+++ b/pex/vendor/_vendored/packaging_20_9/packaging/requirements.py
@@ -8,7 +8,7 @@ import string
 import sys
 
 if "packaging" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pyparsing import (  # noqa: N817
+    from pyparsing import (  # noqa: N817
     Combine,
     Literal as L,
     Optional,
@@ -21,7 +21,7 @@ if "packaging" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
     stringStart,
 )  # vendor:skip
 else:
-  from pex.third_party.pyparsing import (  # noqa: N817
+    from pex.third_party.pyparsing import (  # noqa: N817
     Combine,
     Literal as L,
     Optional,

--- a/pex/vendor/_vendored/packaging_21_3/.layout.json
+++ b/pex/vendor/_vendored/packaging_21_3/.layout.json
@@ -1,1 +1,1 @@
-{"fingerprint": "44476a1f2ecb29b520c353ce20d8967cf001b935ee8ee16cb35583c9b5fe87e5", "record_relpath": "packaging-21.3.dist-info/RECORD", "root_is_purelib": true, "stash_dir": ".prefix"}
+{"fingerprint": "cab252202e7be970bad6b45497b8967cfb9a2759e6071eb30119be7b9fff62e1", "record_relpath": "packaging-21.3.dist-info/RECORD", "root_is_purelib": true, "stash_dir": ".prefix"}

--- a/pex/vendor/_vendored/packaging_21_3/packaging/markers.py
+++ b/pex/vendor/_vendored/packaging_21_3/packaging/markers.py
@@ -9,7 +9,7 @@ import sys
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 if "packaging" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pyparsing import (  # noqa: N817
+    from pyparsing import (  # noqa: N817
     Forward,
     Group,
     Literal as L,
@@ -21,7 +21,7 @@ if "packaging" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
     stringStart,
 )  # vendor:skip
 else:
-  from pex.third_party.pyparsing import (  # noqa: N817
+    from pex.third_party.pyparsing import (  # noqa: N817
     Forward,
     Group,
     Literal as L,

--- a/pex/vendor/_vendored/packaging_21_3/packaging/requirements.py
+++ b/pex/vendor/_vendored/packaging_21_3/packaging/requirements.py
@@ -8,7 +8,7 @@ import urllib.parse
 from typing import List, Optional as TOptional, Set
 
 if "packaging" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pyparsing import (  # noqa
+    from pyparsing import (  # noqa
     Combine,
     Literal as L,
     Optional,
@@ -21,7 +21,7 @@ if "packaging" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
     stringStart,
 )  # vendor:skip
 else:
-  from pex.third_party.pyparsing import (  # noqa
+    from pex.third_party.pyparsing import (  # noqa
     Combine,
     Literal as L,
     Optional,

--- a/pex/vendor/_vendored/setuptools/.layout.json
+++ b/pex/vendor/_vendored/setuptools/.layout.json
@@ -1,1 +1,1 @@
-{"fingerprint": "66974ae8d54525a2996281ddbd983213d5594739f85808a04df65fe630ce9b65", "record_relpath": "setuptools-44.0.0+3acb925dd708430aeaf197ea53ac8a752f7c1863.dist-info/RECORD", "root_is_purelib": true, "stash_dir": ".prefix"}
+{"fingerprint": "3ed0a88e9187417528887dc52d09fcfc8f0166098f63499834ddef53f9e46890", "record_relpath": "setuptools-44.0.0+3acb925dd708430aeaf197ea53ac8a752f7c1863.dist-info/RECORD", "root_is_purelib": true, "stash_dir": ".prefix"}

--- a/pex/vendor/_vendored/setuptools/easy_install.py
+++ b/pex/vendor/_vendored/setuptools/easy_install.py
@@ -2,8 +2,8 @@
 
 if __name__ == '__main__':
     if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-      from setuptools.command.easy_install import main  # vendor:skip
+        from setuptools.command.easy_install import main  # vendor:skip
     else:
-      from pex.third_party.setuptools.command.easy_install import main
+        from pex.third_party.setuptools.command.easy_install import main
 
     main()

--- a/pex/vendor/_vendored/setuptools/pkg_resources/__init__.py
+++ b/pex/vendor/_vendored/setuptools/pkg_resources/__init__.py
@@ -55,14 +55,14 @@ except NameError:
     FileExistsError = OSError
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources.extern import six  # vendor:skip
+    from pkg_resources.extern import six  # vendor:skip
 else:
-  from pex.third_party.pkg_resources.extern import six
+    from pex.third_party.pkg_resources.extern import six
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources.extern.six.moves import urllib, map, filter  # vendor:skip
+    from pkg_resources.extern.six.moves import urllib, map, filter  # vendor:skip
 else:
-  from pex.third_party.pkg_resources.extern.six.moves import urllib, map, filter
+    from pex.third_party.pkg_resources.extern.six.moves import urllib, map, filter
 
 
 # capture these to bypass sandboxing
@@ -86,34 +86,34 @@ except ImportError:
 
 from . import py31compat
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources.extern import appdirs  # vendor:skip
+    from pkg_resources.extern import appdirs  # vendor:skip
 else:
-  from pex.third_party.pkg_resources.extern import appdirs
+    from pex.third_party.pkg_resources.extern import appdirs
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources.extern import packaging  # vendor:skip
+    from pkg_resources.extern import packaging  # vendor:skip
 else:
-  from pex.third_party.pkg_resources.extern import packaging
+    from pex.third_party.pkg_resources.extern import packaging
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  __import__('pkg_resources.extern.packaging.version')  # vendor:skip
+    __import__('pkg_resources.extern.packaging.version')  # vendor:skip
 else:
-  __import__('pex.third_party.pkg_resources.extern.packaging.version')
+    __import__('pex.third_party.pkg_resources.extern.packaging.version')
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  __import__('pkg_resources.extern.packaging.specifiers')  # vendor:skip
+    __import__('pkg_resources.extern.packaging.specifiers')  # vendor:skip
 else:
-  __import__('pex.third_party.pkg_resources.extern.packaging.specifiers')
+    __import__('pex.third_party.pkg_resources.extern.packaging.specifiers')
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  __import__('pkg_resources.extern.packaging.requirements')  # vendor:skip
+    __import__('pkg_resources.extern.packaging.requirements')  # vendor:skip
 else:
-  __import__('pex.third_party.pkg_resources.extern.packaging.requirements')
+    __import__('pex.third_party.pkg_resources.extern.packaging.requirements')
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  __import__('pkg_resources.extern.packaging.markers')  # vendor:skip
+    __import__('pkg_resources.extern.packaging.markers')  # vendor:skip
 else:
-  __import__('pex.third_party.pkg_resources.extern.packaging.markers')
+    __import__('pex.third_party.pkg_resources.extern.packaging.markers')
 
 
 

--- a/pex/vendor/_vendored/setuptools/pkg_resources/_vendor/packaging/markers.py
+++ b/pex/vendor/_vendored/setuptools/pkg_resources/_vendor/packaging/markers.py
@@ -9,19 +9,19 @@ import platform
 import sys
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources.extern.pyparsing import ParseException, ParseResults, stringStart, stringEnd  # vendor:skip
+    from pkg_resources.extern.pyparsing import ParseException, ParseResults, stringStart, stringEnd  # vendor:skip
 else:
-  from pex.third_party.pkg_resources.extern.pyparsing import ParseException, ParseResults, stringStart, stringEnd
+    from pex.third_party.pkg_resources.extern.pyparsing import ParseException, ParseResults, stringStart, stringEnd
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources.extern.pyparsing import ZeroOrMore, Group, Forward, QuotedString  # vendor:skip
+    from pkg_resources.extern.pyparsing import ZeroOrMore, Group, Forward, QuotedString  # vendor:skip
 else:
-  from pex.third_party.pkg_resources.extern.pyparsing import ZeroOrMore, Group, Forward, QuotedString
+    from pex.third_party.pkg_resources.extern.pyparsing import ZeroOrMore, Group, Forward, QuotedString
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources.extern.pyparsing import Literal as L  # vendor:skip
+    from pkg_resources.extern.pyparsing import Literal as L  # vendor:skip
 else:
-  from pex.third_party.pkg_resources.extern.pyparsing import Literal as L
+    from pex.third_party.pkg_resources.extern.pyparsing import Literal as L
   # noqa
 
 from ._compat import string_types

--- a/pex/vendor/_vendored/setuptools/pkg_resources/_vendor/packaging/requirements.py
+++ b/pex/vendor/_vendored/setuptools/pkg_resources/_vendor/packaging/requirements.py
@@ -7,24 +7,24 @@ import string
 import re
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources.extern.pyparsing import stringStart, stringEnd, originalTextFor, ParseException  # vendor:skip
+    from pkg_resources.extern.pyparsing import stringStart, stringEnd, originalTextFor, ParseException  # vendor:skip
 else:
-  from pex.third_party.pkg_resources.extern.pyparsing import stringStart, stringEnd, originalTextFor, ParseException
+    from pex.third_party.pkg_resources.extern.pyparsing import stringStart, stringEnd, originalTextFor, ParseException
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources.extern.pyparsing import ZeroOrMore, Word, Optional, Regex, Combine  # vendor:skip
+    from pkg_resources.extern.pyparsing import ZeroOrMore, Word, Optional, Regex, Combine  # vendor:skip
 else:
-  from pex.third_party.pkg_resources.extern.pyparsing import ZeroOrMore, Word, Optional, Regex, Combine
+    from pex.third_party.pkg_resources.extern.pyparsing import ZeroOrMore, Word, Optional, Regex, Combine
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources.extern.pyparsing import Literal as L  # vendor:skip
+    from pkg_resources.extern.pyparsing import Literal as L  # vendor:skip
 else:
-  from pex.third_party.pkg_resources.extern.pyparsing import Literal as L
+    from pex.third_party.pkg_resources.extern.pyparsing import Literal as L
   # noqa
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources.extern.six.moves.urllib import parse as urlparse  # vendor:skip
+    from pkg_resources.extern.six.moves.urllib import parse as urlparse  # vendor:skip
 else:
-  from pex.third_party.pkg_resources.extern.six.moves.urllib import parse as urlparse
+    from pex.third_party.pkg_resources.extern.six.moves.urllib import parse as urlparse
 
 
 from .markers import MARKER_EXPR, Marker

--- a/pex/vendor/_vendored/setuptools/setuptools/_vendor/packaging/markers.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/_vendor/packaging/markers.py
@@ -9,19 +9,19 @@ import platform
 import sys
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.pyparsing import ParseException, ParseResults, stringStart, stringEnd  # vendor:skip
+    from setuptools.extern.pyparsing import ParseException, ParseResults, stringStart, stringEnd  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.pyparsing import ParseException, ParseResults, stringStart, stringEnd
+    from pex.third_party.setuptools.extern.pyparsing import ParseException, ParseResults, stringStart, stringEnd
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.pyparsing import ZeroOrMore, Group, Forward, QuotedString  # vendor:skip
+    from setuptools.extern.pyparsing import ZeroOrMore, Group, Forward, QuotedString  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.pyparsing import ZeroOrMore, Group, Forward, QuotedString
+    from pex.third_party.setuptools.extern.pyparsing import ZeroOrMore, Group, Forward, QuotedString
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.pyparsing import Literal as L  # vendor:skip
+    from setuptools.extern.pyparsing import Literal as L  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.pyparsing import Literal as L
+    from pex.third_party.setuptools.extern.pyparsing import Literal as L
   # noqa
 
 from ._compat import string_types

--- a/pex/vendor/_vendored/setuptools/setuptools/_vendor/packaging/requirements.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/_vendor/packaging/requirements.py
@@ -7,24 +7,24 @@ import string
 import re
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.pyparsing import stringStart, stringEnd, originalTextFor, ParseException  # vendor:skip
+    from setuptools.extern.pyparsing import stringStart, stringEnd, originalTextFor, ParseException  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.pyparsing import stringStart, stringEnd, originalTextFor, ParseException
+    from pex.third_party.setuptools.extern.pyparsing import stringStart, stringEnd, originalTextFor, ParseException
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.pyparsing import ZeroOrMore, Word, Optional, Regex, Combine  # vendor:skip
+    from setuptools.extern.pyparsing import ZeroOrMore, Word, Optional, Regex, Combine  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.pyparsing import ZeroOrMore, Word, Optional, Regex, Combine
+    from pex.third_party.setuptools.extern.pyparsing import ZeroOrMore, Word, Optional, Regex, Combine
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.pyparsing import Literal as L  # vendor:skip
+    from setuptools.extern.pyparsing import Literal as L  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.pyparsing import Literal as L
+    from pex.third_party.setuptools.extern.pyparsing import Literal as L
   # noqa
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.six.moves.urllib import parse as urlparse  # vendor:skip
+    from setuptools.extern.six.moves.urllib import parse as urlparse  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.six.moves.urllib import parse as urlparse
+    from pex.third_party.setuptools.extern.six.moves.urllib import parse as urlparse
 
 
 from .markers import MARKER_EXPR, Marker

--- a/pex/vendor/_vendored/setuptools/setuptools/archive_util.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/archive_util.py
@@ -9,9 +9,9 @@ import contextlib
 from distutils.errors import DistutilsError
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources import ensure_directory  # vendor:skip
+    from pkg_resources import ensure_directory  # vendor:skip
 else:
-  from pex.third_party.pkg_resources import ensure_directory
+    from pex.third_party.pkg_resources import ensure_directory
 
 
 __all__ = [

--- a/pex/vendor/_vendored/setuptools/setuptools/build_meta.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/build_meta.py
@@ -34,26 +34,26 @@ import shutil
 import contextlib
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  import setuptools  # vendor:skip
+    import setuptools  # vendor:skip
 else:
-  import pex.third_party.setuptools as setuptools
+    import pex.third_party.setuptools as setuptools
 
 import distutils
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.py31compat import TemporaryDirectory  # vendor:skip
+    from setuptools.py31compat import TemporaryDirectory  # vendor:skip
 else:
-  from pex.third_party.setuptools.py31compat import TemporaryDirectory
+    from pex.third_party.setuptools.py31compat import TemporaryDirectory
 
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources import parse_requirements  # vendor:skip
+    from pkg_resources import parse_requirements  # vendor:skip
 else:
-  from pex.third_party.pkg_resources import parse_requirements
+    from pex.third_party.pkg_resources import parse_requirements
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources.py31compat import makedirs  # vendor:skip
+    from pkg_resources.py31compat import makedirs  # vendor:skip
 else:
-  from pex.third_party.pkg_resources.py31compat import makedirs
+    from pex.third_party.pkg_resources.py31compat import makedirs
 
 
 __all__ = ['get_requires_for_build_sdist',

--- a/pex/vendor/_vendored/setuptools/setuptools/command/__init__.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/__init__.py
@@ -9,9 +9,9 @@ from distutils.command.bdist import bdist
 import sys
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.command import install_scripts  # vendor:skip
+    from setuptools.command import install_scripts  # vendor:skip
 else:
-  from pex.third_party.setuptools.command import install_scripts
+    from pex.third_party.setuptools.command import install_scripts
 
 
 if 'egg' not in bdist.format_commands:

--- a/pex/vendor/_vendored/setuptools/setuptools/command/alias.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/alias.py
@@ -1,15 +1,15 @@
 from distutils.errors import DistutilsOptionError
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.six.moves import map  # vendor:skip
+    from setuptools.extern.six.moves import map  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.six.moves import map
+    from pex.third_party.setuptools.extern.six.moves import map
 
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.command.setopt import edit_config, option_base, config_file  # vendor:skip
+    from setuptools.command.setopt import edit_config, option_base, config_file  # vendor:skip
 else:
-  from pex.third_party.setuptools.command.setopt import edit_config, option_base, config_file
+    from pex.third_party.setuptools.command.setopt import edit_config, option_base, config_file
 
 
 

--- a/pex/vendor/_vendored/setuptools/setuptools/command/bdist_egg.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/bdist_egg.py
@@ -13,30 +13,30 @@ import textwrap
 import marshal
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import six  # vendor:skip
+    from setuptools.extern import six  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import six
+    from pex.third_party.setuptools.extern import six
 
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources import get_build_platform, Distribution, ensure_directory  # vendor:skip
+    from pkg_resources import get_build_platform, Distribution, ensure_directory  # vendor:skip
 else:
-  from pex.third_party.pkg_resources import get_build_platform, Distribution, ensure_directory
+    from pex.third_party.pkg_resources import get_build_platform, Distribution, ensure_directory
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources import EntryPoint  # vendor:skip
+    from pkg_resources import EntryPoint  # vendor:skip
 else:
-  from pex.third_party.pkg_resources import EntryPoint
+    from pex.third_party.pkg_resources import EntryPoint
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extension import Library  # vendor:skip
+    from setuptools.extension import Library  # vendor:skip
 else:
-  from pex.third_party.setuptools.extension import Library
+    from pex.third_party.setuptools.extension import Library
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools import Command  # vendor:skip
+    from setuptools import Command  # vendor:skip
 else:
-  from pex.third_party.setuptools import Command
+    from pex.third_party.setuptools import Command
 
 
 try:

--- a/pex/vendor/_vendored/setuptools/setuptools/command/build_clib.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/build_clib.py
@@ -2,9 +2,9 @@ import distutils.command.build_clib as orig
 from distutils.errors import DistutilsSetupError
 from distutils import log
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.dep_util import newer_pairwise_group  # vendor:skip
+    from setuptools.dep_util import newer_pairwise_group  # vendor:skip
 else:
-  from pex.third_party.setuptools.dep_util import newer_pairwise_group
+    from pex.third_party.setuptools.dep_util import newer_pairwise_group
 
 
 

--- a/pex/vendor/_vendored/setuptools/setuptools/command/build_ext.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/build_ext.py
@@ -9,14 +9,14 @@ from distutils.errors import DistutilsError
 from distutils import log
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extension import Library  # vendor:skip
+    from setuptools.extension import Library  # vendor:skip
 else:
-  from pex.third_party.setuptools.extension import Library
+    from pex.third_party.setuptools.extension import Library
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import six  # vendor:skip
+    from setuptools.extern import six  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import six
+    from pex.third_party.setuptools.extern import six
 
 
 if six.PY2:

--- a/pex/vendor/_vendored/setuptools/setuptools/command/build_py.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/build_py.py
@@ -9,21 +9,21 @@ import distutils.errors
 import itertools
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import six  # vendor:skip
+    from setuptools.extern import six  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import six
+    from pex.third_party.setuptools.extern import six
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.six.moves import map, filter, filterfalse  # vendor:skip
+    from setuptools.extern.six.moves import map, filter, filterfalse  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.six.moves import map, filter, filterfalse
+    from pex.third_party.setuptools.extern.six.moves import map, filter, filterfalse
 
 
 try:
     if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-      from setuptools.lib2to3_ex import Mixin2to3  # vendor:skip
+        from setuptools.lib2to3_ex import Mixin2to3  # vendor:skip
     else:
-      from pex.third_party.setuptools.lib2to3_ex import Mixin2to3
+        from pex.third_party.setuptools.lib2to3_ex import Mixin2to3
 
 except ImportError:
 

--- a/pex/vendor/_vendored/setuptools/setuptools/command/develop.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/develop.py
@@ -6,30 +6,30 @@ import glob
 import io
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import six  # vendor:skip
+    from setuptools.extern import six  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import six
+    from pex.third_party.setuptools.extern import six
 
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  import pkg_resources  # vendor:skip
+    import pkg_resources  # vendor:skip
 else:
-  import pex.third_party.pkg_resources as pkg_resources
+    import pex.third_party.pkg_resources as pkg_resources
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.command.easy_install import easy_install  # vendor:skip
+    from setuptools.command.easy_install import easy_install  # vendor:skip
 else:
-  from pex.third_party.setuptools.command.easy_install import easy_install
+    from pex.third_party.setuptools.command.easy_install import easy_install
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools import namespaces  # vendor:skip
+    from setuptools import namespaces  # vendor:skip
 else:
-  from pex.third_party.setuptools import namespaces
+    from pex.third_party.setuptools import namespaces
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  import setuptools  # vendor:skip
+    import setuptools  # vendor:skip
 else:
-  import pex.third_party.setuptools as setuptools
+    import pex.third_party.setuptools as setuptools
 
 
 __metaclass__ = type

--- a/pex/vendor/_vendored/setuptools/setuptools/command/easy_install.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/easy_install.py
@@ -44,75 +44,75 @@ import io
 from sysconfig import get_config_vars, get_path
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools import SetuptoolsDeprecationWarning  # vendor:skip
+    from setuptools import SetuptoolsDeprecationWarning  # vendor:skip
 else:
-  from pex.third_party.setuptools import SetuptoolsDeprecationWarning
+    from pex.third_party.setuptools import SetuptoolsDeprecationWarning
 
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import six  # vendor:skip
+    from setuptools.extern import six  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import six
+    from pex.third_party.setuptools.extern import six
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.six.moves import configparser, map  # vendor:skip
+    from setuptools.extern.six.moves import configparser, map  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.six.moves import configparser, map
+    from pex.third_party.setuptools.extern.six.moves import configparser, map
 
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools import Command  # vendor:skip
+    from setuptools import Command  # vendor:skip
 else:
-  from pex.third_party.setuptools import Command
+    from pex.third_party.setuptools import Command
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.sandbox import run_setup  # vendor:skip
+    from setuptools.sandbox import run_setup  # vendor:skip
 else:
-  from pex.third_party.setuptools.sandbox import run_setup
+    from pex.third_party.setuptools.sandbox import run_setup
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.py27compat import rmtree_safe  # vendor:skip
+    from setuptools.py27compat import rmtree_safe  # vendor:skip
 else:
-  from pex.third_party.setuptools.py27compat import rmtree_safe
+    from pex.third_party.setuptools.py27compat import rmtree_safe
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.command import setopt  # vendor:skip
+    from setuptools.command import setopt  # vendor:skip
 else:
-  from pex.third_party.setuptools.command import setopt
+    from pex.third_party.setuptools.command import setopt
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.archive_util import unpack_archive  # vendor:skip
+    from setuptools.archive_util import unpack_archive  # vendor:skip
 else:
-  from pex.third_party.setuptools.archive_util import unpack_archive
+    from pex.third_party.setuptools.archive_util import unpack_archive
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.package_index import (
+    from setuptools.package_index import (
     PackageIndex, parse_requirement_arg, URL_SCHEME,
 )  # vendor:skip
 else:
-  from pex.third_party.setuptools.package_index import (
+    from pex.third_party.setuptools.package_index import (
     PackageIndex, parse_requirement_arg, URL_SCHEME,
 )
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.command import bdist_egg, egg_info  # vendor:skip
+    from setuptools.command import bdist_egg, egg_info  # vendor:skip
 else:
-  from pex.third_party.setuptools.command import bdist_egg, egg_info
+    from pex.third_party.setuptools.command import bdist_egg, egg_info
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.wheel import Wheel  # vendor:skip
+    from setuptools.wheel import Wheel  # vendor:skip
 else:
-  from pex.third_party.setuptools.wheel import Wheel
+    from pex.third_party.setuptools.wheel import Wheel
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources import (
+    from pkg_resources import (
     yield_lines, normalize_path, resource_string, ensure_directory,
     get_distribution, find_distributions, Environment, Requirement,
     Distribution, PathMetadata, EggMetadata, WorkingSet, DistributionNotFound,
     VersionConflict, DEVELOP_DIST,
 )  # vendor:skip
 else:
-  from pex.third_party.pkg_resources import (
+    from pex.third_party.pkg_resources import (
     yield_lines, normalize_path, resource_string, ensure_directory,
     get_distribution, find_distributions, Environment, Requirement,
     Distribution, PathMetadata, EggMetadata, WorkingSet, DistributionNotFound,
@@ -120,9 +120,9 @@ else:
 )
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  import pkg_resources.py31compat  # vendor:skip
+    import pkg_resources.py31compat  # vendor:skip
 else:
-  import pex.third_party.pkg_resources.py31compat, pex.third_party.pkg_resources as pkg_resources
+    import pex.third_party.pkg_resources.py31compat, pex.third_party.pkg_resources as pkg_resources
 
 
 __metaclass__ = type
@@ -2351,9 +2351,9 @@ def current_umask():
 def bootstrap():
     # This function is called when setuptools*.egg is run using /bin/sh
     if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-      import setuptools  # vendor:skip
+        import setuptools  # vendor:skip
     else:
-      import pex.third_party.setuptools as setuptools
+        import pex.third_party.setuptools as setuptools
 
 
     argv0 = os.path.dirname(setuptools.__path__[0])
@@ -2364,14 +2364,14 @@ def bootstrap():
 
 def main(argv=None, **kw):
     if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-      from setuptools import setup  # vendor:skip
+        from setuptools import setup  # vendor:skip
     else:
-      from pex.third_party.setuptools import setup
+        from pex.third_party.setuptools import setup
 
     if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-      from setuptools.dist import Distribution  # vendor:skip
+        from setuptools.dist import Distribution  # vendor:skip
     else:
-      from pex.third_party.setuptools.dist import Distribution
+        from pex.third_party.setuptools.dist import Distribution
 
 
     class DistributionWithoutHelpCommands(Distribution):

--- a/pex/vendor/_vendored/setuptools/setuptools/command/egg_info.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/egg_info.py
@@ -17,70 +17,70 @@ import time
 import collections
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import six  # vendor:skip
+    from setuptools.extern import six  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import six
+    from pex.third_party.setuptools.extern import six
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.six.moves import map  # vendor:skip
+    from setuptools.extern.six.moves import map  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.six.moves import map
+    from pex.third_party.setuptools.extern.six.moves import map
 
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools import Command  # vendor:skip
+    from setuptools import Command  # vendor:skip
 else:
-  from pex.third_party.setuptools import Command
+    from pex.third_party.setuptools import Command
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.command.sdist import sdist  # vendor:skip
+    from setuptools.command.sdist import sdist  # vendor:skip
 else:
-  from pex.third_party.setuptools.command.sdist import sdist
+    from pex.third_party.setuptools.command.sdist import sdist
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.command.sdist import walk_revctrl  # vendor:skip
+    from setuptools.command.sdist import walk_revctrl  # vendor:skip
 else:
-  from pex.third_party.setuptools.command.sdist import walk_revctrl
+    from pex.third_party.setuptools.command.sdist import walk_revctrl
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.command.setopt import edit_config  # vendor:skip
+    from setuptools.command.setopt import edit_config  # vendor:skip
 else:
-  from pex.third_party.setuptools.command.setopt import edit_config
+    from pex.third_party.setuptools.command.setopt import edit_config
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.command import bdist_egg  # vendor:skip
+    from setuptools.command import bdist_egg  # vendor:skip
 else:
-  from pex.third_party.setuptools.command import bdist_egg
+    from pex.third_party.setuptools.command import bdist_egg
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources import (
+    from pkg_resources import (
     parse_requirements, safe_name, parse_version,
     safe_version, yield_lines, EntryPoint, iter_entry_points, to_filename)  # vendor:skip
 else:
-  from pex.third_party.pkg_resources import (
+    from pex.third_party.pkg_resources import (
     parse_requirements, safe_name, parse_version,
     safe_version, yield_lines, EntryPoint, iter_entry_points, to_filename)
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  import setuptools.unicode_utils as unicode_utils  # vendor:skip
+    import setuptools.unicode_utils as unicode_utils  # vendor:skip
 else:
-  import pex.third_party.setuptools.unicode_utils as unicode_utils
+    import pex.third_party.setuptools.unicode_utils as unicode_utils
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.glob import glob  # vendor:skip
+    from setuptools.glob import glob  # vendor:skip
 else:
-  from pex.third_party.setuptools.glob import glob
+    from pex.third_party.setuptools.glob import glob
 
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import packaging  # vendor:skip
+    from setuptools.extern import packaging  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import packaging
+    from pex.third_party.setuptools.extern import packaging
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools import SetuptoolsDeprecationWarning  # vendor:skip
+    from setuptools import SetuptoolsDeprecationWarning  # vendor:skip
 else:
-  from pex.third_party.setuptools import SetuptoolsDeprecationWarning
+    from pex.third_party.setuptools import SetuptoolsDeprecationWarning
 
 
 def translate_pattern(glob):

--- a/pex/vendor/_vendored/setuptools/setuptools/command/install.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/install.py
@@ -6,9 +6,9 @@ import platform
 import distutils.command.install as orig
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  import setuptools  # vendor:skip
+    import setuptools  # vendor:skip
 else:
-  import pex.third_party.setuptools as setuptools
+    import pex.third_party.setuptools as setuptools
 
 
 # Prior to numpy 1.9, NumPy relies on the '_install' name, so provide it for

--- a/pex/vendor/_vendored/setuptools/setuptools/command/install_egg_info.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/install_egg_info.py
@@ -2,24 +2,24 @@ from distutils import log, dir_util
 import os
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools import Command  # vendor:skip
+    from setuptools import Command  # vendor:skip
 else:
-  from pex.third_party.setuptools import Command
+    from pex.third_party.setuptools import Command
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools import namespaces  # vendor:skip
+    from setuptools import namespaces  # vendor:skip
 else:
-  from pex.third_party.setuptools import namespaces
+    from pex.third_party.setuptools import namespaces
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.archive_util import unpack_archive  # vendor:skip
+    from setuptools.archive_util import unpack_archive  # vendor:skip
 else:
-  from pex.third_party.setuptools.archive_util import unpack_archive
+    from pex.third_party.setuptools.archive_util import unpack_archive
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  import pkg_resources  # vendor:skip
+    import pkg_resources  # vendor:skip
 else:
-  import pex.third_party.pkg_resources as pkg_resources
+    import pex.third_party.pkg_resources as pkg_resources
 
 
 

--- a/pex/vendor/_vendored/setuptools/setuptools/command/install_lib.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/install_lib.py
@@ -96,9 +96,9 @@ class install_lib(orig.install_lib):
         # Exclude namespace package __init__.py* files from the output
 
         if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-          from setuptools.archive_util import unpack_directory  # vendor:skip
+            from setuptools.archive_util import unpack_directory  # vendor:skip
         else:
-          from pex.third_party.setuptools.archive_util import unpack_directory
+            from pex.third_party.setuptools.archive_util import unpack_directory
 
         from distutils import log
 

--- a/pex/vendor/_vendored/setuptools/setuptools/command/install_scripts.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/install_scripts.py
@@ -4,9 +4,9 @@ import os
 import sys
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources import Distribution, PathMetadata, ensure_directory  # vendor:skip
+    from pkg_resources import Distribution, PathMetadata, ensure_directory  # vendor:skip
 else:
-  from pex.third_party.pkg_resources import Distribution, PathMetadata, ensure_directory
+    from pex.third_party.pkg_resources import Distribution, PathMetadata, ensure_directory
 
 
 
@@ -19,9 +19,9 @@ class install_scripts(orig.install_scripts):
 
     def run(self):
         if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-          import setuptools.command.easy_install as ei  # vendor:skip
+            import setuptools.command.easy_install as ei  # vendor:skip
         else:
-          import pex.third_party.setuptools.command.easy_install as ei
+            import pex.third_party.setuptools.command.easy_install as ei
 
 
         self.run_command("egg_info")
@@ -62,9 +62,9 @@ class install_scripts(orig.install_scripts):
     def write_script(self, script_name, contents, mode="t", *ignored):
         """Write an executable file to the scripts directory"""
         if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-          from setuptools.command.easy_install import chmod, current_umask  # vendor:skip
+            from setuptools.command.easy_install import chmod, current_umask  # vendor:skip
         else:
-          from pex.third_party.setuptools.command.easy_install import chmod, current_umask
+            from pex.third_party.setuptools.command.easy_install import chmod, current_umask
 
 
         log.info("Installing %s script to %s", script_name, self.install_dir)

--- a/pex/vendor/_vendored/setuptools/setuptools/command/py36compat.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/py36compat.py
@@ -4,9 +4,9 @@ from distutils.util import convert_path
 from distutils.command import sdist
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.six.moves import filter  # vendor:skip
+    from setuptools.extern.six.moves import filter  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.six.moves import filter
+    from pex.third_party.setuptools.extern.six.moves import filter
 
 
 

--- a/pex/vendor/_vendored/setuptools/setuptools/command/register.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/register.py
@@ -2,9 +2,9 @@ from distutils import log
 import distutils.command.register as orig
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.errors import RemovedCommandError  # vendor:skip
+    from setuptools.errors import RemovedCommandError  # vendor:skip
 else:
-  from pex.third_party.setuptools.errors import RemovedCommandError
+    from pex.third_party.setuptools.errors import RemovedCommandError
 
 
 

--- a/pex/vendor/_vendored/setuptools/setuptools/command/rotate.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/rotate.py
@@ -5,15 +5,15 @@ import os
 import shutil
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import six  # vendor:skip
+    from setuptools.extern import six  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import six
+    from pex.third_party.setuptools.extern import six
 
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools import Command  # vendor:skip
+    from setuptools import Command  # vendor:skip
 else:
-  from pex.third_party.setuptools import Command
+    from pex.third_party.setuptools import Command
 
 
 

--- a/pex/vendor/_vendored/setuptools/setuptools/command/saveopts.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/saveopts.py
@@ -1,7 +1,7 @@
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.command.setopt import edit_config, option_base  # vendor:skip
+    from setuptools.command.setopt import edit_config, option_base  # vendor:skip
 else:
-  from pex.third_party.setuptools.command.setopt import edit_config, option_base
+    from pex.third_party.setuptools.command.setopt import edit_config, option_base
 
 
 

--- a/pex/vendor/_vendored/setuptools/setuptools/command/sdist.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/sdist.py
@@ -6,17 +6,17 @@ import io
 import contextlib
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import six, ordered_set  # vendor:skip
+    from setuptools.extern import six, ordered_set  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import six, ordered_set
+    from pex.third_party.setuptools.extern import six, ordered_set
 
 
 from .py36compat import sdist_add_defaults
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  import pkg_resources  # vendor:skip
+    import pkg_resources  # vendor:skip
 else:
-  import pex.third_party.pkg_resources as pkg_resources
+    import pex.third_party.pkg_resources as pkg_resources
 
 
 _default_revctrl = list

--- a/pex/vendor/_vendored/setuptools/setuptools/command/setopt.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/setopt.py
@@ -5,15 +5,15 @@ import distutils
 import os
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.six.moves import configparser  # vendor:skip
+    from setuptools.extern.six.moves import configparser  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.six.moves import configparser
+    from pex.third_party.setuptools.extern.six.moves import configparser
 
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools import Command  # vendor:skip
+    from setuptools import Command  # vendor:skip
 else:
-  from pex.third_party.setuptools import Command
+    from pex.third_party.setuptools import Command
 
 
 __all__ = ['config_file', 'edit_config', 'option_base', 'setopt']

--- a/pex/vendor/_vendored/setuptools/setuptools/command/test.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/test.py
@@ -9,29 +9,29 @@ from distutils import log
 from unittest import TestLoader
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import six  # vendor:skip
+    from setuptools.extern import six  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import six
+    from pex.third_party.setuptools.extern import six
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.six.moves import map, filter  # vendor:skip
+    from setuptools.extern.six.moves import map, filter  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.six.moves import map, filter
+    from pex.third_party.setuptools.extern.six.moves import map, filter
 
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources import (resource_listdir, resource_exists, normalize_path,
+    from pkg_resources import (resource_listdir, resource_exists, normalize_path,
                            working_set, _namespace_packages, evaluate_marker,
                            add_activation_listener, require, EntryPoint)  # vendor:skip
 else:
-  from pex.third_party.pkg_resources import (resource_listdir, resource_exists, normalize_path,
+    from pex.third_party.pkg_resources import (resource_listdir, resource_exists, normalize_path,
                            working_set, _namespace_packages, evaluate_marker,
                            add_activation_listener, require, EntryPoint)
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools import Command  # vendor:skip
+    from setuptools import Command  # vendor:skip
 else:
-  from pex.third_party.setuptools import Command
+    from pex.third_party.setuptools import Command
 
 from .build_py import _unique_everseen
 

--- a/pex/vendor/_vendored/setuptools/setuptools/command/upload.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/upload.py
@@ -2,9 +2,9 @@ from distutils import log
 from distutils.command import upload as orig
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.errors import RemovedCommandError  # vendor:skip
+    from setuptools.errors import RemovedCommandError  # vendor:skip
 else:
-  from pex.third_party.setuptools.errors import RemovedCommandError
+    from pex.third_party.setuptools.errors import RemovedCommandError
 
 
 

--- a/pex/vendor/_vendored/setuptools/setuptools/command/upload_docs.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/command/upload_docs.py
@@ -17,20 +17,20 @@ import itertools
 import functools
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import six  # vendor:skip
+    from setuptools.extern import six  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import six
+    from pex.third_party.setuptools.extern import six
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.six.moves import http_client, urllib  # vendor:skip
+    from setuptools.extern.six.moves import http_client, urllib  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.six.moves import http_client, urllib
+    from pex.third_party.setuptools.extern.six.moves import http_client, urllib
 
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources import iter_entry_points  # vendor:skip
+    from pkg_resources import iter_entry_points  # vendor:skip
 else:
-  from pex.third_party.pkg_resources import iter_entry_points
+    from pex.third_party.pkg_resources import iter_entry_points
 
 from .upload import upload
 

--- a/pex/vendor/_vendored/setuptools/setuptools/config.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/config.py
@@ -12,19 +12,19 @@ from importlib import import_module
 
 from distutils.errors import DistutilsOptionError, DistutilsFileError
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.packaging.version import LegacyVersion, parse  # vendor:skip
+    from setuptools.extern.packaging.version import LegacyVersion, parse  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.packaging.version import LegacyVersion, parse
+    from pex.third_party.setuptools.extern.packaging.version import LegacyVersion, parse
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.packaging.specifiers import SpecifierSet  # vendor:skip
+    from setuptools.extern.packaging.specifiers import SpecifierSet  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.packaging.specifiers import SpecifierSet
+    from pex.third_party.setuptools.extern.packaging.specifiers import SpecifierSet
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.six import string_types, PY3  # vendor:skip
+    from setuptools.extern.six import string_types, PY3  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.six import string_types, PY3
+    from pex.third_party.setuptools.extern.six import string_types, PY3
 
 
 
@@ -49,9 +49,9 @@ def read_configuration(
     :rtype: dict
     """
     if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-      from setuptools.dist import Distribution, _Distribution  # vendor:skip
+        from setuptools.dist import Distribution, _Distribution  # vendor:skip
     else:
-      from pex.third_party.setuptools.dist import Distribution, _Distribution
+        from pex.third_party.setuptools.dist import Distribution, _Distribution
 
 
     filepath = os.path.abspath(filepath)
@@ -598,15 +598,15 @@ class ConfigOptionsHandler(ConfigHandler):
 
         if findns:
             if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-              from setuptools import find_namespace_packages as find_packages  # vendor:skip
+                from setuptools import find_namespace_packages as find_packages  # vendor:skip
             else:
-              from pex.third_party.setuptools import find_namespace_packages as find_packages
+                from pex.third_party.setuptools import find_namespace_packages as find_packages
 
         else:
             if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-              from setuptools import find_packages  # vendor:skip
+                from setuptools import find_packages  # vendor:skip
             else:
-              from pex.third_party.setuptools import find_packages
+                from pex.third_party.setuptools import find_packages
 
 
         return find_packages(**find_kwargs)

--- a/pex/vendor/_vendored/setuptools/setuptools/dist.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/dist.py
@@ -26,63 +26,63 @@ from distutils.util import rfc822_escape
 from distutils.version import StrictVersion
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import six  # vendor:skip
+    from setuptools.extern import six  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import six
+    from pex.third_party.setuptools.extern import six
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import packaging  # vendor:skip
+    from setuptools.extern import packaging  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import packaging
+    from pex.third_party.setuptools.extern import packaging
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import ordered_set  # vendor:skip
+    from setuptools.extern import ordered_set  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import ordered_set
+    from pex.third_party.setuptools.extern import ordered_set
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.six.moves import map, filter, filterfalse  # vendor:skip
+    from setuptools.extern.six.moves import map, filter, filterfalse  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.six.moves import map, filter, filterfalse
+    from pex.third_party.setuptools.extern.six.moves import map, filter, filterfalse
 
 
 from . import SetuptoolsDeprecationWarning
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.depends import Require  # vendor:skip
+    from setuptools.depends import Require  # vendor:skip
 else:
-  from pex.third_party.setuptools.depends import Require
+    from pex.third_party.setuptools.depends import Require
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools import windows_support  # vendor:skip
+    from setuptools import windows_support  # vendor:skip
 else:
-  from pex.third_party.setuptools import windows_support
+    from pex.third_party.setuptools import windows_support
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.monkey import get_unpatched  # vendor:skip
+    from setuptools.monkey import get_unpatched  # vendor:skip
 else:
-  from pex.third_party.setuptools.monkey import get_unpatched
+    from pex.third_party.setuptools.monkey import get_unpatched
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.config import parse_configuration  # vendor:skip
+    from setuptools.config import parse_configuration  # vendor:skip
 else:
-  from pex.third_party.setuptools.config import parse_configuration
+    from pex.third_party.setuptools.config import parse_configuration
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  import pkg_resources  # vendor:skip
+    import pkg_resources  # vendor:skip
 else:
-  import pex.third_party.pkg_resources as pkg_resources
+    import pex.third_party.pkg_resources as pkg_resources
 
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  __import__('setuptools.extern.packaging.specifiers')  # vendor:skip
+    __import__('setuptools.extern.packaging.specifiers')  # vendor:skip
 else:
-  __import__('pex.third_party.setuptools.extern.packaging.specifiers')
+    __import__('pex.third_party.setuptools.extern.packaging.specifiers')
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  __import__('setuptools.extern.packaging.version')  # vendor:skip
+    __import__('setuptools.extern.packaging.version')  # vendor:skip
 else:
-  __import__('pex.third_party.setuptools.extern.packaging.version')
+    __import__('pex.third_party.setuptools.extern.packaging.version')
 
 
 
@@ -613,9 +613,9 @@ class Distribution(_Distribution):
         ways.
         """
         if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-          from setuptools.extern.six.moves.configparser import ConfigParser  # vendor:skip
+            from setuptools.extern.six.moves.configparser import ConfigParser  # vendor:skip
         else:
-          from pex.third_party.setuptools.extern.six.moves.configparser import ConfigParser
+            from pex.third_party.setuptools.extern.six.moves.configparser import ConfigParser
 
 
         # Ignore install directory options if we have a venv
@@ -822,9 +822,9 @@ class Distribution(_Distribution):
     def fetch_build_egg(self, req):
         """Fetch an egg needed for building"""
         if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-          from setuptools.installer import fetch_build_egg  # vendor:skip
+            from setuptools.installer import fetch_build_egg  # vendor:skip
         else:
-          from pex.third_party.setuptools.installer import fetch_build_egg
+            from pex.third_party.setuptools.installer import fetch_build_egg
 
         return fetch_build_egg(self, req)
 

--- a/pex/vendor/_vendored/setuptools/setuptools/extension.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/extension.py
@@ -5,9 +5,9 @@ import distutils.errors
 import distutils.extension
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.six.moves import map  # vendor:skip
+    from setuptools.extern.six.moves import map  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.six.moves import map
+    from pex.third_party.setuptools.extern.six.moves import map
 
 
 from .monkey import get_unpatched

--- a/pex/vendor/_vendored/setuptools/setuptools/installer.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/installer.py
@@ -6,24 +6,24 @@ from distutils import log
 from distutils.errors import DistutilsError
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  import pkg_resources  # vendor:skip
+    import pkg_resources  # vendor:skip
 else:
-  import pex.third_party.pkg_resources as pkg_resources
+    import pex.third_party.pkg_resources as pkg_resources
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.command.easy_install import easy_install  # vendor:skip
+    from setuptools.command.easy_install import easy_install  # vendor:skip
 else:
-  from pex.third_party.setuptools.command.easy_install import easy_install
+    from pex.third_party.setuptools.command.easy_install import easy_install
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import six  # vendor:skip
+    from setuptools.extern import six  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import six
+    from pex.third_party.setuptools.extern import six
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.wheel import Wheel  # vendor:skip
+    from setuptools.wheel import Wheel  # vendor:skip
 else:
-  from pex.third_party.setuptools.wheel import Wheel
+    from pex.third_party.setuptools.wheel import Wheel
 
 
 from .py31compat import TemporaryDirectory

--- a/pex/vendor/_vendored/setuptools/setuptools/lib2to3_ex.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/lib2to3_ex.py
@@ -12,9 +12,9 @@ from distutils import log
 from lib2to3.refactor import RefactoringTool, get_fixers_from_package
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  import setuptools  # vendor:skip
+    import setuptools  # vendor:skip
 else:
-  import pex.third_party.setuptools as setuptools
+    import pex.third_party.setuptools as setuptools
 
 
 

--- a/pex/vendor/_vendored/setuptools/setuptools/monkey.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/monkey.py
@@ -11,15 +11,15 @@ from importlib import import_module
 import inspect
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import six  # vendor:skip
+    from setuptools.extern import six  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import six
+    from pex.third_party.setuptools.extern import six
 
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  import setuptools  # vendor:skip
+    import setuptools  # vendor:skip
 else:
-  import pex.third_party.setuptools as setuptools
+    import pex.third_party.setuptools as setuptools
 
 
 __all__ = []

--- a/pex/vendor/_vendored/setuptools/setuptools/msvc.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/msvc.py
@@ -28,24 +28,24 @@ import platform
 import itertools
 import distutils.errors
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.packaging.version import LegacyVersion  # vendor:skip
+    from setuptools.extern.packaging.version import LegacyVersion  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.packaging.version import LegacyVersion
+    from pex.third_party.setuptools.extern.packaging.version import LegacyVersion
 
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.six.moves import filterfalse  # vendor:skip
+    from setuptools.extern.six.moves import filterfalse  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.six.moves import filterfalse
+    from pex.third_party.setuptools.extern.six.moves import filterfalse
 
 
 from .monkey import get_unpatched
 
 if platform.system() == 'Windows':
     if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-      from setuptools.extern.six.moves import winreg  # vendor:skip
+        from setuptools.extern.six.moves import winreg  # vendor:skip
     else:
-      from pex.third_party.setuptools.extern.six.moves import winreg
+        from pex.third_party.setuptools.extern.six.moves import winreg
 
     from os import environ
 else:

--- a/pex/vendor/_vendored/setuptools/setuptools/namespaces.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/namespaces.py
@@ -3,9 +3,9 @@ from distutils import log
 import itertools
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.six.moves import map  # vendor:skip
+    from setuptools.extern.six.moves import map  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.six.moves import map
+    from pex.third_party.setuptools.extern.six.moves import map
 
 
 

--- a/pex/vendor/_vendored/setuptools/setuptools/package_index.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/package_index.py
@@ -11,56 +11,56 @@ import warnings
 from functools import wraps
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import six  # vendor:skip
+    from setuptools.extern import six  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import six
+    from pex.third_party.setuptools.extern import six
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.six.moves import urllib, http_client, configparser, map  # vendor:skip
+    from setuptools.extern.six.moves import urllib, http_client, configparser, map  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.six.moves import urllib, http_client, configparser, map
+    from pex.third_party.setuptools.extern.six.moves import urllib, http_client, configparser, map
 
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  import setuptools  # vendor:skip
+    import setuptools  # vendor:skip
 else:
-  import pex.third_party.setuptools as setuptools
+    import pex.third_party.setuptools as setuptools
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources import (
+    from pkg_resources import (
     CHECKOUT_DIST, Distribution, BINARY_DIST, normalize_path, SOURCE_DIST,
     Environment, find_distributions, safe_name, safe_version,
     to_filename, Requirement, DEVELOP_DIST, EGG_DIST,
 )  # vendor:skip
 else:
-  from pex.third_party.pkg_resources import (
+    from pex.third_party.pkg_resources import (
     CHECKOUT_DIST, Distribution, BINARY_DIST, normalize_path, SOURCE_DIST,
     Environment, find_distributions, safe_name, safe_version,
     to_filename, Requirement, DEVELOP_DIST, EGG_DIST,
 )
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools import ssl_support  # vendor:skip
+    from setuptools import ssl_support  # vendor:skip
 else:
-  from pex.third_party.setuptools import ssl_support
+    from pex.third_party.setuptools import ssl_support
 
 from distutils import log
 from distutils.errors import DistutilsError
 from fnmatch import translate
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.py27compat import get_all_headers  # vendor:skip
+    from setuptools.py27compat import get_all_headers  # vendor:skip
 else:
-  from pex.third_party.setuptools.py27compat import get_all_headers
+    from pex.third_party.setuptools.py27compat import get_all_headers
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.py33compat import unescape  # vendor:skip
+    from setuptools.py33compat import unescape  # vendor:skip
 else:
-  from pex.third_party.setuptools.py33compat import unescape
+    from pex.third_party.setuptools.py33compat import unescape
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.wheel import Wheel  # vendor:skip
+    from setuptools.wheel import Wheel  # vendor:skip
 else:
-  from pex.third_party.setuptools.wheel import Wheel
+    from pex.third_party.setuptools.wheel import Wheel
 
 
 __metaclass__ = type
@@ -727,9 +727,9 @@ class PackageIndex(Environment):
             if os.path.dirname(filename) != tmpdir:
                 dst = os.path.join(tmpdir, basename)
                 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-                  from setuptools.command.easy_install import samefile  # vendor:skip
+                    from setuptools.command.easy_install import samefile  # vendor:skip
                 else:
-                  from pex.third_party.setuptools.command.easy_install import samefile
+                    from pex.third_party.setuptools.command.easy_install import samefile
 
                 if not samefile(filename, dst):
                     shutil.copy2(filename, dst)

--- a/pex/vendor/_vendored/setuptools/setuptools/py27compat.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/py27compat.py
@@ -6,9 +6,9 @@ import sys
 import platform
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import six  # vendor:skip
+    from setuptools.extern import six  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import six
+    from pex.third_party.setuptools.extern import six
 
 
 

--- a/pex/vendor/_vendored/setuptools/setuptools/py33compat.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/py33compat.py
@@ -8,14 +8,14 @@ except ImportError:
     html = None
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import six  # vendor:skip
+    from setuptools.extern import six  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import six
+    from pex.third_party.setuptools.extern import six
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.six.moves import html_parser  # vendor:skip
+    from setuptools.extern.six.moves import html_parser  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.six.moves import html_parser
+    from pex.third_party.setuptools.extern.six.moves import html_parser
 
 
 __metaclass__ = type

--- a/pex/vendor/_vendored/setuptools/setuptools/sandbox.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/sandbox.py
@@ -10,20 +10,20 @@ import pickle
 import textwrap
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import six  # vendor:skip
+    from setuptools.extern import six  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import six
+    from pex.third_party.setuptools.extern import six
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.six.moves import builtins, map  # vendor:skip
+    from setuptools.extern.six.moves import builtins, map  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.six.moves import builtins, map
+    from pex.third_party.setuptools.extern.six.moves import builtins, map
 
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  import pkg_resources.py31compat  # vendor:skip
+    import pkg_resources.py31compat  # vendor:skip
 else:
-  import pex.third_party.pkg_resources.py31compat, pex.third_party.pkg_resources as pkg_resources
+    import pex.third_party.pkg_resources.py31compat, pex.third_party.pkg_resources as pkg_resources
 
 
 if sys.platform.startswith('java'):
@@ -37,9 +37,9 @@ except NameError:
 _open = open
 from distutils.errors import DistutilsError
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources import working_set  # vendor:skip
+    from pkg_resources import working_set  # vendor:skip
 else:
-  from pex.third_party.pkg_resources import working_set
+    from pex.third_party.pkg_resources import working_set
 
 
 
@@ -124,9 +124,9 @@ class UnpickleableException(Exception):
         except Exception:
             # get UnpickleableException inside the sandbox
             if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-              from setuptools.sandbox import UnpickleableException as cls  # vendor:skip
+                from setuptools.sandbox import UnpickleableException as cls  # vendor:skip
             else:
-              from pex.third_party.setuptools.sandbox import UnpickleableException as cls
+                from pex.third_party.setuptools.sandbox import UnpickleableException as cls
 
             return cls.dump(cls, cls(repr(exc)))
 
@@ -212,9 +212,9 @@ def setup_context(setup_dir):
                         with pushd(setup_dir):
                             # ensure setuptools commands are available
                             if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-                              __import__('setuptools')  # vendor:skip
+                                __import__('setuptools')  # vendor:skip
                             else:
-                              __import__('pex.third_party.setuptools')
+                                __import__('pex.third_party.setuptools')
 
                             yield
 
@@ -428,9 +428,9 @@ class DirectorySandbox(AbstractSandbox):
 
     def _violation(self, operation, *args, **kw):
         if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-          from setuptools.sandbox import SandboxViolation  # vendor:skip
+            from setuptools.sandbox import SandboxViolation  # vendor:skip
         else:
-          from pex.third_party.setuptools.sandbox import SandboxViolation
+            from pex.third_party.setuptools.sandbox import SandboxViolation
 
         raise SandboxViolation(operation, args, kw)
 

--- a/pex/vendor/_vendored/setuptools/setuptools/ssl_support.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/ssl_support.py
@@ -5,15 +5,15 @@ import re
 import functools
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.six.moves import urllib, http_client, map, filter  # vendor:skip
+    from setuptools.extern.six.moves import urllib, http_client, map, filter  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.six.moves import urllib, http_client, map, filter
+    from pex.third_party.setuptools.extern.six.moves import urllib, http_client, map, filter
 
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources import ResolutionError, ExtractionError  # vendor:skip
+    from pkg_resources import ResolutionError, ExtractionError  # vendor:skip
 else:
-  from pex.third_party.pkg_resources import ResolutionError, ExtractionError
+    from pex.third_party.pkg_resources import ResolutionError, ExtractionError
 
 
 try:

--- a/pex/vendor/_vendored/setuptools/setuptools/unicode_utils.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/unicode_utils.py
@@ -2,9 +2,9 @@ import unicodedata
 import sys
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern import six  # vendor:skip
+    from setuptools.extern import six  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern import six
+    from pex.third_party.setuptools.extern import six
 
 
 

--- a/pex/vendor/_vendored/setuptools/setuptools/version.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/version.py
@@ -1,7 +1,7 @@
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  import pkg_resources  # vendor:skip
+    import pkg_resources  # vendor:skip
 else:
-  import pex.third_party.pkg_resources as pkg_resources
+    import pex.third_party.pkg_resources as pkg_resources
 
 
 try:

--- a/pex/vendor/_vendored/setuptools/setuptools/wheel.py
+++ b/pex/vendor/_vendored/setuptools/setuptools/wheel.py
@@ -10,39 +10,39 @@ import re
 import zipfile
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  import pkg_resources  # vendor:skip
+    import pkg_resources  # vendor:skip
 else:
-  import pex.third_party.pkg_resources as pkg_resources
+    import pex.third_party.pkg_resources as pkg_resources
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  import setuptools  # vendor:skip
+    import setuptools  # vendor:skip
 else:
-  import pex.third_party.setuptools as setuptools
+    import pex.third_party.setuptools as setuptools
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from pkg_resources import parse_version  # vendor:skip
+    from pkg_resources import parse_version  # vendor:skip
 else:
-  from pex.third_party.pkg_resources import parse_version
+    from pex.third_party.pkg_resources import parse_version
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.packaging.tags import sys_tags  # vendor:skip
+    from setuptools.extern.packaging.tags import sys_tags  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.packaging.tags import sys_tags
+    from pex.third_party.setuptools.extern.packaging.tags import sys_tags
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.packaging.utils import canonicalize_name  # vendor:skip
+    from setuptools.extern.packaging.utils import canonicalize_name  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.packaging.utils import canonicalize_name
+    from pex.third_party.setuptools.extern.packaging.utils import canonicalize_name
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.extern.six import PY3  # vendor:skip
+    from setuptools.extern.six import PY3  # vendor:skip
 else:
-  from pex.third_party.setuptools.extern.six import PY3
+    from pex.third_party.setuptools.extern.six import PY3
 
 if "setuptools" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from setuptools.command.egg_info import write_requirements  # vendor:skip
+    from setuptools.command.egg_info import write_requirements  # vendor:skip
 else:
-  from pex.third_party.setuptools.command.egg_info import write_requirements
+    from pex.third_party.setuptools.command.egg_info import write_requirements
 
 
 

--- a/pex/vendor/_vendored/toml/.layout.json
+++ b/pex/vendor/_vendored/toml/.layout.json
@@ -1,1 +1,1 @@
-{"fingerprint": "1cfb2eda37e031f9815ccfd65b3695c9fb3c8bc6db24ded550a627da1d42c324", "record_relpath": "toml-0.10.2.dist-info/RECORD", "root_is_purelib": true, "stash_dir": ".prefix"}
+{"fingerprint": "3fd281547bbc087c77a8de1a2ccdd19711d62164aa3edef5a801f8092650db08", "record_relpath": "toml-0.10.2.dist-info/RECORD", "root_is_purelib": true, "stash_dir": ".prefix"}

--- a/pex/vendor/_vendored/toml/toml/__init__.py
+++ b/pex/vendor/_vendored/toml/toml/__init__.py
@@ -4,14 +4,14 @@ Released under the MIT license.
 """
 
 if "toml" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from toml import encoder  # vendor:skip
+    from toml import encoder  # vendor:skip
 else:
-  from pex.third_party.toml import encoder
+    from pex.third_party.toml import encoder
 
 if "toml" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from toml import decoder  # vendor:skip
+    from toml import decoder  # vendor:skip
 else:
-  from pex.third_party.toml import decoder
+    from pex.third_party.toml import decoder
 
 
 __version__ = "0.10.2"

--- a/pex/vendor/_vendored/toml/toml/decoder.py
+++ b/pex/vendor/_vendored/toml/toml/decoder.py
@@ -5,9 +5,9 @@ import re
 import sys
 
 if "toml" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from toml.tz import TomlTz  # vendor:skip
+    from toml.tz import TomlTz  # vendor:skip
 else:
-  from pex.third_party.toml.tz import TomlTz
+    from pex.third_party.toml.tz import TomlTz
 
 
 if sys.version_info < (3,):

--- a/pex/vendor/_vendored/toml/toml/encoder.py
+++ b/pex/vendor/_vendored/toml/toml/encoder.py
@@ -4,9 +4,9 @@ import sys
 from decimal import Decimal
 
 if "toml" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from toml.decoder import InlineTableDict  # vendor:skip
+    from toml.decoder import InlineTableDict  # vendor:skip
 else:
-  from pex.third_party.toml.decoder import InlineTableDict
+    from pex.third_party.toml.decoder import InlineTableDict
 
 
 if sys.version_info >= (3,):
@@ -291,9 +291,9 @@ class TomlPreserveCommentEncoder(TomlEncoder):
 
     def __init__(self, _dict=dict, preserve=False):
         if "toml" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-          from toml.decoder import CommentValue  # vendor:skip
+            from toml.decoder import CommentValue  # vendor:skip
         else:
-          from pex.third_party.toml.decoder import CommentValue
+            from pex.third_party.toml.decoder import CommentValue
 
         super(TomlPreserveCommentEncoder, self).__init__(_dict, preserve)
         self.dump_funcs[CommentValue] = lambda v: v.dump(self.dump_value)

--- a/pex/vendor/_vendored/toml/toml/ordered.py
+++ b/pex/vendor/_vendored/toml/toml/ordered.py
@@ -1,13 +1,13 @@
 from collections import OrderedDict
 if "toml" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from toml import TomlEncoder  # vendor:skip
+    from toml import TomlEncoder  # vendor:skip
 else:
-  from pex.third_party.toml import TomlEncoder
+    from pex.third_party.toml import TomlEncoder
 
 if "toml" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from toml import TomlDecoder  # vendor:skip
+    from toml import TomlDecoder  # vendor:skip
 else:
-  from pex.third_party.toml import TomlDecoder
+    from pex.third_party.toml import TomlDecoder
 
 
 

--- a/pex/vendor/_vendored/tomli-w/.layout.json
+++ b/pex/vendor/_vendored/tomli-w/.layout.json
@@ -1,1 +1,1 @@
-{"fingerprint": "aa3678564fc2104aae0d694c677d3ea26701821134153749cc0074077c75e70e", "record_relpath": "tomli_w-1.0.0.dist-info/RECORD", "root_is_purelib": true, "stash_dir": ".prefix"}
+{"fingerprint": "7872fe51520cd4b4901d8dea706607d9a7e20d4a6c94f6d4e66b36b6bb3e8608", "record_relpath": "tomli_w-1.0.0.dist-info/RECORD", "root_is_purelib": true, "stash_dir": ".prefix"}

--- a/pex/vendor/_vendored/tomli-w/tomli_w/__init__.py
+++ b/pex/vendor/_vendored/tomli-w/tomli_w/__init__.py
@@ -2,7 +2,7 @@ __all__ = ("dumps", "dump")
 __version__ = "1.0.0"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
 
 if "tomli-w" in __import__("os").environ.get("__PEX_UNVENDORED__", ""):
-  from tomli_w._writer import dump, dumps  # vendor:skip
+    from tomli_w._writer import dump, dumps  # vendor:skip
 else:
-  from pex.third_party.tomli_w._writer import dump, dumps
+    from pex.third_party.tomli_w._writer import dump, dumps
 

--- a/tox.ini
+++ b/tox.ini
@@ -143,6 +143,7 @@ deps =
     attrs @ git+https://github.com/python-attrs/attrs@947bfb542104209a587280701d8cb389c813459d
 
     httpx==0.23.0
+    libcst==1.6.0
 
     # We pin at 0.971 since this is the last version of mypy that supports `--python-version 2.7`.
     mypy[python2]==0.971
@@ -187,7 +188,7 @@ skip_install = true
 deps =
     ansicolors==1.1.8
     pip==24.0
-    redbaron==0.9.2
+    libcst==1.6.0
     setuptools==50.3.2
     wheel==0.35.1
     {[testenv:format-run]deps}


### PR DESCRIPTION
RedBaron stopped being maintained in 2019. Although this change was
motivated by wanting to upgrade vendored packaging to 24.2, which
RedBaron could not handle due to new Python syntax introduced since
RedBaron went dormant, I'm proceeding with the change on its own. It
turns out packaging 24.2 is not a currently viable upgrade for other
reasons.