### PR TITLE
Add a system to produce Windows script `.exe`s.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ env:
   # We have integration tests that exercise `--scie` support and these can trigger downloads from
   # GitHub Releases that needed elevated rate limit quota, which this gives.
   SCIENCE_AUTH_API_GITHUB_COM_BEARER: ${{ secrets.GITHUB_TOKEN }}
+  # We fetch Windows script executable stubs when building Pex.
+  _PEX_FETCH_WINDOWS_STUBS_BEARER: ${{ secrets.GITHUB_TOKEN }}
 concurrency:
   group: CI-${{ github.ref }}
   # Queue on all branches and tags, but only cancel overlapping PR burns.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
       tag:
         description: The tag to manually run a deploy for.
         required: true
+env:
+  # We build Pex `--scie`s that fetch from science.
+  SCIENCE_AUTH_API_GITHUB_COM_BEARER: ${{ secrets.GITHUB_TOKEN }}
+  # We fetch Windows script executable stubs when building Pex.
+  _PEX_FETCH_WINDOWS_STUBS_BEARER: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   org-check:
     name: Check GitHub Organization

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ __pycache__/
 /compatible-tox-hack/compatible_tox_hack.egg-info/
 /dist/
 /docs/_static_dynamic/
+/pex/windows/stubs/
 

--- a/build-backend/pex_build/setuptools/build.py
+++ b/build-backend/pex_build/setuptools/build.py
@@ -7,6 +7,7 @@ import hashlib
 import os.path
 import subprocess
 import sys
+from collections import OrderedDict
 from zipfile import ZIP_DEFLATED
 
 import pex_build
@@ -19,10 +20,25 @@ from pex import hashing, requirements, windows
 from pex.common import open_zip, safe_copy, safe_mkdir, temporary_dir
 from pex.orderedset import OrderedSet
 from pex.pep_376 import Hash, InstalledFile, Record
+from pex.typing import cast
 from pex.version import __version__
 
 if pex_build.TYPE_CHECKING:
     from typing import Any, Dict, List, Optional
+
+
+def build_sdist(
+    sdist_directory,  # type: str
+    config_settings=None,  # type: Optional[Dict[str, Any]]
+):
+    # type: (...) -> str
+
+    for stub in windows.fetch_all_stubs():
+        print("Embedded Windows script stub", stub.path, file=sys.stderr)
+
+    return cast(
+        str, setuptools.build_meta.build_sdist(sdist_directory, config_settings=config_settings)
+    )
 
 
 def get_requires_for_build_wheel(config_settings=None):
@@ -45,9 +61,12 @@ def build_wheel(
 ):
     # type: (...) -> str
 
-    wheel = setuptools.build_meta.build_wheel(
-        wheel_directory, config_settings=config_settings, metadata_directory=metadata_directory
-    )  # type: str
+    wheel = cast(
+        str,
+        setuptools.build_meta.build_wheel(
+            wheel_directory, config_settings=config_settings, metadata_directory=metadata_directory
+        ),
+    )
     wheel_path = os.path.join(wheel_directory, wheel)
     with temporary_dir() as chroot:
         with open_zip(wheel_path) as zip_fp:
