### PR TITLE
Upgrade PyPy to 7.3.18.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           - tox-env: py311-pip23_3_2
           - tox-env: py313-pip25_0
           - tox-env: py314-pip25_0
-          - tox-env: pypy311-pip24_3_1
+          - tox-env: pypy310-pip24_3_1
 
           # Integration tests, split most into two shards:
           # ----------------------------------------------
@@ -104,9 +104,9 @@ jobs:
           - tox-env: py314-pip25_0-integration
             pex-test-pos-args: --shard 2/2
 
-          - tox-env: pypy311-pip24_3_1-integration
+          - tox-env: pypy310-pip24_3_1-integration
             pex-test-pos-args: --shard 1/2
-          - tox-env: pypy311-pip24_3_1-integration
+          - tox-env: pypy310-pip24_3_1-integration
             pex-test-pos-args: --shard 2/2
     steps:
       - name: Free Up Disk Space

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           - tox-env: py311-pip23_3_2
           - tox-env: py313-pip25_0
           - tox-env: py314-pip25_0
-          - tox-env: pypy310-pip24_3_1
+          - tox-env: pypy311-pip24_3_1
 
           # Integration tests, split most into two shards:
           # ----------------------------------------------
@@ -104,9 +104,9 @@ jobs:
           - tox-env: py314-pip25_0-integration
             pex-test-pos-args: --shard 2/2
 
-          - tox-env: pypy310-pip24_3_1-integration
+          - tox-env: pypy311-pip24_3_1-integration
             pex-test-pos-args: --shard 1/2
-          - tox-env: pypy310-pip24_3_1-integration
+          - tox-env: pypy311-pip24_3_1-integration
             pex-test-pos-args: --shard 2/2
     steps:
       - name: Free Up Disk Space

--- a/docker/base/install_pythons.sh
+++ b/docker/base/install_pythons.sh
@@ -38,13 +38,14 @@ PYENV_VERSIONS=(
   3.5.10
   3.6.15
   3.12.9
-  pypy2.7-7.3.17
+  pypy2.7-7.3.18
   pypy3.5-7.0.0
   pypy3.6-7.3.3
   pypy3.7-7.3.9
   pypy3.8-7.3.11
   pypy3.9-7.3.16
-  pypy3.10-7.3.17
+  pypy3.10-7.3.18
+  pypy3.11-7.3.18
 )
 git clone --depth 1 "${PYENV_REPO:-https://github.com/pyenv/pyenv}" "${PYENV_ROOT}" && (
   cd "${PYENV_ROOT}" && git checkout "${PYENV_SHA:-HEAD}" && src/configure && make -C src


### PR DESCRIPTION
This pulls in a beta release of a 3.11 interpreter.
We don't switch to that yet though.

See: https://pypy.org/posts/2025/02/pypy-v7318-release.html