### PR TITLE
Windows Build Fixes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 
 /.mypy_cache/
 /.tox/
+/compatible-tox-hack/compatible_tox_hack.egg-info/
 /dist/
 /docs/_static_dynamic/
 

--- a/compatible-tox-hack/pyproject.toml
+++ b/compatible-tox-hack/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "compatible-tox-hack"
+version = "0.1.0"
+dependencies = [
+    "tox<4; platform_system != 'Windows'",
+    "tox; platform_system == 'Windows'",
+    "virtualenv<20.16; platform_system != 'Windows'",
+    "virtualenv; platform_system == 'Windows'",
+]

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -15,7 +15,7 @@ def filtered_stream(exclude: str, dest: TextIO) -> Iterator[int]:
     read_fd, write_fd = os.pipe()
 
     def filter_stream() -> None:
-        with os.fdopen(read_fd, "r") as fh:
+        with os.fdopen(read_fd, "r", encoding="utf-8") as fh:
             for line in fh:
                 if not re.search(exclude, line):
                     dest.write(line)
@@ -50,6 +50,7 @@ def run_black(*args: str) -> None:
             ],
             stdout=out_fd,
             stderr=subprocess.STDOUT,
+            encoding="utf-8",
             check=True,
         )
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,7 @@ skip_missing_interpreters = true
 minversion = 3.25.1
 requires =
     # Ensure tox and virtualenv compatible back through Python 2.7.
-    tox<4
-    virtualenv<20.16
+    compatible-tox-hack @ file://{toxinidir}/compatible-tox-hack
 
 [testenv]
 # N.B.: We need modern setuptools downloaded out of band by virtualenv to work with Python>=3.12.
@@ -192,6 +191,8 @@ deps =
     setuptools==50.3.2
     wheel==0.35.1
     {[testenv:format-run]deps}
+setenv =
+    PYTHONUTF8=1
 commands =
     python -m pex.vendor {posargs}
     {[testenv:format-run]commands}
@@ -202,6 +203,7 @@ skip_install = true
 deps =
     tox
     httpx==0.23.0
+setenv = {[testenv:vendor]setenv}
 commands =
     tox -e vendor -- --no-update
     python scripts/embed-virtualenv.py


### PR DESCRIPTION
Re-jigger configuration for tox and git to support Windows dev / CI.
As part of this, fix `pex.pyenv` to work with `pyenv-win`.

More work towards #2658.

CF: https://github.com/tox-dev/tox/issues/3136#issuecomment-2638029551