@@ -56,21 +75,24 @@ def build_wheel(
         dist_info_dir = "pex-{version}.dist-info".format(version=__version__)
         record_path = os.path.join(chroot, dist_info_dir, "RECORD")
         with open(record_path) as fp:
-            installed_files = list(Record.read(fp))
+            installed_files_by_path = OrderedDict(
+                (installed_file.path, installed_file) for installed_file in Record.read(fp)
+            )
 
         for stub in windows.fetch_all_stubs():
             stub_relpath = os.path.relpath(
                 stub.path, os.path.dirname(os.path.dirname(os.path.dirname(windows.__file__)))
             )
+            if stub_relpath in installed_files_by_path:
+                continue
             stub_dst = os.path.join(chroot, stub_relpath)
             safe_mkdir(os.path.dirname(stub_dst))
             safe_copy(stub.path, stub_dst)
-            installed_files.append(
-                InstalledFile(
-                    path=stub_relpath,
-                    hash=Hash.create(hashlib.sha256(stub.data)),
-                    size=len(stub.data),
-                )
+            data = stub.read_data()
+            installed_files_by_path[stub_relpath] = InstalledFile(
+                path=stub_relpath,
+                hash=Hash.create(hashlib.sha256(data)),
+                size=len(data),
             )
             print("Embedded Windows script stub", stub.path, file=sys.stderr)
 
@@ -90,11 +112,11 @@ def build_wheel(
                     dst = os.path.relpath(src, chroot)
                     hasher = hashlib.sha256()
                     hashing.file_hash(src, digest=hasher)
-                    installed_files.append(
-                        InstalledFile(path=dst, hash=Hash.create(hasher), size=os.path.getsize(src))
+                    installed_files_by_path[dst] = InstalledFile(
+                        path=dst, hash=Hash.create(hasher), size=os.path.getsize(src)
                     )
 
-        Record.write(record_path, installed_files)
+        Record.write(record_path, installed_files_by_path.values())
         with open_zip(wheel_path, "w", compression=ZIP_DEFLATED) as zip_fp:
 
             def add_top_level_dir(name):

--- a/pex/os.py
+++ b/pex/os.py
@@ -6,15 +6,49 @@ from __future__ import absolute_import
 import os
 import sys
 
+from pex.enum import Enum
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any, List, NoReturn, Text, Tuple, Union
 
+
+class _CurrentOs(object):
+    def __get__(self, obj, objtype=None):
+        # type: (...) -> Os.Value
+        if not hasattr(self, "_current"):
+            # N.B.: Python 2.7 uses "linux2".
+            if sys.platform.startswith("linux"):
+                self._current = Os.LINUX
+            elif sys.platform == "darwin":
+                self._current = Os.MACOS
+            elif sys.platform == "win32":
+                self._current = Os.WINDOWS
+            if not hasattr(self, "_current"):
+                raise ValueError(
+                    "The current operating system is not supported!: {system}".format(
+                        system=sys.platform
+                    )
+                )
+        return self._current
+
+
+class Os(Enum["Os.Value"]):
+    class Value(Enum.Value):
+        pass
+
+    LINUX = Value("linux")
+    MACOS = Value("macos")
+    WINDOWS = Value("windows")
+    CURRENT = _CurrentOs()
+
+
+Os.seal()
+
 # N.B.: Python 2.7 uses "linux2".
-LINUX = sys.platform.startswith("linux")
-MAC = sys.platform == "darwin"
-WINDOWS = sys.platform == "win32"
+LINUX = Os.CURRENT is Os.LINUX
+MAC = Os.CURRENT is Os.MACOS
+WINDOWS = Os.CURRENT is Os.WINDOWS
 
 
 HOME_ENV_VAR = "USERPROFILE" if WINDOWS else "HOME"

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -552,7 +552,7 @@ class PEXBuilder(object):
         )
 
         bootstrap_digest = hashlib.sha1()
-        bootstrap_packages = ["cache", "fs", "repl", "third_party", "venv"]
+        bootstrap_packages = ["cache", "fs", "repl", "third_party", "venv", "windows"]
         if self._pex_info.includes_tools:
             bootstrap_packages.extend(["commands", "tools"])
 

--- a/pex/scie/__init__.py
+++ b/pex/scie/__init__.py
@@ -23,11 +23,11 @@ from pex.scie.model import (
     ScieConfiguration,
     ScieInfo,
     ScieOptions,
-    SciePlatform,
     ScieStyle,
     Url,
 )
 from pex.scie.science import SCIENCE_RELEASES_URL, SCIENCE_REQUIREMENT
+from pex.sysconfig import SysPlatform
 from pex.typing import TYPE_CHECKING, cast
 from pex.variables import ENV, Variables
 
@@ -40,7 +40,6 @@ __all__ = (
     "ScieConfiguration",
     "ScieInfo",
     "ScieOptions",
-    "SciePlatform",
     "ScieStyle",
     "build",
     "extract_options",
@@ -162,11 +161,11 @@ def register_options(parser):
         dest="scie_platforms",
         default=[],
         action="append",
-        type=SciePlatform.parse,
+        type=SysPlatform.parse,
         choices=[
             platform
-            for platform in SciePlatform.values()
-            if platform not in (SciePlatform.WINDOWS_AARCH64, SciePlatform.WINDOWS_X86_64)
+            for platform in SysPlatform.values()
+            if platform not in (SysPlatform.WINDOWS_AARCH64, SysPlatform.WINDOWS_X86_64)
         ],
         help=(
             "The platform to produce the native PEX scie executable for. Can be specified multiple "

--- a/pex/scie/science.py
+++ b/pex/scie/science.py
@@ -32,10 +32,10 @@ from pex.scie.model import (
     Provider,
     ScieConfiguration,
     ScieInfo,
-    SciePlatform,
     ScieStyle,
     Url,
 )
+from pex.sysconfig import SysPlatform
 from pex.third_party.packaging.specifiers import SpecifierSet
 from pex.third_party.packaging.version import InvalidVersion
 from pex.tracer import TRACER
@@ -75,7 +75,7 @@ def _science_binary_url(suffix=""):
     return "{science_releases_url}/download/v{version}/{binary}{suffix}".format(
         science_releases_url=SCIENCE_RELEASES_URL,
         version=MIN_SCIENCE_VERSION.raw,
-        binary=SciePlatform.CURRENT.qualified_binary_name("science-fat"),
+        binary=SysPlatform.CURRENT.qualified_binary_name("science-fat"),
         suffix=suffix,
     )
 
@@ -290,10 +290,10 @@ def _science_dir(
 
 def _science_binary_names():
     # type: () -> Iterator[str]
-    yield SciePlatform.CURRENT.binary_name("science-fat")
-    yield SciePlatform.CURRENT.qualified_binary_name("science-fat")
-    yield SciePlatform.CURRENT.binary_name("science")
-    yield SciePlatform.CURRENT.qualified_binary_name("science")
+    yield SysPlatform.CURRENT.binary_name("science-fat")
+    yield SysPlatform.CURRENT.qualified_binary_name("science-fat")
+    yield SysPlatform.CURRENT.binary_name("science")
+    yield SysPlatform.CURRENT.qualified_binary_name("science")
 
 
 def _is_compatible_science_binary(

--- a/pex/sysconfig.py
+++ b/pex/sysconfig.py
@@ -3,10 +3,17 @@
 
 from __future__ import absolute_import
 
+import os
 import os.path
+import platform
 from sysconfig import get_config_var
 
-from pex.os import WINDOWS
+from pex.enum import Enum
+from pex.os import WINDOWS, Os
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Text, TypeVar
 
 EXE_EXTENSION = get_config_var("EXE") or ""
 EXE_EXTENSIONS = (
@@ -16,8 +23,12 @@ EXE_EXTENSIONS = (
 )
 
 
+if TYPE_CHECKING:
+    _Text = TypeVar("_Text", str, Text)
+
+
 def script_name(name):
-    # type: (str) -> str
+    # type: (_Text) -> _Text
     if not EXE_EXTENSION:
         return name
     stem, ext = os.path.splitext(name)
@@ -28,3 +39,92 @@ def script_name(name):
 #  with either sysconfig.get_config_vars() or Formatter().parse() to pick apart the script dir
 #  suffix from any base dir template.
 SCRIPT_DIR = "Scripts" if WINDOWS else "bin"
+
+
+class _CurrentPlatform(object):
+    def __get__(self, obj, objtype=None):
+        # type: (...) -> SysPlatform.Value
+        if not hasattr(self, "_current"):
+            machine = platform.machine().lower()
+            if Os.CURRENT is Os.LINUX:
+                if machine in ("aarch64", "arm64"):
+                    self._current = SysPlatform.LINUX_AARCH64
+                elif machine in ("armv7l", "armv8l"):
+                    self._current = SysPlatform.LINUX_ARMV7L
+                elif machine == "ppc64le":
+                    self._current = SysPlatform.LINUX_PPC64LE
+                elif machine == "s390x":
+                    self._current = SysPlatform.LINUX_S390X
+                elif machine in ("amd64", "x86_64"):
+                    self._current = SysPlatform.LINUX_X86_64
+            if Os.CURRENT is Os.MACOS:
+                if machine in ("aarch64", "arm64"):
+                    self._current = SysPlatform.MACOS_AARCH64
+                elif machine in ("amd64", "x86_64"):
+                    self._current = SysPlatform.MACOS_X86_64
+            if Os.CURRENT is Os.WINDOWS:
+                if machine in ("aarch64", "arm64"):
+                    self._current = SysPlatform.WINDOWS_AARCH64
+                elif machine in ("amd64", "x86_64"):
+                    self._current = SysPlatform.WINDOWS_X86_64
+            if not hasattr(self, "_current"):
+                raise ValueError(
+                    "The current operating system / machine pair is not supported!: "
+                    "{system} / {machine}".format(system=Os.CURRENT, machine=machine)
+                )
+        return self._current
+
+
+class _PlatformValue(Enum.Value):
+    def __init__(
+        self,
+        os_type,  # type: Os.Value
+        arch,
+    ):
+        super(_PlatformValue, self).__init__("{os}-{arch}".format(os=os_type, arch=arch))
+        self.os = os_type
+        self.arch = arch
+
+    @property
+    def extension(self):
+        # type: () -> str
+        return ".exe" if self.os is Os.WINDOWS else ""
+
+    def binary_name(self, binary_name):
+        # type: (_Text) -> _Text
+        return "{binary_name}{extension}".format(binary_name=binary_name, extension=self.extension)
+
+    def qualified_binary_name(self, binary_name):
+        # type: (_Text) -> _Text
+        return "{binary_name}-{platform}{extension}".format(
+            binary_name=binary_name, platform=self, extension=self.extension
+        )
+
+    def qualified_file_name(self, file_name):
+        # type: (_Text) -> _Text
+        stem, ext = os.path.splitext(file_name)
+        return "{stem}-{platform}{ext}".format(stem=stem, platform=self, ext=ext)
+
+
+class SysPlatform(Enum["SysPlatform.Value"]):
+    class Value(_PlatformValue):
+        pass
+
+    LINUX_AARCH64 = Value(Os.LINUX, "aarch64")
+    LINUX_ARMV7L = Value(Os.LINUX, "armv7l")
+    LINUX_PPC64LE = Value(Os.LINUX, "powerpc64")
+    LINUX_S390X = Value(Os.LINUX, "s390x")
+    LINUX_X86_64 = Value(Os.LINUX, "x86_64")
+    MACOS_AARCH64 = Value(Os.MACOS, "aarch64")
+    MACOS_X86_64 = Value(Os.MACOS, "x86_64")
+    WINDOWS_AARCH64 = Value(Os.WINDOWS, "aarch64")
+    WINDOWS_X86_64 = Value(Os.WINDOWS, "x86_64")
+    CURRENT = _CurrentPlatform()
+
+    @classmethod
+    def parse(cls, value):
+        # type: (str) -> SysPlatform.Value
+        return cls.CURRENT if "current" == value else cls.for_value(value)
+
+
+SysPlatform.seal()

--- a/pex/venv/venv_pex.py
+++ b/pex/venv/venv_pex.py
@@ -134,7 +134,6 @@ def boot(
             )
         except ImportError:
             pass
-
     ignored_pex_env_vars = [
         "{}={}".format(name, value)
         for name, value in os.environ.items()
@@ -167,6 +166,7 @@ def boot(
             "__PEX_UNVENDORED__",
             # These are _not_ used at runtime, but are present under testing / CI and
             # simplest to add an exception for here and not warn about in CI runs.
+            "_PEX_FETCH_WINDOWS_STUBS_BEARER",
             "_PEX_PEXPECT_TIMEOUT",
             "_PEX_PIP_VERSION",
             "_PEX_REQUIRES_PYTHON",
@@ -194,6 +194,7 @@ def boot(
             "_PEX_CACHE_ACCESS_LOCK",
         )
     ]
+
     if ignored_pex_env_vars:
         maybe_log(
             "Ignoring the following environment variables in Pex venv mode:\n"

--- a/pex/venv/venv_pex.py
+++ b/pex/venv/venv_pex.py
@@ -134,6 +134,7 @@ def boot(
             )
         except ImportError:
             pass
+
     ignored_pex_env_vars = [
         "{}={}".format(name, value)
         for name, value in os.environ.items()
@@ -194,11 +195,12 @@ def boot(
             "_PEX_CACHE_ACCESS_LOCK",
         )
     ]
-
     if ignored_pex_env_vars:
         maybe_log(
             "Ignoring the following environment variables in Pex venv mode:\n"
-            "{}".format(os.linesep.join(sorted(ignored_pex_env_vars)))
+            "{ignored_env_vars}".format(
+                ignored_env_vars=os.linesep.join(sorted(ignored_pex_env_vars))
+            )
         )
 
     os.environ["VIRTUAL_ENV"] = venv_dir

--- a/pex/windows/__init__.py
+++ b/pex/windows/__init__.py
@@ -8,7 +8,6 @@ import os.path
 import struct
 import uuid
 import zipfile
-from typing import Iterator, Optional
 
 from pex.common import safe_open
 from pex.fetcher import URLFetcher
@@ -18,7 +17,7 @@ from pex.sysconfig import SysPlatform
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Text
+    from typing import Iterator, Optional, Text
 
     import attr  # vendor:skip
 else:

--- a/pex/windows/__init__.py
+++ b/pex/windows/__init__.py
@@ -44,13 +44,23 @@ def _stub_name(
 
 
 _TRAMPOLINE_VERSION = "0.5.29"
+_EXTRA_HEADERS = (
+    {
+        "Authorization": "Bearer {bearer}".format(
+            bearer=os.environ["_PEX_FETCH_WINDOWS_STUBS_BEARER"]
+        )
+    }
+    if "_PEX_FETCH_WINDOWS_STUBS_BEARER" in os.environ
+    else None
+)
 
 
 def _fetch_stub(stub_name):
     # type: (str) -> bytes
     with URLFetcher().get_body_stream(
         "https://raw.githubusercontent.com/astral-sh/uv/refs/tags/{version}/crates/uv-trampoline/"
-        "trampolines/{stub_name}".format(version=_TRAMPOLINE_VERSION, stub_name=stub_name)
+        "trampolines/{stub_name}".format(version=_TRAMPOLINE_VERSION, stub_name=stub_name),
+        extra_headers=_EXTRA_HEADERS,
     ) as in_fp:
         return in_fp.read()
 

--- a/pex/windows/__init__.py
+++ b/pex/windows/__init__.py
@@ -1,0 +1,111 @@
+# Copyright 2025 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import contextlib
+import os.path
+import struct
+import uuid
+import zipfile
+from typing import Iterator, Optional
+
+from pex.common import safe_open
+from pex.fetcher import URLFetcher
+from pex.fs import safe_rename
+from pex.os import Os
+from pex.sysconfig import SysPlatform
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Text
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
+
+
+def _stub_name(
+    platform=SysPlatform.CURRENT,  # type: SysPlatform.Value
+    gui=False,  # type: bool
+):
+    # type: (...) -> str
+
+    if platform.os is not Os.WINDOWS:
+        raise ValueError(
+            "Script stubs are only available for Windows platforms; given: {platform}".format(
+                platform=platform
+            )
+        )
+
+    return platform.binary_name(
+        "uv-trampoline-{arch}-{type}".format(arch=platform.arch, type="gui" if gui else "console")
+    )
+
+
+_TRAMPOLINE_VERSION = "0.5.29"
+
+
+def _fetch_stub(stub_name):
+    # type: (str) -> bytes
+    with URLFetcher().get_body_stream(
+        "https://raw.githubusercontent.com/astral-sh/uv/refs/tags/{version}/crates/uv-trampoline/"
+        "trampolines/{stub_name}".format(version=_TRAMPOLINE_VERSION, stub_name=stub_name)
+    ) as in_fp:
+        return in_fp.read()
+
+
+@attr.s(frozen=True)
+class Stub(object):
+    path = attr.ib()  # type: str
+    data = attr.ib()  # type: bytes
+
+
+def _load_stub(
+    platform=SysPlatform.CURRENT,  # type: SysPlatform.Value
+    gui=False,  # type: bool
+):
+    # type: (...) -> Stub
+
+    stub_name = _stub_name(platform=platform, gui=gui)
+    stub_dst = os.path.join(os.path.dirname(__file__), "stubs", stub_name)
+    if os.path.exists(stub_dst):
+        with open(stub_dst, "rb") as fp:
+            return Stub(path=stub_dst, data=fp.read())
+
+    stub = _fetch_stub(stub_name)
+    with safe_open(
+        "{stub_dst}.{unique}".format(stub_dst=stub_dst, unique=uuid.uuid4().hex), "wb"
+    ) as out_fp:
+        out_fp.write(stub)
+    safe_rename(out_fp.name, stub_dst)
+    return Stub(path=stub_dst, data=stub)
+
+
+def fetch_all_stubs():
+    # type: () -> Iterator[Stub]
+    for platform in (SysPlatform.WINDOWS_AARCH64, SysPlatform.WINDOWS_X86_64):
+        for gui in (True, False):
+            yield _load_stub(platform=platform, gui=gui)
+
+
+def create_script(
+    path,  # type: Text
+    contents,  # type: Text
+    platform=SysPlatform.CURRENT,  # type: SysPlatform.Value
+    gui=False,  # type: bool
+    python_path=None,  # type: Optional[Text]
+):
+    # type: (...) -> None
+
+    with open("{path}.{unique}".format(path=path, unique=uuid.uuid4().hex), "wb") as fp:
+        fp.write(_load_stub(platform=platform, gui=gui).data)
+        with contextlib.closing(zipfile.ZipFile(fp, "a")) as zip_fp:
+            zip_fp.writestr("__main__.py", contents.encode("utf-8"), zipfile.ZIP_STORED)
+        python_path_bytes = platform.binary_name(
+            python_path or ("pythonw" if gui else "python")
+        ).encode("utf-8")
+        fp.write(python_path_bytes)
+        fp.write(struct.pack("<I", len(python_path_bytes)))
+        fp.write(b"UVSC")
+    safe_rename(fp.name, platform.binary_name(path))

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -287,11 +287,8 @@ def make_bdist(
         yield install_wheel(dist_location)
 
 
-def install_wheel(
-    wheel,  # type: str
-    interpreter=None,  # type: Optional[PythonInterpreter]
-):
-    # type: (...) -> Distribution
+def install_wheel(wheel):
+    # type: (str) -> Distribution
     install_dir = os.path.join(safe_mkdtemp(), os.path.basename(wheel))
     install_wheel_chroot(wheel_path=wheel, destination=install_dir)
     return Distribution.load(install_dir)

--- a/testing/bin/run_tests.py
+++ b/testing/bin/run_tests.py
@@ -20,6 +20,7 @@ os.environ["_PEX_TEST_PROJECT_DIR"] = str(
 )
 sys.path.insert(0, os.environ["_PEX_TEST_PROJECT_DIR"])
 
+from pex import windows
 from pex.compatibility import urlparse
 from pex.typing import TYPE_CHECKING, cast
 from testing import devpi, pex_project_dir
@@ -106,6 +107,12 @@ def main():
     logger.log(
         logging.root.level, "Logging configured at level {level}.".format(level=options.log_level)
     )
+
+    # Ensure we have stubs available to alleviate tests from having to distinguish a special loose
+    # source state of the Pex codebase vs a packaged state.
+    for stub in windows.fetch_all_stubs():
+        if not stub.cached:
+            logger.info("Fetched windows script executable stub: {stub}".format(stub=stub.path))
 
     if options.devpi:
         if options.shutdown_devpi:

--- a/testing/scie.py
+++ b/testing/scie.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 
 import pytest
 
-from pex.scie import SciePlatform
+from pex.sysconfig import SysPlatform
 from testing import IS_PYPY, PY_VER
 
 
@@ -15,9 +15,9 @@ def has_provider():
         if PY_VER == (2, 7):
             return True
 
-        if SciePlatform.LINUX_AARCH64 is SciePlatform.CURRENT:
+        if SysPlatform.LINUX_AARCH64 is SysPlatform.CURRENT:
             return PY_VER >= (3, 7)
-        elif SciePlatform.MACOS_AARCH64 is SciePlatform.CURRENT:
+        elif SysPlatform.MACOS_AARCH64 is SysPlatform.CURRENT:
             return PY_VER >= (3, 8)
         else:
             return PY_VER >= (3, 6)

--- a/tests/integration/cli/commands/test_cache_prune.py
+++ b/tests/integration/cli/commands/test_cache_prune.py
@@ -297,8 +297,8 @@ def test_zipapp_prune_shared_bootstrap(
     assert_installed_wheels(
         expected_pip_wheels_plus("ansicolors"),
         message=(
-            "There should be an ansicolors wheel for the pex as well as pip, setuptools and wheel wheels "
-            "for at least 1 Pip."
+            "There should be an ansicolors wheel for the pex as well as pip, setuptools and wheel "
+            "wheels for at least 1 Pip."
         ),
     )
 

--- a/tests/integration/scie/test_discussion_2516.py
+++ b/tests/integration/scie/test_discussion_2516.py
@@ -9,7 +9,7 @@ import subprocess
 from textwrap import dedent
 
 from pex.common import safe_open
-from pex.scie import SciePlatform
+from pex.sysconfig import SysPlatform
 from pex.typing import TYPE_CHECKING
 from testing import make_env, run_pex_command
 
@@ -97,7 +97,7 @@ def test_discussion_2516_op(tmpdir):
         os.path.join(str(tmpdir), "ardia*")
     ), "We expected no PEX or scie leaked in the CWD."
 
-    native_scie = os.path.join(out_dir, SciePlatform.CURRENT.value, "ardia")
+    native_scie = os.path.join(out_dir, SysPlatform.CURRENT.value, "ardia")
     output = subprocess.check_output(
         args=[native_scie, "Tux", "says", "Moo?"], env=make_env(PATH=None)
     ).decode("utf-8")

--- a/tests/integration/scie/test_pex_scie.py
+++ b/tests/integration/scie/test_pex_scie.py
@@ -22,7 +22,8 @@ from pex.fetcher import URLFetcher
 from pex.layout import Layout
 from pex.orderedset import OrderedSet
 from pex.os import is_exe
-from pex.scie import SciePlatform, ScieStyle
+from pex.scie import ScieStyle
+from pex.sysconfig import SysPlatform
 from pex.targets import LocalInterpreter
 from pex.typing import TYPE_CHECKING
 from pex.version import __version__
@@ -179,19 +180,19 @@ def test_multiple_platforms(tmpdir):
         ).assert_success()
 
     python_version_by_platform = {
-        SciePlatform.LINUX_AARCH64: "3.9",
-        SciePlatform.LINUX_ARMV7L: "3.11",
-        SciePlatform.LINUX_PPC64LE: "3.12",
-        SciePlatform.LINUX_S390X: "3.13",
-        SciePlatform.LINUX_X86_64: "3.10",
-        SciePlatform.MACOS_AARCH64: "3.11",
-        SciePlatform.MACOS_X86_64: "3.12",
+        SysPlatform.LINUX_AARCH64: "3.9",
+        SysPlatform.LINUX_ARMV7L: "3.11",
+        SysPlatform.LINUX_PPC64LE: "3.12",
+        SysPlatform.LINUX_S390X: "3.13",
+        SysPlatform.LINUX_X86_64: "3.10",
+        SysPlatform.MACOS_AARCH64: "3.11",
+        SysPlatform.MACOS_X86_64: "3.12",
     }
-    assert SciePlatform.CURRENT in python_version_by_platform
+    assert SysPlatform.CURRENT in python_version_by_platform
 
     def assert_platforms(
         output_dir,  # type: str
-        expected_platforms,  # type: Iterable[SciePlatform.Value]
+        expected_platforms,  # type: Iterable[SysPlatform.Value]
     ):
         # type: (...) -> None
 
@@ -209,7 +210,7 @@ def test_multiple_platforms(tmpdir):
             assert is_exe(scie), "Expected --scie build to produce a {binary} binary.".format(
                 binary=binary
             )
-            if platform is SciePlatform.CURRENT:
+            if platform is SysPlatform.CURRENT:
                 assert b"| PEX-scie wabbit! |" in subprocess.check_output(
                     args=[scie, "PEX-scie wabbit!"], env=make_env(PATH=None)
                 )
@@ -238,13 +239,13 @@ def test_multiple_platforms(tmpdir):
     assert_platforms(
         output_dir=all_platforms_output_dir,
         expected_platforms=(
-            SciePlatform.LINUX_AARCH64,
-            SciePlatform.LINUX_ARMV7L,
-            SciePlatform.LINUX_PPC64LE,
-            SciePlatform.LINUX_S390X,
-            SciePlatform.LINUX_X86_64,
-            SciePlatform.MACOS_AARCH64,
-            SciePlatform.MACOS_X86_64,
+            SysPlatform.LINUX_AARCH64,
+            SysPlatform.LINUX_ARMV7L,
+            SysPlatform.LINUX_PPC64LE,
+            SysPlatform.LINUX_S390X,
+            SysPlatform.LINUX_X86_64,
+            SysPlatform.MACOS_AARCH64,
+            SysPlatform.MACOS_X86_64,
         ),
     )
 
@@ -257,17 +258,17 @@ def test_multiple_platforms(tmpdir):
             "--scie-platform",
             "current",
             "--scie-platform",
-            str(SciePlatform.LINUX_AARCH64),
+            str(SysPlatform.LINUX_AARCH64),
             "--scie-platform",
-            str(SciePlatform.LINUX_X86_64),
+            str(SysPlatform.LINUX_X86_64),
         ],
     )
     assert_platforms(
         output_dir=restricted_platforms_output_dir,
         expected_platforms=(
-            SciePlatform.CURRENT,
-            SciePlatform.LINUX_AARCH64,
-            SciePlatform.LINUX_X86_64,
+            SysPlatform.CURRENT,
+            SysPlatform.LINUX_AARCH64,
+            SysPlatform.LINUX_X86_64,
         ),
     )
 
@@ -313,7 +314,7 @@ def test_specified_science_binary(tmpdir):
     local_science_binary = os.path.join(str(tmpdir), "science")
     with open(local_science_binary, "wb") as write_fp, URLFetcher().get_body_stream(
         "https://github.com/a-scie/lift/releases/download/v0.10.1/{binary}".format(
-            binary=SciePlatform.CURRENT.qualified_binary_name("science")
+            binary=SysPlatform.CURRENT.qualified_binary_name("science")
         )
     ) as read_fp:
         shutil.copyfileobj(read_fp, write_fp)
@@ -427,19 +428,19 @@ def test_custom_lazy_urls(tmpdir):
     )
 
     expected_platform = None  # type: Optional[str]
-    if SciePlatform.CURRENT is SciePlatform.LINUX_AARCH64:
+    if SysPlatform.CURRENT is SysPlatform.LINUX_AARCH64:
         expected_platform = "aarch64-unknown-linux-gnu"
-    elif SciePlatform.CURRENT is SciePlatform.LINUX_ARMV7L:
+    elif SysPlatform.CURRENT is SysPlatform.LINUX_ARMV7L:
         expected_platform = "armv7-unknown-linux-gnueabihf"
-    elif SciePlatform.CURRENT is SciePlatform.LINUX_PPC64LE:
+    elif SysPlatform.CURRENT is SysPlatform.LINUX_PPC64LE:
         expected_platform = "ppc64le-unknown-linux-gnu"
-    elif SciePlatform.CURRENT is SciePlatform.LINUX_S390X:
+    elif SysPlatform.CURRENT is SysPlatform.LINUX_S390X:
         expected_platform = "s390x-unknown-linux-gnu"
-    elif SciePlatform.CURRENT is SciePlatform.LINUX_X86_64:
+    elif SysPlatform.CURRENT is SysPlatform.LINUX_X86_64:
         expected_platform = "x86_64-unknown-linux-gnu"
-    elif SciePlatform.CURRENT is SciePlatform.MACOS_AARCH64:
+    elif SysPlatform.CURRENT is SysPlatform.MACOS_AARCH64:
         expected_platform = "aarch64-apple-darwin"
-    elif SciePlatform.CURRENT is SciePlatform.MACOS_X86_64:
+    elif SysPlatform.CURRENT is SysPlatform.MACOS_X86_64:
         expected_platform = "x86_64-apple-darwin"
     assert expected_platform is not None
 
@@ -1118,7 +1119,7 @@ def test_scie_name_style_platform_file_suffix(tmpdir):
     run_pex_command(
         args=["--scie", "lazy", "--scie-name-style", "platform-file-suffix", "-o", output_file]
     ).assert_success()
-    assert sorted(["app", SciePlatform.CURRENT.qualified_binary_name("app")]) == sorted(
+    assert sorted(["app", SysPlatform.CURRENT.qualified_binary_name("app")]) == sorted(
         os.listdir(dist_dir)
     )
 
@@ -1128,7 +1129,7 @@ def test_scie_name_style_platform_parent_dir(tmpdir):
     # type: (Any) -> None
 
     foreign_platform = next(
-        plat for plat in SciePlatform.values() if SciePlatform.CURRENT is not plat
+        plat for plat in SysPlatform.values() if SysPlatform.CURRENT is not plat
     )
     dist_dir = os.path.join(str(tmpdir), "dist")
     output_file = os.path.join(dist_dir, "app")

--- a/tests/integration/test_excludes.py
+++ b/tests/integration/test_excludes.py
@@ -28,10 +28,10 @@ from pex.resolve.resolver_configuration import ResolverVersion
 from pex.sorted_tuple import SortedTuple
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import InstallationChoice, Virtualenv
-from testing import PY_VER, data, make_env, run_pex_command
+from testing import PY_VER, IntegResults, data, make_env, run_pex_command
 from testing.cli import run_pex3
 from testing.lock import extract_lock_option_args, index_lock_artifacts
-from testing.pytest.tmp import TempdirFactory
+from testing.pytest.tmp import Tempdir, TempdirFactory
 
 if TYPE_CHECKING:
     from typing import Any
@@ -311,27 +311,33 @@ class PipOptions(object):
     [pytest.param(pip_options, id=str(pip_options)) for pip_options in PipOptions.iter()],
 )
 def test_exclude_deep(
-    tmpdir,  # type: Any
+    tmpdir,  # type: Tempdir
     pip_options,  # type: PipOptions
 ):
     # type: (...) -> None
 
+    pex_root = tmpdir.join("pex_root")
+
+    def run_pex(*args):
+        # type: (str) -> IntegResults
+        return run_pex_command(
+            args=["--pex-root", pex_root] + list(pip_options.iter_args()) + list(args)
+        )
+
     # Bootstrap the Pip version being used if needed before we turn off PyPI.
     if pip_options.pip_version is not PipVersion.VENDORED:
-        run_pex_command(
-            args=list(pip_options.iter_args()) + ["ansicolors==1.1.8", "--", "-c", ""]
-        ).assert_success()
+        run_pex("ansicolors==1.1.8", "--", "-c", "").assert_success()
 
     venv = Virtualenv.create(
-        os.path.join(str(tmpdir), "venv"),
+        venv_dir=tmpdir.join("venv"),
         install_pip=InstallationChoice.UPGRADED,
         install_setuptools=InstallationChoice.UPGRADED,
         install_wheel=InstallationChoice.UPGRADED,
     )
     pip = venv.bin_path("pip")
 
-    find_links = os.path.join(str(tmpdir), "find_links")
-    project_dir = os.path.join(str(tmpdir), "projects")
+    find_links = tmpdir.join("find_links")
+    project_dir = tmpdir.join("projects")
 
     foo_dir = os.path.join(project_dir, "foo")
     with safe_open(os.path.join(foo_dir, "foo.py"), "w") as fp:
@@ -429,12 +435,12 @@ def test_exclude_deep(
 
     # Building a Pex that requires bar should (transitively) aggressively blow up in normal
     # circumstances.
-    run_pex_command(
-        args=list(pip_options.iter_args()) + ["-f", find_links, "--no-pypi", "foo", "-vv"]
-    ).assert_failure(expected_error_re=r".*I'm an evil package\..*", re_flags=re.DOTALL)
+    run_pex("-f", find_links, "--no-pypi", "foo", "-vv").assert_failure(
+        expected_error_re=r".*I'm an evil package\..*", re_flags=re.DOTALL
+    )
 
     # But an `--exclude bar` should solve this by never resolving bar at all.
-    exe = os.path.join(str(tmpdir), "exe.py")
+    exe = tmpdir.join("exe.py")
     with safe_open(exe, "w") as fp:
         fp.write(
             dedent(
@@ -451,10 +457,20 @@ def test_exclude_deep(
                 """
             )
         )
-    pex = os.path.join(str(tmpdir), "pex")
-    run_pex_command(
-        args=list(pip_options.iter_args())
-        + ["-f", find_links, "--no-pypi", "foo", "--exclude", "bar", "-o", pex, "--exe", exe]
+    pex = tmpdir.join("pex")
+    run_pex(
+        "--runtime-pex-root",
+        pex_root,
+        "-f",
+        find_links,
+        "--no-pypi",
+        "foo",
+        "--exclude",
+        "bar",
+        "-o",
+        pex,
+        "--exe",
+        exe,
     ).assert_success()
 
     # The `--exclude bar` should hobble the PEX by default though, since bar is needed but missing.

--- a/tests/integration/test_excludes.py
+++ b/tests/integration/test_excludes.py
@@ -435,7 +435,7 @@ def test_exclude_deep(
 
     # Building a Pex that requires bar should (transitively) aggressively blow up in normal
     # circumstances.
-    run_pex("-f", find_links, "--no-pypi", "foo", "-vv").assert_failure(
+    run_pex("-f", find_links, "--no-pypi", "foo", "-vvv").assert_failure(
         expected_error_re=r".*I'm an evil package\..*", re_flags=re.DOTALL
     )
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -55,7 +55,13 @@ def assert_force_local_implicit_ns_packages_issues_598(
 ):
     def create_foo_bar_setup(name, **extra_args):
         # type: (str, **Any) -> str
-        setup_args = dict(name=name, version="0.0.1", packages=["foo", "foo.bar"])
+        setup_args = dict(
+            name=name,
+            version="0.0.1",
+            packages=["foo", "foo.bar"],
+            # Ensure we generate a universal wheel:
+            options={"bdist_wheel": {"python_tag": "py2.py3"}},
+        )
         if create_ns_packages:
             setup_args.update(namespace_packages=["foo", "foo.bar"])
         if requirements:

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -148,7 +148,7 @@ def assert_force_local_implicit_ns_packages_issues_598(
     def add_wheel(builder, content):
         # type: (PEXBuilder, Dict[str, str]) -> None
         with temporary_content(content) as project:
-            dist = install_wheel(WheelBuilder(project, interpreter=builder.interpreter).bdist())
+            dist = install_wheel(WheelBuilder(project).bdist())
             builder.add_dist_location(dist.location)
 
     def add_sources(builder, content):


### PR DESCRIPTION
Use the stubs generated by the uv project for this. The lineage extends
back to distutils through the Posy project. The API is setup and
manually tested to produce working Windows scripts and the packaging
system is updated to embed these stubs in the Pex PEX, wheel and scies.
Actually using the API to create scripts when creating venvs on Windows
is still left to do.

Work towards #2658.