### PR TITLE
Fix `pex3 lock subset`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,22 @@
 # Release Notes
 
+## 2.33.1
+
+This release fixes a bug in both `pex3 lock subset` and
+`pex3 lock {create,sync,update} --elide-unused-requires-dist` for `--style universal` locks whose
+locked requirements have dependencies de-selected by the following environment markers:
++ `os_name`
++ `platform_system`
++ `sys_platform`
++ `python_version`
++ `python_full_version`
+
+The first three could lead to errors when the universal lock was generated with `--target-system`s
+and the last two could lead to errors when the universal lock was generated with
+`--interpreter-constraint`.
+
+* Fix `pex3 lock subset`. (#2684)
+
 ## 2.33.0
 
 This release adds support for Pip 25.0.1.

--- a/pex/cli/commands/lock.py
+++ b/pex/cli/commands/lock.py
@@ -1447,7 +1447,14 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
                                 constraint=constraint_by_project_name[req.project_name],
                             )
                         )
-                    to_resolve.extend(requires_dist.filter_dependencies(req, locked_req))
+                    to_resolve.extend(
+                        requires_dist.filter_dependencies(
+                            req,
+                            locked_req,
+                            requires_python=lock_file.requires_python,
+                            target_systems=lock_file.target_systems,
+                        )
+                    )
 
             resolve_subsets.append(
                 attr.evolve(

--- a/pex/resolve/lockfile/model.py
+++ b/pex/resolve/lockfile/model.py
@@ -121,7 +121,12 @@ class Lockfile(object):
             overridden=SortedTuple(overridden),
             locked_resolves=SortedTuple(
                 (
-                    requires_dist.remove_unused_requires_dist(resolve_requirements, locked_resolve)
+                    requires_dist.remove_unused_requires_dist(
+                        resolve_requirements,
+                        locked_resolve,
+                        requires_python=requires_python,
+                        target_systems=target_systems,
+                    )
                     if elide_unused_requires_dist
                     else locked_resolve
                 )

--- a/pex/resolve/lockfile/requires_dist.py
+++ b/pex/resolve/lockfile/requires_dist.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 import operator
 from collections import defaultdict, deque
-from typing import Any, FrozenSet, Type, TypeVar
 
 from pex.dist_metadata import Requirement
 from pex.exceptions import production_assert
@@ -19,7 +18,21 @@ from pex.third_party.packaging.markers import Marker, Variable
 from pex.typing import TYPE_CHECKING, Generic, cast
 
 if TYPE_CHECKING:
-    from typing import Callable, DefaultDict, Dict, Iterable, Iterator, List, Optional, Tuple, Union
+    from typing import (
+        Any,
+        Callable,
+        DefaultDict,
+        Dict,
+        FrozenSet,
+        Iterable,
+        Iterator,
+        List,
+        Optional,
+        Tuple,
+        Type,
+        TypeVar,
+        Union,
+    )
 
     import attr  # vendor:skip
 

--- a/pex/resolve/lockfile/requires_dist.py
+++ b/pex/resolve/lockfile/requires_dist.py
@@ -5,24 +5,85 @@ from __future__ import absolute_import
 
 import operator
 from collections import defaultdict, deque
+from typing import Any, FrozenSet, Type, TypeVar
 
 from pex.dist_metadata import Requirement
 from pex.exceptions import production_assert
+from pex.interpreter_constraints import iter_compatible_versions
 from pex.orderedset import OrderedSet
+from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
-from pex.resolve.locked_resolve import LockedRequirement, LockedResolve
+from pex.resolve.locked_resolve import LockedRequirement, LockedResolve, TargetSystem
 from pex.sorted_tuple import SortedTuple
 from pex.third_party.packaging.markers import Marker, Variable
-from pex.typing import TYPE_CHECKING, cast
+from pex.typing import TYPE_CHECKING, Generic, cast
 
 if TYPE_CHECKING:
     from typing import Callable, DefaultDict, Dict, Iterable, Iterator, List, Optional, Tuple, Union
 
     import attr  # vendor:skip
 
-    EvalExtra = Callable[[ProjectName], bool]
+    EvalMarker = Callable[["MarkerEnv"], bool]
 else:
     from pex.third_party import attr
+
+
+@attr.s(frozen=True)
+class MarkerEnv(object):
+    @classmethod
+    def create(
+        cls,
+        extras,  # type: Iterable[str]
+        requires_python,  # type: Iterable[str]
+        target_systems,  # type: Iterable[TargetSystem.Value]
+    ):
+        # type: (...) -> MarkerEnv
+
+        python_full_versions = (
+            list(iter_compatible_versions(requires_python)) if requires_python else []
+        )
+        python_versions = OrderedSet(
+            python_full_version[:2] for python_full_version in python_full_versions
+        )
+
+        os_names = []
+        platform_systems = []
+        sys_platforms = []
+        for target_system in target_systems:
+            if target_system is TargetSystem.LINUX:
+                os_names.append("posix")
+                platform_systems.append("Linux")
+                sys_platforms.append("linux")
+                sys_platforms.append("linux2")
+            elif target_system is TargetSystem.MAC:
+                os_names.append("posix")
+                platform_systems.append("Darwin")
+                sys_platforms.append("darwin")
+            elif target_system is TargetSystem.WINDOWS:
+                os_names.append("nt")
+                platform_systems.append("Windows")
+                sys_platforms.append("win32")
+
+        return cls(
+            extras=frozenset(ProjectName(extra) for extra in (extras or [""])),
+            os_names=frozenset(os_names),
+            platform_systems=frozenset(platform_systems),
+            sys_platforms=frozenset(sys_platforms),
+            python_versions=frozenset(
+                Version(".".join(map(str, python_version))) for python_version in python_versions
+            ),
+            python_full_versions=frozenset(
+                Version(".".join(map(str, python_full_version)))
+                for python_full_version in python_full_versions
+            ),
+        )
+
+    extras = attr.ib()  # type: FrozenSet[ProjectName]
+    os_names = attr.ib()  # type: FrozenSet[str]
+    platform_systems = attr.ib()  # type: FrozenSet[str]
+    sys_platforms = attr.ib()  # type: FrozenSet[str]
+    python_versions = attr.ib()  # type: FrozenSet[Version]
+    python_full_versions = attr.ib()  # type: FrozenSet[Version]
 
 
 _OPERATORS = {
@@ -39,26 +100,110 @@ _OPERATORS = {
 
 class _Op(object):
     def __init__(self, lhs):
-        self.lhs = lhs  # type: EvalExtra
-        self.rhs = None  # type: Optional[EvalExtra]
+        self.lhs = lhs  # type: EvalMarker
+        self.rhs = None  # type: Optional[EvalMarker]
 
 
 class _And(_Op):
-    def __call__(self, extra):
-        # type: (ProjectName) -> bool
+    def __call__(self, marker_env):
+        # type: (MarkerEnv) -> bool
         production_assert(self.rhs is not None)
-        return self.lhs(extra) and cast("EvalExtra", self.rhs)(extra)
+        return self.lhs(marker_env) and cast("EvalMarker", self.rhs)(marker_env)
 
 
 class _Or(_Op):
-    def __call__(self, extra):
-        # type: (ProjectName) -> bool
+    def __call__(self, marker_env):
+        # type: (MarkerEnv) -> bool
         production_assert(self.rhs is not None)
-        return self.lhs(extra) or cast("EvalExtra", self.rhs)(extra)
+        return self.lhs(marker_env) or cast("EvalMarker", self.rhs)(marker_env)
 
 
-def _parse_extra_item(
-    stack,  # type: List[EvalExtra]
+def _get_values_func(marker):
+    # type: (str) -> Optional[Tuple[Callable[[MarkerEnv], FrozenSet], Type]]
+
+    if marker == "extra":
+        return lambda marker_env: marker_env.extras, ProjectName
+    elif marker == "os_name":
+        return lambda marker_env: marker_env.os_names, str
+    elif marker == "platform_system":
+        return lambda marker_env: marker_env.platform_systems, str
+    elif marker == "sys_platform":
+        return lambda marker_env: marker_env.sys_platforms, str
+    elif marker == "python_version":
+        return lambda marker_env: marker_env.python_versions, Version
+    elif marker == "python_full_version":
+        return lambda marker_env: marker_env.python_full_versions, Version
+    return None
+
+
+if TYPE_CHECKING:
+    _T = TypeVar("_T")
+
+
+class EvalMarkerFunc(Generic["_T"]):
+    @classmethod
+    def create(
+        cls,
+        lhs,  # type: Any
+        op,  # type: Any
+        rhs,  # type: Any
+    ):
+        # type: (...) -> Callable[[MarkerEnv], bool]
+
+        if isinstance(lhs, Variable):
+            value = _get_values_func(str(lhs))
+            if value:
+                get_values, operand_type = value
+                return cls(
+                    get_values=get_values,
+                    op=_OPERATORS[str(op)],
+                    operand_type=operand_type,
+                    rhs=operand_type(rhs),
+                )
+
+        if isinstance(rhs, Variable):
+            value = _get_values_func(str(rhs))
+            if value:
+                get_values, operand_type = value
+                return cls(
+                    get_values=get_values,
+                    op=_OPERATORS[str(op)],
+                    operand_type=operand_type,
+                    lhs=operand_type(lhs),
+                )
+
+        return lambda _: True
+
+    def __init__(
+        self,
+        get_values,  # type: Callable[[MarkerEnv], Iterable[_T]]
+        op,  # type: Callable[[_T, _T], bool]
+        operand_type,  # type: Callable[[Any], _T]
+        lhs=None,  # type: Optional[_T]
+        rhs=None,  # type: Optional[_T]
+    ):
+        # type: (...) -> None
+
+        self._get_values = get_values
+        if lhs is not None:
+            self._func = lambda value: op(cast("_T", lhs), operand_type(value))
+        elif rhs is not None:
+            self._func = lambda value: op(operand_type(value), cast("_T", rhs))
+        else:
+            raise ValueError(
+                "Must be called with exactly one of lhs or rhs but not both. "
+                "Given lhs={lhs} and rhs={rhs}".format(lhs=lhs, rhs=rhs)
+            )
+
+    def __call__(self, marker_env):
+        # type: (MarkerEnv) -> bool
+
+        values = self._get_values(marker_env)
+        return any(map(self._func, values)) if values else True
+
+
+def _parse_marker_item(
+    stack,  # type: List[EvalMarker]
     item,  # type: Union[str, List, Tuple]
     marker,  # type: Marker
 ):
@@ -70,16 +215,10 @@ def _parse_extra_item(
         stack.append(_Or(stack.pop()))
     elif isinstance(item, list):
         for element in item:
-            _parse_extra_item(stack, element, marker)
+            _parse_marker_item(stack, element, marker)
     elif isinstance(item, tuple):
         lhs, op, rhs = item
-        if isinstance(lhs, Variable) and "extra" == str(lhs):
-            check = lambda extra: _OPERATORS[str(op)](extra, ProjectName(str(rhs)))
-        elif isinstance(rhs, Variable) and "extra" == str(rhs):
-            check = lambda extra: _OPERATORS[str(op)](extra, ProjectName(str(lhs)))
-        else:
-            # Any other condition could potentially be true.
-            check = lambda _: True
+        check = EvalMarkerFunc.create(lhs, op, rhs)
         if stack:
             production_assert(isinstance(stack[-1], _Op))
             cast(_Op, stack[-1]).rhs = check
@@ -89,47 +228,53 @@ def _parse_extra_item(
         raise ValueError("Marker is invalid: {marker}".format(marker=marker))
 
 
-def _parse_extra_check(marker):
-    # type: (Marker) -> EvalExtra
-    checks = []  # type: List[EvalExtra]
+def _parse_marker_check(marker):
+    # type: (Marker) -> EvalMarker
+    checks = []  # type: List[EvalMarker]
     for item in marker._markers:
-        _parse_extra_item(checks, item, marker)
+        _parse_marker_item(checks, item, marker)
     production_assert(len(checks) == 1)
     return checks[0]
 
 
-_EXTRA_CHECKS = {}  # type: Dict[str, EvalExtra]
+_MARKER_CHECKS = {}  # type: Dict[str, EvalMarker]
 
 
-def _parse_marker_for_extra_check(marker):
-    # type: (Marker) -> EvalExtra
+def _parse_marker(marker):
+    # type: (Marker) -> EvalMarker
     maker_str = str(marker)
-    eval_extra = _EXTRA_CHECKS.get(maker_str)
-    if not eval_extra:
-        eval_extra = _parse_extra_check(marker)
-        _EXTRA_CHECKS[maker_str] = eval_extra
-    return eval_extra
+    eval_marker = _MARKER_CHECKS.get(maker_str)
+    if not eval_marker:
+        eval_marker = _parse_marker_check(marker)
+        _MARKER_CHECKS[maker_str] = eval_marker
+    return eval_marker
 
 
 def filter_dependencies(
     requirement,  # type: Requirement
     locked_requirement,  # type: LockedRequirement
+    requires_python=(),  # type: Iterable[str]
+    target_systems=(),  # type: Iterable[TargetSystem.Value]
 ):
     # type: (...) -> Iterator[Requirement]
 
-    extras = requirement.extras or [""]
+    marker_env = MarkerEnv.create(
+        extras=requirement.extras, requires_python=requires_python, target_systems=target_systems
+    )
     for dep in locked_requirement.requires_dists:
         if not dep.marker:
             yield dep
         else:
-            eval_extra = _parse_marker_for_extra_check(dep.marker)
-            if any(eval_extra(ProjectName(extra)) for extra in extras):
+            eval_marker = _parse_marker(dep.marker)
+            if eval_marker(marker_env):
                 yield dep
 
 
 def remove_unused_requires_dist(
     resolve_requirements,  # type: Iterable[Requirement]
     locked_resolve,  # type: LockedResolve
+    requires_python=(),  # type: Iterable[str]
+    target_systems=(),  # type: Iterable[TargetSystem.Value]
 ):
     # type: (...) -> LockedResolve
 
@@ -151,7 +296,9 @@ def remove_unused_requires_dist(
         if not locked_req:
             continue
 
-        for dep in filter_dependencies(requirement, locked_req):
+        for dep in filter_dependencies(
+            requirement, locked_req, requires_python=requires_python, target_systems=target_systems
+        ):
             if dep.project_name in locked_req_by_project_name:
                 requires_dist_by_locked_req[locked_req].add(dep)
                 requirements.append(dep)

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.33.0"
+__version__ = "2.33.1"

--- a/testing/data/locks/issue-2683.lock.json
+++ b/testing/data/locks/issue-2683.lock.json
@@ -1,0 +1,5548 @@
+{
+  "allow_builds": true,
+  "allow_prereleases": false,
+  "allow_wheels": true,
+  "build_isolation": true,
+  "constraints": [],
+  "locked_resolves": [
+    {
+      "locked_requirements": [
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "ca34aadfb59889376d475bd8c1d7850c42b22a0cece54ed478945f41b0b960de",
+              "url": "https://files.pythonhosted.org/packages/bc/37/176e986a1fc8865c14d56dfea7faca5a404d609a31da810c4b8ce2cace1e/acsylla-0.2.0-cp310-cp310-manylinux_2_28_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "57834973f8916c282488a711de0b9017e18ce10319583c92eeff2ec1da18aa3b",
+              "url": "https://files.pythonhosted.org/packages/95/85/3280954ca626cd17187619735a4b8dabe26d0688379d972c36cfb47cceec/acsylla-0.2.0-cp310-cp310-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "22f966ff9e9c71eb2ca1bea0c3a8e56e76512e564323fb83c106f01acafeed3f",
+              "url": "https://files.pythonhosted.org/packages/c7/8c/0cd3933e0cc1b14ca05916c6f3181cc13007aaf6ccae70beed80d55f074b/acsylla-0.2.0-cp310-cp310-manylinux_2_28_aarch64.whl"
+            }
+          ],
+          "project_name": "acsylla",
+          "requires_dists": [
+            "Cython; extra == \"dev\"",
+            "asynctest==0.13.0; extra == \"dev\"",
+            "black==22.8.0; extra == \"dev\"",
+            "click==8.1.3; extra == \"dev\"",
+            "flake8==4.0.1; extra == \"dev\"",
+            "isort==5.9.3; extra == \"dev\"",
+            "mypy==0.910; extra == \"dev\"",
+            "pytest-asyncio==0.16.0; extra == \"dev\"",
+            "pytest-cov==3.0.0; extra == \"dev\"",
+            "pytest-mock==3.6.1; extra == \"dev\"",
+            "pytest==6.2.5; extra == \"dev\"",
+            "setuptools; extra == \"dev\""
+          ],
+          "requires_python": null,
+          "version": "0.2.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "99bd884ca390466db5e27ffccff1d179ec5c05c965cfefc0607e69f9e411cb25",
+              "url": "https://files.pythonhosted.org/packages/cb/06/8b505aea3d77021b18dcbd8133aa1418f1a1e37e432a465b14c46b2c0eaa/alembic-1.14.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b00892b53b3642d0b8dbedba234dbf1924b69be83a9a769d5a624b01094e304b",
+              "url": "https://files.pythonhosted.org/packages/00/1e/8cb8900ba1b6360431e46fb7a89922916d3a1b017a8908a7c0499cc7e5f6/alembic-1.14.0.tar.gz"
+            }
+          ],
+          "project_name": "alembic",
+          "requires_dists": [
+            "Mako",
+            "SQLAlchemy>=1.3.0",
+            "backports.zoneinfo; python_version < \"3.9\" and extra == \"tz\"",
+            "importlib-metadata; python_version < \"3.9\"",
+            "importlib-resources; python_version < \"3.9\"",
+            "typing-extensions>=4"
+          ],
+          "requires_python": ">=3.8",
+          "version": "1.14.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53",
+              "url": "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89",
+              "url": "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz"
+            }
+          ],
+          "project_name": "annotated-types",
+          "requires_dists": [
+            "typing-extensions>=4.0.0; python_version < \"3.9\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "0.7.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "ea60c3723ab42ba6fff7e8ccb0488c898ec538ff4df1f1d5e642c3601d07e352",
+              "url": "https://files.pythonhosted.org/packages/a0/7a/4daaf3b6c08ad7ceffea4634ec206faeff697526421c20f07628c7372156/anyio-4.7.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2f834749c602966b7d456a7567cafcb309f96482b5081d14ac93ccd457f9dd48",
+              "url": "https://files.pythonhosted.org/packages/f6/40/318e58f669b1a9e00f5c4453910682e2d9dd594334539c7b7817dabb765f/anyio-4.7.0.tar.gz"
+            }
+          ],
+          "project_name": "anyio",
+          "requires_dists": [
+            "Sphinx~=7.4; extra == \"doc\"",
+            "anyio[trio]; extra == \"test\"",
+            "coverage[toml]>=7; extra == \"test\"",
+            "exceptiongroup>=1.0.2; python_version < \"3.11\"",
+            "exceptiongroup>=1.2.0; extra == \"test\"",
+            "hypothesis>=4.0; extra == \"test\"",
+            "idna>=2.8",
+            "packaging; extra == \"doc\"",
+            "psutil>=5.9; extra == \"test\"",
+            "pytest-mock>=3.6.1; extra == \"test\"",
+            "pytest>=7.0; extra == \"test\"",
+            "sniffio>=1.1",
+            "sphinx-autodoc-typehints>=1.2.0; extra == \"doc\"",
+            "sphinx_rtd_theme; extra == \"doc\"",
+            "trio>=0.26.1; extra == \"trio\"",
+            "trustme; extra == \"test\"",
+            "truststore>=0.9.1; python_version >= \"3.10\" and extra == \"test\"",
+            "typing_extensions>=4.5; python_version < \"3.13\"",
+            "uvloop>=0.21; (platform_python_implementation == \"CPython\" and platform_system != \"Windows\") and extra == \"test\""
+          ],
+          "requires_python": ">=3.9",
+          "version": "4.7.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c",
+              "url": "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee",
+              "url": "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz"
+            }
+          ],
+          "project_name": "appnope",
+          "requires_dists": [],
+          "requires_python": ">=3.6",
+          "version": "0.1.4"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "e3078351a059199dd5138cb1c706e6430c05eff2ff136af5eb4790f9d28932e2",
+              "url": "https://files.pythonhosted.org/packages/25/8a/c46dcc25341b5bce5472c718902eb3d38600a903b14fa6aeecef3f21a46f/asttokens-3.0.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0dcd8baa8d62b0c1d118b399b2ddba3c4aff271d0d7a9e0d4c1681c79035bbc7",
+              "url": "https://files.pythonhosted.org/packages/4a/e7/82da0a03e7ba5141f05cce0d302e6eed121ae055e0456ca228bf693984bc/asttokens-3.0.0.tar.gz"
+            }
+          ],
+          "project_name": "asttokens",
+          "requires_dists": [
+            "astroid<4,>=2; extra == \"astroid\"",
+            "astroid<4,>=2; extra == \"test\"",
+            "pytest-cov; extra == \"test\"",
+            "pytest-xdist; extra == \"test\"",
+            "pytest; extra == \"test\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "3.0.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "ac96cd038792094f438ad1f6ff80837353805ac950cd2aa0e0625ef19850c308",
+              "url": "https://files.pythonhosted.org/packages/89/aa/ab0f7891a01eeb2d2e338ae8fecbe57fcebea1a24dbb64d45801bfab481d/attrs-24.3.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8f5c07333d543103541ba7be0e2ce16eeee8130cb0b3f9238ab904ce1e85baff",
+              "url": "https://files.pythonhosted.org/packages/48/c8/6260f8ccc11f0917360fc0da435c5c9c7504e3db174d5a12a1494887b045/attrs-24.3.0.tar.gz"
+            }
+          ],
+          "project_name": "attrs",
+          "requires_dists": [
+            "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"benchmark\"",
+            "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"cov\"",
+            "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"dev\"",
+            "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"tests\"",
+            "cogapp; extra == \"docs\"",
+            "coverage[toml]>=5.3; extra == \"cov\"",
+            "furo; extra == \"docs\"",
+            "hypothesis; extra == \"benchmark\"",
+            "hypothesis; extra == \"cov\"",
+            "hypothesis; extra == \"dev\"",
+            "hypothesis; extra == \"tests\"",
+            "mypy>=1.11.1; (platform_python_implementation == \"CPython\" and python_version >= \"3.10\") and extra == \"benchmark\"",
+            "mypy>=1.11.1; (platform_python_implementation == \"CPython\" and python_version >= \"3.10\") and extra == \"cov\"",
+            "mypy>=1.11.1; (platform_python_implementation == \"CPython\" and python_version >= \"3.10\") and extra == \"dev\"",
+            "mypy>=1.11.1; (platform_python_implementation == \"CPython\" and python_version >= \"3.10\") and extra == \"tests\"",
+            "mypy>=1.11.1; (platform_python_implementation == \"CPython\" and python_version >= \"3.10\") and extra == \"tests-mypy\"",
+            "myst-parser; extra == \"docs\"",
+            "pre-commit-uv; extra == \"dev\"",
+            "pympler; extra == \"benchmark\"",
+            "pympler; extra == \"cov\"",
+            "pympler; extra == \"dev\"",
+            "pympler; extra == \"tests\"",
+            "pytest-codspeed; extra == \"benchmark\"",
+            "pytest-mypy-plugins; (platform_python_implementation == \"CPython\" and python_version >= \"3.10\") and extra == \"benchmark\"",
+            "pytest-mypy-plugins; (platform_python_implementation == \"CPython\" and python_version >= \"3.10\") and extra == \"cov\"",
+            "pytest-mypy-plugins; (platform_python_implementation == \"CPython\" and python_version >= \"3.10\") and extra == \"dev\"",
+            "pytest-mypy-plugins; (platform_python_implementation == \"CPython\" and python_version >= \"3.10\") and extra == \"tests\"",
+            "pytest-mypy-plugins; (platform_python_implementation == \"CPython\" and python_version >= \"3.10\") and extra == \"tests-mypy\"",
+            "pytest-xdist[psutil]; extra == \"benchmark\"",
+            "pytest-xdist[psutil]; extra == \"cov\"",
+            "pytest-xdist[psutil]; extra == \"dev\"",
+            "pytest-xdist[psutil]; extra == \"tests\"",
+            "pytest>=4.3.0; extra == \"benchmark\"",
+            "pytest>=4.3.0; extra == \"cov\"",
+            "pytest>=4.3.0; extra == \"dev\"",
+            "pytest>=4.3.0; extra == \"tests\"",
+            "sphinx-notfound-page; extra == \"docs\"",
+            "sphinx; extra == \"docs\"",
+            "sphinxcontrib-towncrier; extra == \"docs\"",
+            "towncrier<24.7; extra == \"docs\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "24.3.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "49680300f842f3a8722b060ac0d3ed7aca071d1ad4d3d38c9fdadafdcc73c30b",
+              "url": "https://files.pythonhosted.org/packages/6d/90/d13cf396989052cadd8511c1878b0913bbce28eeef5feb95710a92e03076/autograd-1.7.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "de743fd368d6df523cd37305dcd171861a9752a144493677d2c9f5a56983ff2f",
+              "url": "https://files.pythonhosted.org/packages/28/ed/67975d75c0fe71220c8df2370c6c1390805790a641359b502f39c042c0c1/autograd-1.7.0.tar.gz"
+            }
+          ],
+          "project_name": "autograd",
+          "requires_dists": [
+            "numpy",
+            "scipy; extra == \"scipy\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "1.7.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "f27abb7b8bb9cffc8badcbf59f3fe44a9db39e124ecacf1992b6d952934ac9c4",
+              "url": "https://files.pythonhosted.org/packages/85/ae/7f2031ea76140444b2453fa139041e5afd4a09fc5300cfefeb1103291f80/autograd-gamma-0.5.0.tar.gz"
+            }
+          ],
+          "project_name": "autograd-gamma",
+          "requires_dists": [
+            "autograd>=1.2.0",
+            "scipy>=1.2.0"
+          ],
+          "requires_python": null,
+          "version": "0.5.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "050e9190e1211f6bb901f44241237e7310a8a71191bb31cb35779f795644209f",
+              "url": "https://files.pythonhosted.org/packages/e2/c3/f429b1e76a26e7a19474a0b56e3b76b403a860725a7e618b96754ebd70aa/awswrangler-3.10.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2c12c522ddf4f59214bb7b79ecab585fa8bb96ea6300e48126962485f1598ddf",
+              "url": "https://files.pythonhosted.org/packages/d1/83/1e60d8a85e1db7203fb33b749666edff29a96f77ecccf219ce4bb2587adc/awswrangler-3.10.1.tar.gz"
+            }
+          ],
+          "project_name": "awswrangler",
+          "requires_dists": [
+            "SPARQLWrapper<3.0.0,>=2.0.0; extra == \"sparql\"",
+            "aiohttp<4.0.0,>=3.9.0; extra == \"gremlin\"",
+            "async-timeout<6.0.0,>=4.0.3; extra == \"gremlin\"",
+            "boto3<2.0.0,>=1.20.32",
+            "botocore<2.0.0,>=1.23.32",
+            "deltalake<0.22.0,>=0.18.0; extra == \"deltalake\"",
+            "geopandas<0.14.0,>=0.13.2; python_version < \"3.12\" and extra == \"geopandas\"",
+            "geopandas<0.15.0,>=0.14.1; python_version >= \"3.12\" and extra == \"geopandas\"",
+            "gremlinpython<4.0.0,>=3.7.1; extra == \"gremlin\"",
+            "jsonpath-ng<2.0.0,>=1.5.3; extra == \"opensearch\"",
+            "modin<0.32.0,>=0.31.0; python_version >= \"3.9\" and extra == \"modin\"",
+            "modin==0.23.1post0; python_version < \"3.9\" and extra == \"modin\"",
+            "numpy<2.0,>=1.18; python_version < \"3.9\"",
+            "numpy<3.0,>=1.26; python_version >= \"3.9\"",
+            "openpyxl<4.0.0,>=3.0.0; extra == \"openpyxl\"",
+            "opensearch-py<3.0.0,>=2.0.0; extra == \"opensearch\"",
+            "oracledb<3,>=1; extra == \"oracle\"",
+            "packaging<25.0,>=21.1",
+            "pandas<2.1.0,>=1.2.0; python_version < \"3.9\"",
+            "pandas<3.0.0,>=1.2.0; python_version >= \"3.9\"",
+            "pg8000<2.0.0,>=1.29.0; extra == \"postgres\"",
+            "progressbar2<5.0.0,>=4.0.0; extra == \"progressbar\"",
+            "pyarrow>=8.0.0",
+            "pymysql<2.0.0,>=1.0.0; extra == \"mysql\"",
+            "pyodbc<6,>=4; extra == \"sqlserver\"",
+            "ray[data,default]<3.0.0,>=2.30.0; extra == \"ray\"",
+            "redshift-connector<3.0.0,>=2.0.0; extra == \"redshift\"",
+            "requests-aws4auth<2.0.0,>=1.1.1; extra == \"opensearch\"",
+            "requests<3.0.0,>=2.0.0; extra == \"gremlin\" or extra == \"sparql\" or extra == \"opencypher\"",
+            "setuptools; python_version >= \"3.12\"",
+            "typing-extensions<5.0.0,>=4.4.0"
+          ],
+          "requires_python": "<4.0,>=3.8",
+          "version": "3.10.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "c94fc8023caf952f8740a48fc400521bba167f883cfa547d985c05fda7223f7a",
+              "url": "https://files.pythonhosted.org/packages/19/4a/b3fefabc2795d0adda85f092332ec0544e57e80c86d6d9f9bb1484b73d79/boto3-1.35.84-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9f9bf72d92f7fdd546b974ffa45fa6715b9af7f5c00463e9d0f6ef9c95efe0c2",
+              "url": "https://files.pythonhosted.org/packages/9f/c5/c6e68d008905ec4069cb92473606fc2eea12384f990c786a199ea3db2c7e/boto3-1.35.84.tar.gz"
+            }
+          ],
+          "project_name": "boto3",
+          "requires_dists": [
+            "botocore<1.36.0,>=1.35.84",
+            "botocore[crt]<2.0a0,>=1.21.0; extra == \"crt\"",
+            "jmespath<2.0.0,>=0.7.1",
+            "s3transfer<0.11.0,>=0.10.0"
+          ],
+          "requires_python": ">=3.8",
+          "version": "1.35.84"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "b4dc2ac7f54ba959429e1debbd6c7c2fb2349baa1cd63803f0682f0773dbd077",
+              "url": "https://files.pythonhosted.org/packages/b4/1f/a36fc867c6aef0d346e9b6b2bfe33be458c36f770f7ad8e15acc3474999d/botocore-1.35.84-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f86754882e04683e2e99a6a23377d0dd7f1fc2b2242844b2381dbe4dcd639301",
+              "url": "https://files.pythonhosted.org/packages/fd/17/d50362869aab4a0ae0f63416a03e592bf7fd3adb155dabce484198545c56/botocore-1.35.84.tar.gz"
+            }
+          ],
+          "project_name": "botocore",
+          "requires_dists": [
+            "awscrt==0.22.0; extra == \"crt\"",
+            "jmespath<2.0.0,>=0.7.1",
+            "python-dateutil<3.0.0,>=2.1",
+            "urllib3!=2.2.0,<3,>=1.25.4; python_version >= \"3.10\"",
+            "urllib3<1.27,>=1.25.4; python_version < \"3.10\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "1.35.84"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "e7f1dfa33c3d93350057d6dc163bb92748b6e6a164c408c75cf2c59be0a203b7",
+              "url": "https://files.pythonhosted.org/packages/3b/3a/354db5ac8349ba5dd9827f43c2436221387368f48db50b030ded8cdf91ea/cassandra_driver-3.29.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "957208093ff2353230d0d83edf8c8e8582e4f2999d9a33292be6558fec943562",
+              "url": "https://files.pythonhosted.org/packages/54/b4/d5da6b2e82abc8b1d9f93bbc633441a51098bb183aaf2c0481162e17fffe/cassandra_driver-3.29.2-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c4310a7d0457f51a63fb019d8ef501588c491141362b53097fbc62fa06559b7c",
+              "url": "https://files.pythonhosted.org/packages/b2/6f/d25121afaa2ea0741d05d2e9921a7ca9b4ce71634b16a8aaee21bd7af818/cassandra-driver-3.29.2.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "06ad489e4df2cc7f41d3aca8bd8ddeb8071c4fb98240ed07f1dcd9b5180fd879",
+              "url": "https://files.pythonhosted.org/packages/cc/60/f8de88175937481be98da88eb88b4fd704093e284e5907775293c496df32/cassandra_driver-3.29.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d70353b6d9d6e01e2b261efccfe90ce0aa6f416588e6e626ca2ed0aff6b540cf",
+              "url": "https://files.pythonhosted.org/packages/f4/6d/366346a652f8523c26307846ec5c59e93fdfeee28e67078d68a07fcb2da2/cassandra_driver-3.29.2-cp310-cp310-macosx_11_0_arm64.whl"
+            }
+          ],
+          "project_name": "cassandra-driver",
+          "requires_dists": [
+            "cryptography>=35.0; extra == \"cle\"",
+            "geomet<0.3,>=0.1",
+            "gremlinpython==3.4.6; extra == \"graph\""
+          ],
+          "requires_python": null,
+          "version": "3.29.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56",
+              "url": "https://files.pythonhosted.org/packages/a5/32/8f6669fc4798494966bf446c8c4a162e0b5d893dff088afddf76414f70e1/certifi-2024.12.14-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db",
+              "url": "https://files.pythonhosted.org/packages/0f/bd/1d41ee578ce09523c81a15426705dd20969f5abf006d1afe8aeff0dd776a/certifi-2024.12.14.tar.gz"
+            }
+          ],
+          "project_name": "certifi",
+          "requires_dists": [],
+          "requires_python": ">=3.6",
+          "version": "2024.12.14"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "6b8b4a92e1c65048ff98cfe1f735ef8f1ceb72e3d5f0c25fdb12087a23da22be",
+              "url": "https://files.pythonhosted.org/packages/21/81/a6cd025db2f08ac88b901b745c163d884641909641f9b826e8cb87645942/cffi-1.17.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67",
+              "url": "https://files.pythonhosted.org/packages/08/fd/cc2fedbd887223f9f5d170c96e57cbf655df9831a6546c1727ae13fa977a/cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6883e737d7d9e4899a8a695e00ec36bd4e5e4f18fabe0aca0efe0a4b44cdb13e",
+              "url": "https://files.pythonhosted.org/packages/36/83/76127035ed2e7e27b0787604d99da630ac3123bfb02d8e80c633f218a11d/cffi-1.17.1-cp310-cp310-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5da5719280082ac6bd9aa7becb3938dc9f9cbd57fac7d2871717b1feb0902ab6",
+              "url": "https://files.pythonhosted.org/packages/40/87/3b8452525437b40f39ca7ff70276679772ee7e8b394934ff60e63b7b090c/cffi-1.17.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2bb1a08b8008b281856e5971307cc386a8e9c5b625ac297e853d36da6efe9c17",
+              "url": "https://files.pythonhosted.org/packages/8d/fb/4da72871d177d63649ac449aec2e8a29efe0274035880c7af59101ca2232/cffi-1.17.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14",
+              "url": "https://files.pythonhosted.org/packages/90/07/f44ca684db4e4f08a3fdc6eeb9a0d15dc6883efc7b8c90357fdbf74e186c/cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8",
+              "url": "https://files.pythonhosted.org/packages/ab/a0/62f00bcb411332106c02b663b26f3545a9ef136f80d5df746c05878f8c4b/cffi-1.17.1-cp310-cp310-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "45398b671ac6d70e67da8e4224a065cec6a93541bb7aebe1b198a61b58c7b702",
+              "url": "https://files.pythonhosted.org/packages/b6/7b/3b2b250f3aab91abe5f8a51ada1b717935fdaec53f790ad4100fe2ec64d1/cffi-1.17.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ad9413ccdeda48c5afdae7e4fa2192157e991ff761e7ab8fdd8926f40b160cc3",
+              "url": "https://files.pythonhosted.org/packages/d3/48/1b9283ebbf0ec065148d8de05d647a986c5f22586b18120020452fff8f5d/cffi-1.17.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "edae79245293e15384b51f88b00613ba9f7198016a5948b5dddf4917d4d26382",
+              "url": "https://files.pythonhosted.org/packages/de/cc/4635c320081c78d6ffc2cab0a76025b691a91204f4aa317d568ff9280a2d/cffi-1.17.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824",
+              "url": "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz"
+            }
+          ],
+          "project_name": "cffi",
+          "requires_dists": [
+            "pycparser"
+          ],
+          "requires_python": ">=3.8",
+          "version": "1.17.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "fe9f97feb71aa9896b81973a7bbada8c49501dc73e58a10fcef6663af95e5079",
+              "url": "https://files.pythonhosted.org/packages/bf/9b/08c0432272d77b04803958a4598a51e2a4b51c06640af8b8f0f908c18bf2/charset_normalizer-3.4.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5ed2e36c3e9b4f21dd9422f6893dec0abf2cca553af509b10cd630f878d3eb99",
+              "url": "https://files.pythonhosted.org/packages/21/67/b4564d81f48042f520c948abac7079356e94b30cb8ffb22e747532cf469d/charset_normalizer-3.4.0-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0de7b687289d3c1b3e8660d0741874abe7888100efe14bd0f9fd7141bcbda92b",
+              "url": "https://files.pythonhosted.org/packages/23/81/d7eef6a99e42c77f444fdd7bc894b0ceca6c3a95c51239e74a722039521c/charset_normalizer-3.4.0-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "136815f06a3ae311fae551c3df1f998a1ebd01ddd424aa5603a4336997629e95",
+              "url": "https://files.pythonhosted.org/packages/3a/a4/8633b0fc1a2d1834d5393dafecce4a1cc56727bfd82b4dc18fc92f0d3cc3/charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "79983512b108e4a164b9c8d34de3992f76d48cadc9554c9e60b43f308988aabe",
+              "url": "https://files.pythonhosted.org/packages/3b/fd/e60a9d9fd967f4ad5a92810138192f825d77b4fa2a557990fd575a47695b/charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "14215b71a762336254351b00ec720a8e85cada43b987da5a042e4ce3e82bd68e",
+              "url": "https://files.pythonhosted.org/packages/64/ea/69af161062166b5975ccbb0961fd2384853190c70786f288684490913bf5/charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1110e22af8ca26b90bd6364fe4c763329b0ebf1ee213ba32b68c73de5752323d",
+              "url": "https://files.pythonhosted.org/packages/67/56/fa28c2c3e31217c4c52158537a2cf5d98a6c1e89d31faf476c89391cd16b/charset_normalizer-3.4.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4f9fc98dad6c2eaa32fc3af1417d95b5e3d08aff968df0cd320066def971f9a6",
+              "url": "https://files.pythonhosted.org/packages/69/8b/825cc84cf13a28bfbcba7c416ec22bf85a9584971be15b21dd8300c65b7f/charset_normalizer-3.4.0-cp310-cp310-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "27623ba66c183eca01bf9ff833875b459cad267aeeb044477fedac35e19ba907",
+              "url": "https://files.pythonhosted.org/packages/73/8b/2102692cb6d7e9f03b9a33a710e0164cadfce312872e3efc7cfe22ed26b4/charset_normalizer-3.4.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "40d3ff7fc90b98c637bda91c89d51264a3dcf210cade3a2c6f838c7268d7a4ca",
+              "url": "https://files.pythonhosted.org/packages/c2/72/12a7f0943dd71fb5b4e7b55c41327ac0a1663046a868ee4d0d8e9c369b85/charset_normalizer-3.4.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0b309d1747110feb25d7ed6b01afdec269c647d382c857ef4663bbe6ad95a912",
+              "url": "https://files.pythonhosted.org/packages/c9/27/cde291783715b8ec30a61c810d0120411844bc4c23b50189b81188b273db/charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f606a1881d2663630ea5b8ce2efe2111740df4b687bd78b34a8131baa007f79b",
+              "url": "https://files.pythonhosted.org/packages/d8/96/cc2c1b5d994119ce9f088a9a0c3ebd489d360a2eb058e2c8049f27092847/charset_normalizer-3.4.0-cp310-cp310-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e",
+              "url": "https://files.pythonhosted.org/packages/f2/4f/e1808dc01273379acc506d18f1504eb2d299bd4131743b9fc54d7be4df1e/charset_normalizer-3.4.0.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7f683ddc7eedd742e2889d2bfb96d69573fde1d92fcb811979cdb7165bb9c7d3",
+              "url": "https://files.pythonhosted.org/packages/f8/01/344ec40cf5d85c1da3c1f57566c59e0c9b56bcc5566c08804a95a6cc8257/charset_normalizer-3.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "86f4e8cca779080f66ff4f191a685ced73d2f72d50216f7112185dc02b90b9b7",
+              "url": "https://files.pythonhosted.org/packages/f9/d2/466a9be1f32d89eb1554cf84073a5ed9262047acee1ab39cbaefc19635d2/charset_normalizer-3.4.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            }
+          ],
+          "project_name": "charset-normalizer",
+          "requires_dists": [],
+          "requires_python": ">=3.7.0",
+          "version": "3.4.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
+              "url": "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de",
+              "url": "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz"
+            }
+          ],
+          "project_name": "click",
+          "requires_dists": [
+            "colorama; platform_system == \"Windows\"",
+            "importlib-metadata; python_version < \"3.8\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "8.1.7"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "fe11acda67f61aaaec473e3afe030feb131d78a43461b718185363384f1ba12e",
+              "url": "https://files.pythonhosted.org/packages/48/41/e1d85ca3cab0b674e277c8c4f678cf66a91cd2cecf93df94353a606fe0db/cloudpickle-3.1.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "81a929b6e3c7335c863c771d673d105f02efdb89dfaba0c90495d1c64796601b",
+              "url": "https://files.pythonhosted.org/packages/97/c7/f746cadd08c4c08129215cf1b984b632f9e579fc781301e63da9e85c76c1/cloudpickle-3.1.0.tar.gz"
+            }
+          ],
+          "project_name": "cloudpickle",
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "3.1.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "5906e71acd67cb07a71e779c47c4bcb45fb8c2993eebe9e5adcd6a6f1b283eff",
+              "url": "https://files.pythonhosted.org/packages/e3/51/9b208e85196941db2f0654ad0357ca6388ab3ed67efdbfc799f35d1f83aa/colorlog-6.9.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bfba54a1b93b94f54e1f4fe48395725a3d92fd2a4af702f6bd70946bdc0c6ac2",
+              "url": "https://files.pythonhosted.org/packages/d3/7a/359f4d5df2353f26172b3cc39ea32daa39af8de522205f512f458923e677/colorlog-6.9.0.tar.gz"
+            }
+          ],
+          "project_name": "colorlog",
+          "requires_dists": [
+            "black; extra == \"development\"",
+            "colorama; sys_platform == \"win32\"",
+            "flake8; extra == \"development\"",
+            "mypy; extra == \"development\"",
+            "pytest; extra == \"development\"",
+            "types-colorama; extra == \"development\""
+          ],
+          "requires_python": ">=3.6",
+          "version": "6.9.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "e6fb86cb70ff661ee8c9c14e7d36d6de3b4066f1441be4063df9c5009f0a64d3",
+              "url": "https://files.pythonhosted.org/packages/e6/75/49e5bfe642f71f272236b5b2d2691cf915a7283cc0ceda56357b61daa538/comm-0.2.2-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3fd7a84065306e07bea1773df6eb8282de51ba82f77c72f9c85716ab11fe980e",
+              "url": "https://files.pythonhosted.org/packages/e9/a8/fb783cb0abe2b5fded9f55e5703015cdf1c9c85b3669087c538dd15a6a86/comm-0.2.2.tar.gz"
+            }
+          ],
+          "project_name": "comm",
+          "requires_dists": [
+            "pytest; extra == \"test\"",
+            "traitlets>=4"
+          ],
+          "requires_python": ">=3.8",
+          "version": "0.2.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "3128087d9783b27237946b712e2d797d569bd09071bf8e288947df7952fd79ee",
+              "url": "https://files.pythonhosted.org/packages/30/3c/d33770b10507ab61018cfdcb913536be00c56a5da6cf9d793fe2400bb3a9/confluent_kafka-2.6.2-cp310-cp310-manylinux_2_28_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b7cf7dad9668ec1ec0f4cb794a237226ed4341871d78a8db6905f76009630f1c",
+              "url": "https://files.pythonhosted.org/packages/32/e3/26a2d03fe3a9b5291ed3eb68b4a3e27c357a7f77413e413b282c30e2f3bb/confluent_kafka-2.6.2-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7879ee77d1ddc4123918a11e73931f8dc24959f897c09ba9003cd225c23ddfaf",
+              "url": "https://files.pythonhosted.org/packages/4a/a0/396247e52a939516a7bb84dedc303f4582b5c35aad873178b16f3a135009/confluent_kafka-2.6.2-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2d20715cb953bacee7182d162b9477f31e74cfda6817b9652d2f297037c7ba4c",
+              "url": "https://files.pythonhosted.org/packages/53/37/bc898bb73cd345fb6386b1536d6b7565d995b0523cb32d7d84ae34e2d831/confluent_kafka-2.6.2-cp310-cp310-manylinux_2_28_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d36cc04548599a74d7757420704f3443ca6192cd82a524f493ae299b9ac8ed81",
+              "url": "https://files.pythonhosted.org/packages/a9/61/22592e589cd284f90a3c28944d1c8b05a8506ac0ae2e0c3a3f74772858da/confluent_kafka-2.6.2.tar.gz"
+            }
+          ],
+          "project_name": "confluent-kafka",
+          "requires_dists": [
+            "attrs; extra == \"all\"",
+            "attrs; extra == \"all\"",
+            "attrs; extra == \"avro\"",
+            "attrs; extra == \"dev\"",
+            "attrs; extra == \"dev\"",
+            "attrs; extra == \"docs\"",
+            "attrs; extra == \"examples\"",
+            "attrs; extra == \"json\"",
+            "attrs; extra == \"protobuf\"",
+            "attrs; extra == \"rules\"",
+            "attrs; extra == \"schemaregistry\"",
+            "attrs; extra == \"tests\"",
+            "avro<2,>=1.11.1; extra == \"all\"",
+            "avro<2,>=1.11.1; extra == \"all\"",
+            "avro<2,>=1.11.1; extra == \"avro\"",
+            "avro<2,>=1.11.1; extra == \"dev\"",
+            "avro<2,>=1.11.1; extra == \"dev\"",
+            "avro<2,>=1.11.1; extra == \"docs\"",
+            "avro<2,>=1.11.1; extra == \"examples\"",
+            "avro<2,>=1.11.1; extra == \"tests\"",
+            "azure-identity; extra == \"all\"",
+            "azure-identity; extra == \"all\"",
+            "azure-identity; extra == \"dev\"",
+            "azure-identity; extra == \"dev\"",
+            "azure-identity; extra == \"docs\"",
+            "azure-identity; extra == \"examples\"",
+            "azure-identity; extra == \"rules\"",
+            "azure-identity; extra == \"tests\"",
+            "azure-keyvault-keys; extra == \"all\"",
+            "azure-keyvault-keys; extra == \"all\"",
+            "azure-keyvault-keys; extra == \"dev\"",
+            "azure-keyvault-keys; extra == \"dev\"",
+            "azure-keyvault-keys; extra == \"docs\"",
+            "azure-keyvault-keys; extra == \"examples\"",
+            "azure-keyvault-keys; extra == \"rules\"",
+            "azure-keyvault-keys; extra == \"tests\"",
+            "boto3; extra == \"all\"",
+            "boto3; extra == \"all\"",
+            "boto3; extra == \"dev\"",
+            "boto3; extra == \"dev\"",
+            "boto3; extra == \"docs\"",
+            "boto3; extra == \"examples\"",
+            "boto3; extra == \"rules\"",
+            "boto3; extra == \"tests\"",
+            "cachetools; extra == \"all\"",
+            "cachetools; extra == \"all\"",
+            "cachetools; extra == \"avro\"",
+            "cachetools; extra == \"dev\"",
+            "cachetools; extra == \"dev\"",
+            "cachetools; extra == \"docs\"",
+            "cachetools; extra == \"examples\"",
+            "cachetools; extra == \"json\"",
+            "cachetools; extra == \"protobuf\"",
+            "cachetools; extra == \"rules\"",
+            "cachetools; extra == \"schemaregistry\"",
+            "cachetools; extra == \"tests\"",
+            "cel-python>=0.1.5; extra == \"all\"",
+            "cel-python>=0.1.5; extra == \"all\"",
+            "cel-python>=0.1.5; extra == \"dev\"",
+            "cel-python>=0.1.5; extra == \"dev\"",
+            "cel-python>=0.1.5; extra == \"docs\"",
+            "cel-python>=0.1.5; extra == \"examples\"",
+            "cel-python>=0.1.5; extra == \"rules\"",
+            "cel-python>=0.1.5; extra == \"tests\"",
+            "confluent-kafka; extra == \"all\"",
+            "confluent-kafka; extra == \"dev\"",
+            "confluent-kafka; extra == \"examples\"",
+            "fastapi; extra == \"all\"",
+            "fastapi; extra == \"dev\"",
+            "fastapi; extra == \"examples\"",
+            "fastavro<1.8.0; python_version == \"3.7\" and extra == \"all\"",
+            "fastavro<1.8.0; python_version == \"3.7\" and extra == \"all\"",
+            "fastavro<1.8.0; python_version == \"3.7\" and extra == \"avro\"",
+            "fastavro<1.8.0; python_version == \"3.7\" and extra == \"dev\"",
+            "fastavro<1.8.0; python_version == \"3.7\" and extra == \"dev\"",
+            "fastavro<1.8.0; python_version == \"3.7\" and extra == \"docs\"",
+            "fastavro<1.8.0; python_version == \"3.7\" and extra == \"examples\"",
+            "fastavro<1.8.0; python_version == \"3.7\" and extra == \"tests\"",
+            "fastavro<2; python_version > \"3.7\" and extra == \"all\"",
+            "fastavro<2; python_version > \"3.7\" and extra == \"all\"",
+            "fastavro<2; python_version > \"3.7\" and extra == \"avro\"",
+            "fastavro<2; python_version > \"3.7\" and extra == \"dev\"",
+            "fastavro<2; python_version > \"3.7\" and extra == \"dev\"",
+            "fastavro<2; python_version > \"3.7\" and extra == \"docs\"",
+            "fastavro<2; python_version > \"3.7\" and extra == \"examples\"",
+            "fastavro<2; python_version > \"3.7\" and extra == \"tests\"",
+            "flake8; extra == \"all\"",
+            "flake8; extra == \"dev\"",
+            "flake8; extra == \"tests\"",
+            "google-api-core; extra == \"all\"",
+            "google-api-core; extra == \"all\"",
+            "google-api-core; extra == \"dev\"",
+            "google-api-core; extra == \"dev\"",
+            "google-api-core; extra == \"docs\"",
+            "google-api-core; extra == \"examples\"",
+            "google-api-core; extra == \"rules\"",
+            "google-api-core; extra == \"tests\"",
+            "google-auth; extra == \"all\"",
+            "google-auth; extra == \"all\"",
+            "google-auth; extra == \"dev\"",
+            "google-auth; extra == \"dev\"",
+            "google-auth; extra == \"docs\"",
+            "google-auth; extra == \"examples\"",
+            "google-auth; extra == \"rules\"",
+            "google-auth; extra == \"tests\"",
+            "google-cloud-kms; extra == \"all\"",
+            "google-cloud-kms; extra == \"all\"",
+            "google-cloud-kms; extra == \"dev\"",
+            "google-cloud-kms; extra == \"dev\"",
+            "google-cloud-kms; extra == \"docs\"",
+            "google-cloud-kms; extra == \"examples\"",
+            "google-cloud-kms; extra == \"rules\"",
+            "google-cloud-kms; extra == \"tests\"",
+            "hkdf==0.0.3; extra == \"all\"",
+            "hkdf==0.0.3; extra == \"all\"",
+            "hkdf==0.0.3; extra == \"dev\"",
+            "hkdf==0.0.3; extra == \"dev\"",
+            "hkdf==0.0.3; extra == \"docs\"",
+            "hkdf==0.0.3; extra == \"examples\"",
+            "hkdf==0.0.3; extra == \"rules\"",
+            "hkdf==0.0.3; extra == \"tests\"",
+            "httpx<0.28.0; extra == \"all\"",
+            "httpx<0.28.0; extra == \"all\"",
+            "httpx<0.28.0; extra == \"avro\"",
+            "httpx<0.28.0; extra == \"dev\"",
+            "httpx<0.28.0; extra == \"dev\"",
+            "httpx<0.28.0; extra == \"docs\"",
+            "httpx<0.28.0; extra == \"examples\"",
+            "httpx<0.28.0; extra == \"json\"",
+            "httpx<0.28.0; extra == \"protobuf\"",
+            "httpx<0.28.0; extra == \"rules\"",
+            "httpx<0.28.0; extra == \"schemaregistry\"",
+            "httpx<0.28.0; extra == \"tests\"",
+            "hvac; extra == \"all\"",
+            "hvac; extra == \"all\"",
+            "hvac; extra == \"dev\"",
+            "hvac; extra == \"dev\"",
+            "hvac; extra == \"docs\"",
+            "hvac; extra == \"examples\"",
+            "hvac; extra == \"rules\"",
+            "hvac; extra == \"tests\"",
+            "jsonata-python; extra == \"all\"",
+            "jsonata-python; extra == \"all\"",
+            "jsonata-python; extra == \"dev\"",
+            "jsonata-python; extra == \"dev\"",
+            "jsonata-python; extra == \"docs\"",
+            "jsonata-python; extra == \"examples\"",
+            "jsonata-python; extra == \"rules\"",
+            "jsonata-python; extra == \"tests\"",
+            "jsonschema; extra == \"all\"",
+            "jsonschema; extra == \"all\"",
+            "jsonschema; extra == \"dev\"",
+            "jsonschema; extra == \"dev\"",
+            "jsonschema; extra == \"docs\"",
+            "jsonschema; extra == \"examples\"",
+            "jsonschema; extra == \"json\"",
+            "jsonschema; extra == \"tests\"",
+            "opentelemetry-distro; extra == \"all\"",
+            "opentelemetry-distro; extra == \"soaktest\"",
+            "opentelemetry-exporter-otlp; extra == \"all\"",
+            "opentelemetry-exporter-otlp; extra == \"soaktest\"",
+            "protobuf; extra == \"all\"",
+            "protobuf; extra == \"all\"",
+            "protobuf; extra == \"dev\"",
+            "protobuf; extra == \"dev\"",
+            "protobuf; extra == \"docs\"",
+            "protobuf; extra == \"examples\"",
+            "protobuf; extra == \"protobuf\"",
+            "protobuf; extra == \"tests\"",
+            "psutil; extra == \"all\"",
+            "psutil; extra == \"soaktest\"",
+            "pydantic; extra == \"all\"",
+            "pydantic; extra == \"dev\"",
+            "pydantic; extra == \"examples\"",
+            "pyrsistent; extra == \"all\"",
+            "pyrsistent; extra == \"all\"",
+            "pyrsistent; extra == \"dev\"",
+            "pyrsistent; extra == \"dev\"",
+            "pyrsistent; extra == \"docs\"",
+            "pyrsistent; extra == \"examples\"",
+            "pyrsistent; extra == \"json\"",
+            "pyrsistent; extra == \"tests\"",
+            "pytest-timeout; extra == \"all\"",
+            "pytest-timeout; extra == \"dev\"",
+            "pytest-timeout; extra == \"tests\"",
+            "pytest; extra == \"all\"",
+            "pytest; extra == \"dev\"",
+            "pytest; extra == \"tests\"",
+            "pyyaml>=6.0.0; extra == \"all\"",
+            "pyyaml>=6.0.0; extra == \"all\"",
+            "pyyaml>=6.0.0; extra == \"dev\"",
+            "pyyaml>=6.0.0; extra == \"dev\"",
+            "pyyaml>=6.0.0; extra == \"docs\"",
+            "pyyaml>=6.0.0; extra == \"examples\"",
+            "pyyaml>=6.0.0; extra == \"rules\"",
+            "pyyaml>=6.0.0; extra == \"tests\"",
+            "requests-mock; extra == \"all\"",
+            "requests-mock; extra == \"dev\"",
+            "requests-mock; extra == \"tests\"",
+            "requests; extra == \"all\"",
+            "requests; extra == \"all\"",
+            "requests; extra == \"avro\"",
+            "requests; extra == \"dev\"",
+            "requests; extra == \"dev\"",
+            "requests; extra == \"docs\"",
+            "requests; extra == \"examples\"",
+            "requests; extra == \"tests\"",
+            "respx; extra == \"all\"",
+            "respx; extra == \"dev\"",
+            "respx; extra == \"tests\"",
+            "six; extra == \"all\"",
+            "six; extra == \"dev\"",
+            "six; extra == \"examples\"",
+            "sphinx-rtd-theme; extra == \"all\"",
+            "sphinx-rtd-theme; extra == \"dev\"",
+            "sphinx-rtd-theme; extra == \"docs\"",
+            "sphinx; extra == \"all\"",
+            "sphinx; extra == \"dev\"",
+            "sphinx; extra == \"docs\"",
+            "tink; extra == \"all\"",
+            "tink; extra == \"all\"",
+            "tink; extra == \"dev\"",
+            "tink; extra == \"dev\"",
+            "tink; extra == \"docs\"",
+            "tink; extra == \"examples\"",
+            "tink; extra == \"rules\"",
+            "tink; extra == \"tests\"",
+            "urllib3<2.0.0; python_version <= \"3.7\" and extra == \"all\"",
+            "urllib3<2.0.0; python_version <= \"3.7\" and extra == \"dev\"",
+            "urllib3<2.0.0; python_version <= \"3.7\" and extra == \"tests\"",
+            "urllib3<3,>=2.0.0; python_version > \"3.7\" and extra == \"all\"",
+            "urllib3<3,>=2.0.0; python_version > \"3.7\" and extra == \"dev\"",
+            "urllib3<3,>=2.0.0; python_version > \"3.7\" and extra == \"tests\"",
+            "uvicorn; extra == \"all\"",
+            "uvicorn; extra == \"dev\"",
+            "uvicorn; extra == \"examples\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "2.6.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "cb76c1a154b83991a3cbbf0dfeb26ec2833ad56f95540b442c73950af2013750",
+              "url": "https://files.pythonhosted.org/packages/b0/2e/52bfeeaa4541889f23d8eadc6386b442ee2470bd3cff9baa67deb2dd5c57/contourpy-1.3.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "974d8145f8ca354498005b5b981165b74a195abfae9a8129df3e56771961d595",
+              "url": "https://files.pythonhosted.org/packages/18/04/9f7d132ce49a212c8e767042cc80ae390f728060d2eea47058f55b9eff1c/contourpy-1.3.1-cp310-cp310-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "abbb49fb7dac584e5abc6636b7b2a7227111c4f771005853e7d25176daaf8453",
+              "url": "https://files.pythonhosted.org/packages/1f/d6/e766395723f6256d45d6e67c13bb638dd1fa9dc10ef912dc7dd3dcfc19de/contourpy-1.3.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "dfd97abd83335045a913e3bcc4a09c0ceadbe66580cf573fe961f4a825efa699",
+              "url": "https://files.pythonhosted.org/packages/25/c2/fc7193cc5383637ff390a712e88e4ded0452c9fbcf84abe3de5ea3df1866/contourpy-1.3.1.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b457d6430833cee8e4b8e9b6f07aa1c161e5e0d52e118dc102c8f9bd7dd060d6",
+              "url": "https://files.pythonhosted.org/packages/3e/4f/e56862e64b52b55b5ddcff4090085521fc228ceb09a88390a2b103dccd1b/contourpy-1.3.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "500360b77259914f7805af7462e41f9cb7ca92ad38e9f94d6c8641b089338124",
+              "url": "https://files.pythonhosted.org/packages/82/1d/e3eaebb4aa2d7311528c048350ca8e99cdacfafd99da87bc0a5f8d81f2c2/contourpy-1.3.1-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "a0cffcbede75c059f535725c1680dfb17b6ba8753f0c74b14e6a9c68c29d7ea3",
+              "url": "https://files.pythonhosted.org/packages/a9/57/86c500d63b3e26e5b73a28b8291a67c5608d4aa87ebd17bd15bb33c178bc/contourpy-1.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "a045f341a77b77e1c5de31e74e966537bba9f3c4099b35bf4c2e3939dd54cdab",
+              "url": "https://files.pythonhosted.org/packages/b2/a3/80937fe3efe0edacf67c9a20b955139a1a622730042c1ea991956f2704ad/contourpy-1.3.1-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ab29962927945d89d9b293eabd0d59aea28d887d4f3be6c22deaefbb938a7277",
+              "url": "https://files.pythonhosted.org/packages/b8/62/bb146d1289d6b3450bccc4642e7f4413b92ebffd9bf2e91b0404323704a7/contourpy-1.3.1-cp310-cp310-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "adce39d67c0edf383647a3a007de0a45fd1b08dedaa5318404f1a73059c2512b",
+              "url": "https://files.pythonhosted.org/packages/bf/f5/0e67902bc4394daee8daa39c81d4f00b50e063ee1a46cb3938cc65585d36/contourpy-1.3.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b2f926efda994cdf3c8d3fdb40b9962f86edbc4457e739277b961eced3d0b4c1",
+              "url": "https://files.pythonhosted.org/packages/de/f3/d796b22d1a2b587acc8100ba8c07fb7b5e17fde265a7bb05ab967f4c935a/contourpy-1.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            }
+          ],
+          "project_name": "contourpy",
+          "requires_dists": [
+            "Pillow; extra == \"test\"",
+            "bokeh; extra == \"bokeh\"",
+            "contourpy[bokeh,docs]; extra == \"mypy\"",
+            "contourpy[test-no-images]; extra == \"test\"",
+            "docutils-stubs; extra == \"mypy\"",
+            "furo; extra == \"docs\"",
+            "matplotlib; extra == \"test\"",
+            "mypy==1.11.1; extra == \"mypy\"",
+            "numpy>=1.23",
+            "pytest-cov; extra == \"test-no-images\"",
+            "pytest-rerunfailures; extra == \"test-no-images\"",
+            "pytest-xdist; extra == \"test-no-images\"",
+            "pytest; extra == \"test-no-images\"",
+            "selenium; extra == \"bokeh\"",
+            "sphinx-copybutton; extra == \"docs\"",
+            "sphinx>=7.2; extra == \"docs\"",
+            "types-Pillow; extra == \"mypy\"",
+            "wurlitzer; extra == \"test-no-images\""
+          ],
+          "requires_python": ">=3.10",
+          "version": "1.3.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30",
+              "url": "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c",
+              "url": "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz"
+            }
+          ],
+          "project_name": "cycler",
+          "requires_dists": [
+            "ipython; extra == \"docs\"",
+            "matplotlib; extra == \"docs\"",
+            "numpydoc; extra == \"docs\"",
+            "pytest-cov; extra == \"tests\"",
+            "pytest-xdist; extra == \"tests\"",
+            "pytest; extra == \"tests\"",
+            "sphinx; extra == \"docs\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "0.12.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "0e22f846f4211383e6a416d04b4c13ed174d24cc5d43f5fd52e7821d0ebc8920",
+              "url": "https://files.pythonhosted.org/packages/77/0a/d29a5aacf47b4383ed569b8478c02d59ee3a01ad91224d2cff8562410e43/debugpy-1.8.11-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2b26fefc4e31ff85593d68b9022e35e8925714a10ab4858fb1b577a8a48cb8cd",
+              "url": "https://files.pythonhosted.org/packages/26/e6/4cf7422eaa591b4c7d6a9fde224095dac25283fdd99d90164f28714242b0/debugpy-1.8.11-cp310-cp310-macosx_14_0_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "61bc8b3b265e6949855300e84dc93d02d7a3a637f2aec6d382afd4ceb9120c9f",
+              "url": "https://files.pythonhosted.org/packages/83/3a/e163de1df5995d95760a4d748b02fbefb1c1bf19e915b664017c40435dbf/debugpy-1.8.11-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6ad2688b69235c43b020e04fecccdf6a96c8943ca9c2fb340b8adc103c655e57",
+              "url": "https://files.pythonhosted.org/packages/bc/e7/666f4c9b0e24796af50aadc28d36d21c2e01e831a934535f956e09b3650c/debugpy-1.8.11.tar.gz"
+            }
+          ],
+          "project_name": "debugpy",
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "1.8.11"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186",
+              "url": "https://files.pythonhosted.org/packages/d5/50/83c593b07763e1161326b3b8c6686f0f4b0f24d5526546bee538c89837d6/decorator-5.1.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330",
+              "url": "https://files.pythonhosted.org/packages/66/0c/8d907af351aa16b42caae42f9d6aa37b900c67308052d10fdce809f8d952/decorator-5.1.1.tar.gz"
+            }
+          ],
+          "project_name": "decorator",
+          "requires_dists": [],
+          "requires_python": ">=3.5",
+          "version": "5.1.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b",
+              "url": "https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc",
+              "url": "https://files.pythonhosted.org/packages/09/35/2495c4ac46b980e4ca1f6ad6db102322ef3ad2410b79fdde159a4b0f3b92/exceptiongroup-1.2.2.tar.gz"
+            }
+          ],
+          "project_name": "exceptiongroup",
+          "requires_dists": [
+            "pytest>=6; extra == \"test\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "1.2.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "8d63781349375b5ebccc3142f4b30350c0cd9c79f921cde38be2be4637e98eaf",
+              "url": "https://files.pythonhosted.org/packages/b5/fd/afcd0496feca3276f509df3dbd5dae726fcc756f1a08d9e25abe1733f962/executing-2.1.0-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8ea27ddd260da8150fa5a708269c4a10e76161e2496ec3e587da9e3c0fe4b9ab",
+              "url": "https://files.pythonhosted.org/packages/8c/e3/7d45f492c2c4a0e8e0fad57d081a7c8a0286cdd86372b070cca1ec0caa1e/executing-2.1.0.tar.gz"
+            }
+          ],
+          "project_name": "executing",
+          "requires_dists": [
+            "asttokens>=2.1.0; extra == \"tests\"",
+            "coverage-enable-subprocess; extra == \"tests\"",
+            "coverage; extra == \"tests\"",
+            "ipython; extra == \"tests\"",
+            "littleutils; extra == \"tests\"",
+            "pytest; extra == \"tests\"",
+            "rich; python_version >= \"3.11\" and extra == \"tests\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "2.1.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "e9240b29e36fa8f4bb7290316988e90c381e5092e0cbe84e7818cc3713bcf305",
+              "url": "https://files.pythonhosted.org/packages/52/b3/7e4df40e585df024fac2f80d1a2d579c854ac37109675db2b0cc22c0bb9e/fastapi-0.115.6-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9ec46f7addc14ea472958a96aae5b5de65f39721a46aaf5705c480d9a8b76654",
+              "url": "https://files.pythonhosted.org/packages/93/72/d83b98cd106541e8f5e5bfab8ef2974ab45a62e8a6c5b5e6940f26d2ed4b/fastapi-0.115.6.tar.gz"
+            }
+          ],
+          "project_name": "fastapi",
+          "requires_dists": [
+            "email-validator>=2.0.0; extra == \"all\"",
+            "email-validator>=2.0.0; extra == \"standard\"",
+            "fastapi-cli[standard]>=0.0.5; extra == \"all\"",
+            "fastapi-cli[standard]>=0.0.5; extra == \"standard\"",
+            "httpx>=0.23.0; extra == \"all\"",
+            "httpx>=0.23.0; extra == \"standard\"",
+            "itsdangerous>=1.1.0; extra == \"all\"",
+            "jinja2>=2.11.2; extra == \"all\"",
+            "jinja2>=2.11.2; extra == \"standard\"",
+            "orjson>=3.2.1; extra == \"all\"",
+            "pydantic!=1.8,!=1.8.1,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4",
+            "pydantic-extra-types>=2.0.0; extra == \"all\"",
+            "pydantic-settings>=2.0.0; extra == \"all\"",
+            "python-multipart>=0.0.7; extra == \"all\"",
+            "python-multipart>=0.0.7; extra == \"standard\"",
+            "pyyaml>=5.3.1; extra == \"all\"",
+            "starlette<0.42.0,>=0.40.0",
+            "typing-extensions>=4.8.0",
+            "ujson!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0,>=4.0.1; extra == \"all\"",
+            "uvicorn[standard]>=0.12.0; extra == \"all\"",
+            "uvicorn[standard]>=0.12.0; extra == \"standard\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "0.115.6"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "e5d5415ff8ced6b173b801e12fc90c1eefca1fb6bf9c19c4fc1f235d4222e753",
+              "url": "https://files.pythonhosted.org/packages/a4/cb/7d2bb508f4ca00a043fd53e8156c11767799d3f534bf451a0942211d5def/findspark-2.0.1-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "aa10a96cb616cab329181d72e8ef13d2dc453b4babd02b5482471a0882c1195e",
+              "url": "https://files.pythonhosted.org/packages/41/86/445e2b90fff1efc0858512102ff78746a04c1a4a9c1d3fa9e4650c11a000/findspark-2.0.1.tar.gz"
+            }
+          ],
+          "project_name": "findspark",
+          "requires_dists": [],
+          "requires_python": null,
+          "version": "2.0.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "f412604ccbeee81b091b420272841e5ec5ef68967a9790e80bffd0e30b8e2977",
+              "url": "https://files.pythonhosted.org/packages/99/3b/406d17b1f63e04a82aa621936e6e1c53a8c05458abd66300ac85ea7f9ae9/fonttools-4.55.3-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "dd68c87a2bfe37c5b33bcda0fba39b65a353876d3b9006fde3adae31f97b3ef5",
+              "url": "https://files.pythonhosted.org/packages/1f/33/0d744ff518ebe50020b63e5018b8b278efd6a930c1d2eedda7defc42153b/fonttools-4.55.3-cp310-cp310-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "62d65a3022c35e404d19ca14f291c89cc5890032ff04f6c17af0bd1927299674",
+              "url": "https://files.pythonhosted.org/packages/34/db/d423bc646e6703fe3e6aea0edd22a2df47b9d188c5f7f1b49070be4d2205/fonttools-4.55.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d342e88764fb201286d185093781bf6628bbe380a913c24adf772d901baa8276",
+              "url": "https://files.pythonhosted.org/packages/75/a0/e5062ac960a385b984ba74e7b55132e7f2c65e449e8330ab0f595407a3de/fonttools-4.55.3-cp310-cp310-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3983313c2a04d6cc1fe9251f8fc647754cf49a61dac6cb1e7249ae67afaafc45",
+              "url": "https://files.pythonhosted.org/packages/76/61/a300d1574dc381393424047c0396a0e213db212e28361123af9830d71a8d/fonttools-4.55.3.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1dcc07934a2165ccdc3a5a608db56fb3c24b609658a5b340aee4ecf3ba679dc0",
+              "url": "https://files.pythonhosted.org/packages/bd/f3/9ac8c6705e4a0ff3c29e524df1caeee6f2987b02fb630129f21cc99a8212/fonttools-4.55.3-cp310-cp310-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f7d66c15ba875432a2d2fb419523f5d3d347f91f48f57b8b08a2dfc3c39b8a3f",
+              "url": "https://files.pythonhosted.org/packages/d8/24/e8b8edd280bdb7d0ecc88a5d952b1dec2ee2335be71cc5a33c64871cdfe8/fonttools-4.55.3-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "27e4ae3592e62eba83cd2c4ccd9462dcfa603ff78e09110680a5444c6925d841",
+              "url": "https://files.pythonhosted.org/packages/f8/9e/e1ba20bd3b71870207fd45ca3b90208a7edd8ae3b001081dc31c45adb017/fonttools-4.55.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            }
+          ],
+          "project_name": "fonttools",
+          "requires_dists": [
+            "brotli>=1.0.1; platform_python_implementation == \"CPython\" and extra == \"all\"",
+            "brotli>=1.0.1; platform_python_implementation == \"CPython\" and extra == \"woff\"",
+            "brotlicffi>=0.8.0; platform_python_implementation != \"CPython\" and extra == \"all\"",
+            "brotlicffi>=0.8.0; platform_python_implementation != \"CPython\" and extra == \"woff\"",
+            "fs<3,>=2.2.0; extra == \"all\"",
+            "fs<3,>=2.2.0; extra == \"ufo\"",
+            "lxml>=4.0; extra == \"all\"",
+            "lxml>=4.0; extra == \"lxml\"",
+            "lz4>=1.7.4.2; extra == \"all\"",
+            "lz4>=1.7.4.2; extra == \"graphite\"",
+            "matplotlib; extra == \"all\"",
+            "matplotlib; extra == \"plot\"",
+            "munkres; platform_python_implementation == \"PyPy\" and extra == \"all\"",
+            "munkres; platform_python_implementation == \"PyPy\" and extra == \"interpolatable\"",
+            "pycairo; extra == \"all\"",
+            "pycairo; extra == \"interpolatable\"",
+            "scipy; platform_python_implementation != \"PyPy\" and extra == \"all\"",
+            "scipy; platform_python_implementation != \"PyPy\" and extra == \"interpolatable\"",
+            "skia-pathops>=0.5.0; extra == \"all\"",
+            "skia-pathops>=0.5.0; extra == \"pathops\"",
+            "sympy; extra == \"all\"",
+            "sympy; extra == \"symfont\"",
+            "uharfbuzz>=0.23.0; extra == \"all\"",
+            "uharfbuzz>=0.23.0; extra == \"repacker\"",
+            "unicodedata2>=15.1.0; python_version <= \"3.12\" and extra == \"all\"",
+            "unicodedata2>=15.1.0; python_version <= \"3.12\" and extra == \"unicode\"",
+            "xattr; sys_platform == \"darwin\" and extra == \"all\"",
+            "xattr; sys_platform == \"darwin\" and extra == \"type1\"",
+            "zopfli>=0.1.4; extra == \"all\"",
+            "zopfli>=0.1.4; extra == \"woff\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "4.55.3"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "2c7907b4692091dd5615c78f2be30398abb28a046633b8c2760550f8c32b8be7",
+              "url": "https://files.pythonhosted.org/packages/0b/ba/1f7ac3a97ac3bc3fdeeba21ccb8703e8cc2857c16bc3efdc19d22658b174/formulaic-1.1.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "35c0eb8fadebc6656ec685a68a3266d755227a80a05ece711897409913f5e3c6",
+              "url": "https://files.pythonhosted.org/packages/e0/6e/1a4816b66110d0e215f82fed0d5b80f10206bb03dc37d5dcf4dcd2600d9d/formulaic-1.1.0.tar.gz"
+            }
+          ],
+          "project_name": "formulaic",
+          "requires_dists": [
+            "astor>=0.8; python_version < \"3.9\"",
+            "cached-property>=1.3.0; python_version < \"3.8\"",
+            "graphlib-backport>=1.0.0; python_version < \"3.9\"",
+            "interface-meta>=1.2.0",
+            "numpy>=1.16.5",
+            "pandas>=1.0",
+            "pyarrow>=1; extra == \"arrow\"",
+            "scipy>=1.6",
+            "sympy!=1.10,>=1.3; extra == \"calculus\"",
+            "typing-extensions>=4.2.0",
+            "wrapt>=1.0; python_version < \"3.13\"",
+            "wrapt>=1.17.0rc1; python_version >= \"3.13\""
+          ],
+          "requires_python": ">=3.7.2",
+          "version": "1.1.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "a41a1e336b381416d6cbed7f1745c848e91defaa4d4c1bdc1312732e46ffad2b",
+              "url": "https://files.pythonhosted.org/packages/c9/81/156ca48f950f833ddc392f8e3677ca50a18cb9d5db38ccb4ecea55a9303f/geomet-0.2.1.post1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "91d754f7c298cbfcabd3befdb69c641c27fe75e808b27aa55028605761d17e95",
+              "url": "https://files.pythonhosted.org/packages/cf/21/58251b3de99e0b5ba649ff511f7f9e8399c3059dd52a643774106e929afa/geomet-0.2.1.post1.tar.gz"
+            }
+          ],
+          "project_name": "geomet",
+          "requires_dists": [
+            "click",
+            "six"
+          ],
+          "requires_python": "!=3.3.*,<4,>2.6",
+          "version": "0.2.1.post1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "ed10eac5830befbdd0c32f83e8aa6288361597550ba669b04c48f0f9a2c843c6",
+              "url": "https://files.pythonhosted.org/packages/e0/1d/a305dce121838d0278cee39d5bb268c657f10a5363ae4b726848f833f1bb/greenlet-3.1.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0bbae94a29c9e5c7e4a2b7f0aae5c17e8e90acbfd3bf6270eeba60c39fce3563",
+              "url": "https://files.pythonhosted.org/packages/25/90/5234a78dc0ef6496a6eb97b67a42a8e96742a56f7dc808cb954a85390448/greenlet-3.1.1-cp310-cp310-macosx_11_0_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "36b89d13c49216cadb828db8dfa6ce86bbbc476a82d3a6c397f0efae0525bdd0",
+              "url": "https://files.pythonhosted.org/packages/2f/b1/aed39043a6fec33c284a2c9abd63ce191f4f1a07319340ffc04d2ed3256f/greenlet-3.1.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4ce3ac6cdb6adf7946475d7ef31777c26d94bccc377e070a7986bd2d5c515467",
+              "url": "https://files.pythonhosted.org/packages/2f/ff/df5fede753cc10f6a5be0931204ea30c35fa2f2ea7a35b25bdaf4fe40e46/greenlet-3.1.1.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b2795058c23988728eec1f36a4e5e4ebad22f8320c85f3587b539b9ac84128d7",
+              "url": "https://files.pythonhosted.org/packages/46/1d/44dbcb0e6c323bd6f71b8c2f4233766a5faf4b8948873225d34a0b7efa71/greenlet-3.1.1-cp310-cp310-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "94b6150a85e1b33b40b1464a3f9988dcc5251d6ed06842abff82e42632fac120",
+              "url": "https://files.pythonhosted.org/packages/76/25/40e0112f7f3ebe54e8e8ed91b2b9f970805143efef16d043dfc15e70f44b/greenlet-3.1.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0fde093fb93f35ca72a556cf72c92ea3ebfda3d79fc35bb19fbe685853869a83",
+              "url": "https://files.pythonhosted.org/packages/7c/16/cd631fa0ab7d06ef06387135b7549fdcc77d8d859ed770a0d28e47b20972/greenlet-3.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "da7a9bff22ce038e19bf62c4dd1ec8391062878710ded0a845bcf47cc0200617",
+              "url": "https://files.pythonhosted.org/packages/cf/69/79e4d63b9387b48939096e25115b8af7cd8a90397a304f92436bcb21f5b2/greenlet-3.1.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "93147c513fac16385d1036b7e5b102c7fbbdb163d556b791f0f11eada7ba65dc",
+              "url": "https://files.pythonhosted.org/packages/fb/2f/3850b867a9af519794784a7eeed1dd5bc68ffbcc5b28cef703711025fd0a/greenlet-3.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            }
+          ],
+          "project_name": "greenlet",
+          "requires_dists": [
+            "Sphinx; extra == \"docs\"",
+            "furo; extra == \"docs\"",
+            "objgraph; extra == \"test\"",
+            "psutil; extra == \"test\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "3.1.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "ccf2ebd2de2d6661e2520dae293298a3803a98ebfc099275f113ce1f6c2a80f1",
+              "url": "https://files.pythonhosted.org/packages/d4/94/074db039532687ec8ef07ebbcc747c46547c94329016e22b97d97b9e5f3b/grpcio-1.68.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0feb02205a27caca128627bd1df4ee7212db051019a9afa76f4bb6a1a80ca95e",
+              "url": "https://files.pythonhosted.org/packages/67/1e/f5d3410674d021831c9fef2d1d7ca2357b08d09c840ad4e054ea8ffc302e/grpcio-1.68.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "963cc8d7d79b12c56008aabd8b457f400952dbea8997dd185f155e2f228db079",
+              "url": "https://files.pythonhosted.org/packages/67/44/06917ffaa35ca463b93dde60f324015fe4192312b0f4dd0faec061e7ca7f/grpcio-1.68.1-cp310-cp310-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "919d7f18f63bcad3a0f81146188e90274fde800a94e35d42ffe9eadf6a9a6330",
+              "url": "https://files.pythonhosted.org/packages/91/93/701d5f33b163a621c8f2d4453f9e22f6c14e996baed54118d0dea93fc8c7/grpcio-1.68.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "44a8502dd5de653ae6a73e2de50a401d84184f0331d0ac3daeb044e66d5c5054",
+              "url": "https://files.pythonhosted.org/packages/91/ec/b76ff6d86bdfd1737a5ec889394b54c18b1ec3832d91041e25023fbcb67d/grpcio-1.68.1.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f8261fa2a5f679abeb2a0a93ad056d765cdca1c47745eda3f2d87f874ff4b8c9",
+              "url": "https://files.pythonhosted.org/packages/d5/b0/ad4c66f2e3181b4eab99885686c960c403ae2300bacfe427526282facc07/grpcio-1.68.1-cp310-cp310-manylinux_2_17_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d99abcd61760ebb34bdff37e5a3ba333c5cc09feda8c1ad42547bea0416ada78",
+              "url": "https://files.pythonhosted.org/packages/ec/cb/94ca41e100201fee8876a4b44d64e43ac7405929909afe1fa943d65b25ef/grpcio-1.68.1-cp310-cp310-macosx_12_0_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d35740e3f45f60f3c37b1e6f2f4702c23867b9ce21c6410254c9c682237da68d",
+              "url": "https://files.pythonhosted.org/packages/f5/88/d1ac9676a0809e3efec154d45246474ec12a4941686da71ffb3d34190294/grpcio-1.68.1-cp310-cp310-linux_armv7l.whl"
+            }
+          ],
+          "project_name": "grpcio",
+          "requires_dists": [
+            "grpcio-tools>=1.68.1; extra == \"protobuf\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "1.68.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "2465e4d347b35dc0c007e074c79d5ded0a89c3aa26651e690f83593e0cc28af8",
+              "url": "https://files.pythonhosted.org/packages/44/53/6318e9ecb495ee1aa922ea66d500c4c2f4cad7218ed67de955cb61fffc38/grpcio_tools-1.68.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2413a17ad16c9c821b36e4a67fc64c37b9e4636ab1c3a07778018801378739ba",
+              "url": "https://files.pythonhosted.org/packages/2a/2f/d2fc30b79d892050a3c40ef8d17d602f4c6eced066d584621c7bbf195b0e/grpcio_tools-1.68.1.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bbe7e1641859c858d0f4631f7f7c09e7302433f1aa037028d2419c1410945fac",
+              "url": "https://files.pythonhosted.org/packages/3d/27/c5c9f8cab6b0769d758e014dc6e0c0d87da25f9bb4843675050abd094f20/grpcio_tools-1.68.1-cp310-cp310-manylinux_2_17_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "85adc798fd3b57ab3e998b5897c5daab6840211ac16cdf3ba99901cb9b90094a",
+              "url": "https://files.pythonhosted.org/packages/4c/cf/c758ba07d4213bf706e90e4adde3dbf47f93d80cb8407fd449cc662f27aa/grpcio_tools-1.68.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "94cbfb9482cfd7bdb5f081b94fa137a16e4fe031daa57a2cd85d8cb4e18dce25",
+              "url": "https://files.pythonhosted.org/packages/51/36/33f04c77aa7c1df26031a32cb22e738ac58fd4708ff983cf3cc24b38705a/grpcio_tools-1.68.1-cp310-cp310-macosx_12_0_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3a93ea324c5cbccdff55110777410d026dc1e69c3d47684ac97f57f7a77b9c70",
+              "url": "https://files.pythonhosted.org/packages/77/ea/7f40e041c12a26d41fbadaada47f6a3d0c4e04819d89ead62cf60a547414/grpcio_tools-1.68.1-cp310-cp310-linux_armv7l.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "55c0f91c4294c5807796ed26af42509f3d68497942a92d9ee9f43b08768d6c3c",
+              "url": "https://files.pythonhosted.org/packages/9b/81/2e42ccd1cfb7a38aecd327942775cbd4b412f41d3d8c5e3c8eb33f093d55/grpcio_tools-1.68.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f0bdccb00709bf6180a80a353a99fa844cc0bb2d450cdf7fc6ab22c988bb6b4c",
+              "url": "https://files.pythonhosted.org/packages/fc/c6/a582490a64d9a7f626b83dbbe92eb7f10c2069b35d573ca9b2b622c994bd/grpcio_tools-1.68.1-cp310-cp310-musllinux_1_1_i686.whl"
+            }
+          ],
+          "project_name": "grpcio-tools",
+          "requires_dists": [
+            "grpcio>=1.68.1",
+            "protobuf<6.0dev,>=5.26.1",
+            "setuptools"
+          ],
+          "requires_python": ">=3.8",
+          "version": "1.68.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761",
+              "url": "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d",
+              "url": "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz"
+            }
+          ],
+          "project_name": "h11",
+          "requires_dists": [
+            "typing-extensions; python_version < \"3.8\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "0.14.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "03a46bcf682256c95b5fd9e9a99c1323584c3eec6440d379b9903d709476bc6d",
+              "url": "https://files.pythonhosted.org/packages/2a/e5/db6d438da759efbb488c4f3fbdab7764492ff3c3f953132efa6b9f0e9e53/h2-4.1.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "a83aca08fbe7aacb79fec788c9c0bac936343560ed9ec18b82a13a12c28d2abb",
+              "url": "https://files.pythonhosted.org/packages/2a/32/fec683ddd10629ea4ea46d206752a95a2d8a48c22521edd70b142488efe1/h2-4.1.0.tar.gz"
+            }
+          ],
+          "project_name": "h2",
+          "requires_dists": [
+            "hpack<5,>=4.0",
+            "hyperframe<7,>=6.0"
+          ],
+          "requires_python": ">=3.6.1",
+          "version": "4.1.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "0256e42687470c6f0044ca78fe375fe32a654be8b5a8313b4a68f52f513389c6",
+              "url": "https://files.pythonhosted.org/packages/5a/ff/83e3b8b077bb66b14e947ac7ab11c974ef73925c960c66eb9327087ad26a/h3-3.7.7-cp310-cp310-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "996ebb32dc26dd607af7493149f94ce316117be6f42971f7b33bbd326ec695d2",
+              "url": "https://files.pythonhosted.org/packages/2e/f8/5846ac4849d5fedea6b99f98dfa80ca2020c6a375b7fd05d92b3c2207885/h3-3.7.7-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "fa2a4aa888cd9476788b874b4e11e178293f5b86e8461c36596bf183c242d417",
+              "url": "https://files.pythonhosted.org/packages/46/43/e8174fee15911ea72b7e3d04a810bbed57691c789632b466663f1b83320f/h3-3.7.7-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "951ecc9da0bcd5091670b13636928747bc98bc76891da0fa725524ec017cd9de",
+              "url": "https://files.pythonhosted.org/packages/5d/64/7673b6a08519111069e02a4535743ac41168eb625993e2815ede1e64303f/h3-3.7.7-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "26b9dd605541223ef927cc913deccb236cee024b16032f4a3e4387e2791479f2",
+              "url": "https://files.pythonhosted.org/packages/7b/75/1c3069539cfb04e076d47c76f44bb24da791ed91220254813052961b042d/h3-3.7.7-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "33d141c3cef0725a881771fd8cb80c06a0db84a6e4ca5c647ce095ae07c61e94",
+              "url": "https://files.pythonhosted.org/packages/8f/8d/b10085f4f6ef7d4cb126a2e0eaf9e907e89cf99965b6578a3d1666f1435e/h3-3.7.7.tar.gz"
+            }
+          ],
+          "project_name": "h3",
+          "requires_dists": [
+            "flake8; extra == \"all\"",
+            "flake8; extra == \"test\"",
+            "numpy; extra == \"all\"",
+            "numpy; extra == \"numpy\"",
+            "pylint; extra == \"all\"",
+            "pylint; extra == \"test\"",
+            "pytest-cov; extra == \"all\"",
+            "pytest-cov; extra == \"test\"",
+            "pytest; extra == \"all\"",
+            "pytest; extra == \"test\""
+          ],
+          "requires_python": null,
+          "version": "3.7.7"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "84a076fad3dc9a9f8063ccb8041ef100867b1878b25ef0ee63847a5d53818a6c",
+              "url": "https://files.pythonhosted.org/packages/d5/34/e8b383f35b77c402d28563d2b8f83159319b509bc5f760b15d60b0abf165/hpack-4.0.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "fc41de0c63e687ebffde81187a948221294896f6bdc0ae2312708df339430095",
+              "url": "https://files.pythonhosted.org/packages/3e/9b/fda93fb4d957db19b0f6b370e79d586b3e8528b20252c729c476a2c02954/hpack-4.0.0.tar.gz"
+            }
+          ],
+          "project_name": "hpack",
+          "requires_dists": [],
+          "requires_python": ">=3.6.1",
+          "version": "4.0.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd",
+              "url": "https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c",
+              "url": "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz"
+            }
+          ],
+          "project_name": "httpcore",
+          "requires_dists": [
+            "anyio<5.0,>=4.0; extra == \"asyncio\"",
+            "certifi",
+            "h11<0.15,>=0.13",
+            "h2<5,>=3; extra == \"http2\"",
+            "socksio==1.*; extra == \"socks\"",
+            "trio<1.0,>=0.22.0; extra == \"trio\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "1.0.7"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "59e724f8b332319e2875efd360e61ac07f33b492889284a3e05e6d13746876f4",
+              "url": "https://files.pythonhosted.org/packages/81/86/ced96e3179c48c6f656354e106934e65c8963d48b69be78f355797f0e1b3/httptools-0.6.4-cp310-cp310-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3c73ce323711a6ffb0d247dcd5a550b8babf0f757e86a52558fe5b86d6fefcc0",
+              "url": "https://files.pythonhosted.org/packages/3b/6f/972f8eb0ea7d98a1c6be436e2142d51ad2a64ee18e02b0e7ff1f62171ab1/httptools-0.6.4-cp310-cp310-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "345c288418f0944a6fe67be8e6afa9262b18c7626c3ef3c28adc5eabc06a68da",
+              "url": "https://files.pythonhosted.org/packages/6a/b0/17c672b4bc5c7ba7f201eada4e96c71d0a59fbc185e60e42580093a86f21/httptools-0.6.4-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "deee0e3343f98ee8047e9f4c5bc7cedbf69f5734454a94c38ee829fb2d5fa3c1",
+              "url": "https://files.pythonhosted.org/packages/92/5e/b4a826fe91971a0b68e8c2bd4e7db3e7519882f5a8ccdb1194be2b3ab98f/httptools-0.6.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4e93eee4add6493b59a5c514da98c939b244fce4a0d8879cd3f466562f4b7d5c",
+              "url": "https://files.pythonhosted.org/packages/a7/9a/ce5e1f7e131522e6d3426e8e7a490b3a01f39a6696602e1c4f33f9e94277/httptools-0.6.4.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ca80b7485c76f768a3bc83ea58373f8db7b015551117375e4918e2aa77ea9b50",
+              "url": "https://files.pythonhosted.org/packages/b0/51/ce61e531e40289a681a463e1258fa1e05e0be54540e40d91d065a264cd8f/httptools-0.6.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "90d96a385fa941283ebd231464045187a31ad932ebfa541be8edf5b3c2328959",
+              "url": "https://files.pythonhosted.org/packages/ea/9e/270b7d767849b0c96f275c695d27ca76c30671f8eb8cc1bab6ced5c5e1d0/httptools-0.6.4-cp310-cp310-musllinux_1_2_aarch64.whl"
+            }
+          ],
+          "project_name": "httptools",
+          "requires_dists": [
+            "Cython>=0.29.24; extra == \"test\""
+          ],
+          "requires_python": ">=3.8.0",
+          "version": "0.6.4"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad",
+              "url": "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc",
+              "url": "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz"
+            }
+          ],
+          "project_name": "httpx",
+          "requires_dists": [
+            "anyio",
+            "brotli; platform_python_implementation == \"CPython\" and extra == \"brotli\"",
+            "brotlicffi; platform_python_implementation != \"CPython\" and extra == \"brotli\"",
+            "certifi",
+            "click==8.*; extra == \"cli\"",
+            "h2<5,>=3; extra == \"http2\"",
+            "httpcore==1.*",
+            "idna",
+            "pygments==2.*; extra == \"cli\"",
+            "rich<14,>=10; extra == \"cli\"",
+            "socksio==1.*; extra == \"socks\"",
+            "zstandard>=0.18.0; extra == \"zstd\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "0.28.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "0ec6bafd80d8ad2195c4f03aacba3a8265e57bc4cff261e802bf39970ed02a15",
+              "url": "https://files.pythonhosted.org/packages/d7/de/85a784bcc4a3779d1753a7ec2dee5de90e18c7bcf402e71b51fcf150b129/hyperframe-6.0.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ae510046231dc8e9ecb1a6586f63d2347bf4c8905914aa84ba585ae85f28a914",
+              "url": "https://files.pythonhosted.org/packages/5a/2a/4747bff0a17f7281abe73e955d60d80aae537a5d203f417fa1c2e7578ebb/hyperframe-6.0.1.tar.gz"
+            }
+          ],
+          "project_name": "hyperframe",
+          "requires_dists": [],
+          "requires_python": ">=3.6.1",
+          "version": "6.0.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3",
+              "url": "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+              "url": "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz"
+            }
+          ],
+          "project_name": "idna",
+          "requires_dists": [
+            "flake8>=7.1.1; extra == \"all\"",
+            "mypy>=1.11.2; extra == \"all\"",
+            "pytest>=8.3.2; extra == \"all\"",
+            "ruff>=0.6.2; extra == \"all\""
+          ],
+          "requires_python": ">=3.6",
+          "version": "3.10"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374",
+              "url": "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+              "url": "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz"
+            }
+          ],
+          "project_name": "iniconfig",
+          "requires_dists": [],
+          "requires_python": ">=3.7",
+          "version": "2.0.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "de35dc5241431886e709e20a14d6597ed07c9f1e8b4bfcffde2190ca5b700ee8",
+              "url": "https://files.pythonhosted.org/packages/02/3f/a6ec28c88e2d8e54d32598a1e0b5208a4baa72a8e7f6e241beab5731eb9d/interface_meta-1.3.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8a4493f8bdb73fb9655dcd5115bc897e207319e36c8835f39c516a2d7e9d79a1",
+              "url": "https://files.pythonhosted.org/packages/4d/75/10526292b332f3479c246750a96f6ec11a28e297839a9c25583b2aadc119/interface_meta-1.3.0.tar.gz"
+            }
+          ],
+          "project_name": "interface-meta",
+          "requires_dists": [],
+          "requires_python": "<4.0,>=3.7",
+          "version": "1.3.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "afdb66ba5aa354b09b91379bac28ae4afebbb30e8b39510c9690afb7a10421b5",
+              "url": "https://files.pythonhosted.org/packages/94/5c/368ae6c01c7628438358e6d337c19b05425727fbb221d2a3c4303c372f42/ipykernel-6.29.5-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f093a22c4a40f8828f8e330a9c297cb93dcab13bd9678ded6de8e5cf81c56215",
+              "url": "https://files.pythonhosted.org/packages/e9/5c/67594cb0c7055dc50814b21731c22a601101ea3b1b50a9a1b090e11f5d0f/ipykernel-6.29.5.tar.gz"
+            }
+          ],
+          "project_name": "ipykernel",
+          "requires_dists": [
+            "appnope; platform_system == \"Darwin\"",
+            "comm>=0.1.1",
+            "coverage[toml]; extra == \"cov\"",
+            "curio; extra == \"cov\"",
+            "debugpy>=1.6.5",
+            "flaky; extra == \"test\"",
+            "ipyparallel; extra == \"test\"",
+            "ipython>=7.23.1",
+            "jupyter-client>=6.1.12",
+            "jupyter-core!=5.0.*,>=4.12",
+            "matplotlib-inline>=0.1",
+            "matplotlib; extra == \"cov\"",
+            "myst-parser; extra == \"docs\"",
+            "nest-asyncio",
+            "packaging",
+            "pre-commit; extra == \"test\"",
+            "psutil",
+            "pydata-sphinx-theme; extra == \"docs\"",
+            "pyqt5; extra == \"pyqt5\"",
+            "pyside6; extra == \"pyside6\"",
+            "pytest-asyncio>=0.23.5; extra == \"test\"",
+            "pytest-cov; extra == \"cov\"",
+            "pytest-cov; extra == \"test\"",
+            "pytest-timeout; extra == \"test\"",
+            "pytest>=7.0; extra == \"test\"",
+            "pyzmq>=24",
+            "sphinx-autodoc-typehints; extra == \"docs\"",
+            "sphinx; extra == \"docs\"",
+            "sphinxcontrib-github-alt; extra == \"docs\"",
+            "sphinxcontrib-spelling; extra == \"docs\"",
+            "tornado>=6.1",
+            "traitlets>=5.4.0",
+            "trio; extra == \"cov\"",
+            "trio; extra == \"docs\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "6.29.5"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "85ec56a7e20f6c38fce7727dcca699ae4ffc85985aa7b23635a8008f918ae321",
+              "url": "https://files.pythonhosted.org/packages/1d/f3/1332ba2f682b07b304ad34cad2f003adcfeb349486103f4b632335074a7c/ipython-8.30.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "cb0a405a306d2995a5cbb9901894d240784a9f341394c6ba3f4fe8c6eb89ff6e",
+              "url": "https://files.pythonhosted.org/packages/d8/8b/710af065ab8ed05649afa5bd1e07401637c9ec9fb7cfda9eac7e91e9fbd4/ipython-8.30.0.tar.gz"
+            }
+          ],
+          "project_name": "ipython",
+          "requires_dists": [
+            "black; extra == \"black\"",
+            "colorama; sys_platform == \"win32\"",
+            "curio; extra == \"test-extra\"",
+            "decorator",
+            "docrepr; extra == \"doc\"",
+            "exceptiongroup; extra == \"doc\"",
+            "exceptiongroup; python_version < \"3.11\"",
+            "intersphinx_registry; extra == \"doc\"",
+            "ipykernel; extra == \"doc\"",
+            "ipykernel; extra == \"kernel\"",
+            "ipyparallel; extra == \"parallel\"",
+            "ipython[black,doc,kernel,matplotlib,nbconvert,nbformat,notebook,parallel,qtconsole]; extra == \"all\"",
+            "ipython[test,test_extra]; extra == \"all\"",
+            "ipython[test]; extra == \"doc\"",
+            "ipython[test]; extra == \"test-extra\"",
+            "ipywidgets; extra == \"notebook\"",
+            "jedi>=0.16",
+            "matplotlib!=3.2.0; extra == \"test-extra\"",
+            "matplotlib-inline",
+            "matplotlib; extra == \"doc\"",
+            "matplotlib; extra == \"matplotlib\"",
+            "nbconvert; extra == \"nbconvert\"",
+            "nbformat; extra == \"nbformat\"",
+            "nbformat; extra == \"test-extra\"",
+            "notebook; extra == \"notebook\"",
+            "numpy>=1.23; extra == \"test-extra\"",
+            "packaging; extra == \"test\"",
+            "pandas; extra == \"test-extra\"",
+            "pexpect>4.3; sys_platform != \"win32\" and sys_platform != \"emscripten\"",
+            "pickleshare; extra == \"test\"",
+            "prompt_toolkit<3.1.0,>=3.0.41",
+            "pygments>=2.4.0",
+            "pytest-asyncio<0.22; extra == \"test\"",
+            "pytest; extra == \"test\"",
+            "qtconsole; extra == \"qtconsole\"",
+            "setuptools>=18.5; extra == \"doc\"",
+            "sphinx-rtd-theme; extra == \"doc\"",
+            "sphinx>=1.3; extra == \"doc\"",
+            "sphinxcontrib-jquery; extra == \"doc\"",
+            "stack_data",
+            "testpath; extra == \"test\"",
+            "tomli; python_version < \"3.11\" and extra == \"doc\"",
+            "traitlets>=5.13.0",
+            "trio; extra == \"test-extra\"",
+            "typing_extensions; extra == \"doc\"",
+            "typing_extensions>=4.6; python_version < \"3.12\""
+          ],
+          "requires_python": ">=3.10",
+          "version": "8.30.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "a8ef22bde8490f57fe5c7681a3c83cb58874daf72b4784de3cce5b6ef6edb5b9",
+              "url": "https://files.pythonhosted.org/packages/c0/5a/9cac0c82afec3d09ccd97c8b6502d48f165f9124db81b4bcb90b4af974ee/jedi-0.19.2-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4770dc3de41bde3966b02eb84fbcf557fb33cce26ad23da12c742fb50ecb11f0",
+              "url": "https://files.pythonhosted.org/packages/72/3a/79a912fbd4d8dd6fbb02bf69afd3bb72cf0c729bb3063c6f4498603db17a/jedi-0.19.2.tar.gz"
+            }
+          ],
+          "project_name": "jedi",
+          "requires_dists": [
+            "Django; extra == \"testing\"",
+            "Jinja2==2.11.3; extra == \"docs\"",
+            "MarkupSafe==1.1.1; extra == \"docs\"",
+            "Pygments==2.8.1; extra == \"docs\"",
+            "alabaster==0.7.12; extra == \"docs\"",
+            "attrs; extra == \"testing\"",
+            "babel==2.9.1; extra == \"docs\"",
+            "chardet==4.0.0; extra == \"docs\"",
+            "colorama; extra == \"testing\"",
+            "commonmark==0.8.1; extra == \"docs\"",
+            "docopt; extra == \"testing\"",
+            "docutils==0.17.1; extra == \"docs\"",
+            "flake8==5.0.4; extra == \"qa\"",
+            "future==0.18.2; extra == \"docs\"",
+            "idna==2.10; extra == \"docs\"",
+            "imagesize==1.2.0; extra == \"docs\"",
+            "mock==1.0.1; extra == \"docs\"",
+            "mypy==0.971; extra == \"qa\"",
+            "packaging==20.9; extra == \"docs\"",
+            "parso<0.9.0,>=0.8.4",
+            "pyparsing==2.4.7; extra == \"docs\"",
+            "pytest<9.0.0; extra == \"testing\"",
+            "pytz==2021.1; extra == \"docs\"",
+            "readthedocs-sphinx-ext==2.1.4; extra == \"docs\"",
+            "recommonmark==0.5.0; extra == \"docs\"",
+            "requests==2.25.1; extra == \"docs\"",
+            "six==1.15.0; extra == \"docs\"",
+            "snowballstemmer==2.1.0; extra == \"docs\"",
+            "sphinx-rtd-theme==0.4.3; extra == \"docs\"",
+            "sphinx==1.8.5; extra == \"docs\"",
+            "sphinxcontrib-serializinghtml==1.1.4; extra == \"docs\"",
+            "sphinxcontrib-websupport==1.2.4; extra == \"docs\"",
+            "types-setuptools==67.2.0.1; extra == \"qa\"",
+            "urllib3==1.26.4; extra == \"docs\""
+          ],
+          "requires_python": ">=3.6",
+          "version": "0.19.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980",
+              "url": "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe",
+              "url": "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz"
+            }
+          ],
+          "project_name": "jmespath",
+          "requires_dists": [],
+          "requires_python": ">=3.7",
+          "version": "1.0.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "06d478d5674cbc267e7496a410ee875abd68e4340feff4490bcb7afb88060ae6",
+              "url": "https://files.pythonhosted.org/packages/91/29/df4b9b42f2be0b623cbd5e2140cafcaa2bef0759a00b7b70104dcfe2fb51/joblib-1.4.2-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2382c5816b2636fbd20a09e0f4e9dad4736765fdfb7dca582943b9c1366b3f0e",
+              "url": "https://files.pythonhosted.org/packages/64/33/60135848598c076ce4b231e1b1895170f45fbcaeaa2c9d5e38b04db70c35/joblib-1.4.2.tar.gz"
+            }
+          ],
+          "project_name": "joblib",
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "1.4.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566",
+              "url": "https://files.pythonhosted.org/packages/69/4a/4f9dbeb84e8850557c02365a0eee0649abe5eb1d84af92a25731c6c0f922/jsonschema-4.23.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4",
+              "url": "https://files.pythonhosted.org/packages/38/2e/03362ee4034a4c917f697890ccd4aec0800ccf9ded7f511971c75451deec/jsonschema-4.23.0.tar.gz"
+            }
+          ],
+          "project_name": "jsonschema",
+          "requires_dists": [
+            "attrs>=22.2.0",
+            "fqdn; extra == \"format\"",
+            "fqdn; extra == \"format-nongpl\"",
+            "idna; extra == \"format\"",
+            "idna; extra == \"format-nongpl\"",
+            "importlib-resources>=1.4.0; python_version < \"3.9\"",
+            "isoduration; extra == \"format\"",
+            "isoduration; extra == \"format-nongpl\"",
+            "jsonpointer>1.13; extra == \"format\"",
+            "jsonpointer>1.13; extra == \"format-nongpl\"",
+            "jsonschema-specifications>=2023.03.6",
+            "pkgutil-resolve-name>=1.3.10; python_version < \"3.9\"",
+            "referencing>=0.28.4",
+            "rfc3339-validator; extra == \"format\"",
+            "rfc3339-validator; extra == \"format-nongpl\"",
+            "rfc3986-validator>0.1.0; extra == \"format-nongpl\"",
+            "rfc3987; extra == \"format\"",
+            "rpds-py>=0.7.1",
+            "uri-template; extra == \"format\"",
+            "uri-template; extra == \"format-nongpl\"",
+            "webcolors>=1.11; extra == \"format\"",
+            "webcolors>=24.6.0; extra == \"format-nongpl\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "4.23.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "a09a0680616357d9a0ecf05c12ad234479f549239d0f5b55f3deea67475da9bf",
+              "url": "https://files.pythonhosted.org/packages/d1/0f/8910b19ac0670a0f80ce1008e5e751c4a57e14d2c4c13a482aa6079fa9d6/jsonschema_specifications-2024.10.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0f38b83639958ce1152d02a7f062902c41c8fd20d558b0c34344292d417ae272",
+              "url": "https://files.pythonhosted.org/packages/10/db/58f950c996c793472e336ff3655b13fbcf1e3b359dcf52dcf3ed3b52c352/jsonschema_specifications-2024.10.1.tar.gz"
+            }
+          ],
+          "project_name": "jsonschema-specifications",
+          "requires_dists": [
+            "referencing>=0.31.0"
+          ],
+          "requires_python": ">=3.9",
+          "version": "2024.10.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "e8a19cc986cc45905ac3362915f410f3af85424b4c0905e94fa5f2cb08e8f23f",
+              "url": "https://files.pythonhosted.org/packages/11/85/b0394e0b6fcccd2c1eeefc230978a6f8cb0c5df1e4cd3e7625735a0d7d1e/jupyter_client-8.6.3-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "35b3a0947c4a6e9d589eb97d7d4cd5e90f910ee73101611f01283732bd6d9419",
+              "url": "https://files.pythonhosted.org/packages/71/22/bf9f12fdaeae18019a468b68952a60fe6dbab5d67cd2a103cac7659b41ca/jupyter_client-8.6.3.tar.gz"
+            }
+          ],
+          "project_name": "jupyter-client",
+          "requires_dists": [
+            "coverage; extra == \"test\"",
+            "importlib-metadata>=4.8.3; python_version < \"3.10\"",
+            "ipykernel; extra == \"docs\"",
+            "ipykernel>=6.14; extra == \"test\"",
+            "jupyter-core!=5.0.*,>=4.12",
+            "mypy; extra == \"test\"",
+            "myst-parser; extra == \"docs\"",
+            "paramiko; sys_platform == \"win32\" and extra == \"test\"",
+            "pre-commit; extra == \"test\"",
+            "pydata-sphinx-theme; extra == \"docs\"",
+            "pytest-cov; extra == \"test\"",
+            "pytest-jupyter[client]>=0.4.1; extra == \"test\"",
+            "pytest-timeout; extra == \"test\"",
+            "pytest<8.2.0; extra == \"test\"",
+            "python-dateutil>=2.8.2",
+            "pyzmq>=23.0",
+            "sphinx-autodoc-typehints; extra == \"docs\"",
+            "sphinx>=4; extra == \"docs\"",
+            "sphinxcontrib-github-alt; extra == \"docs\"",
+            "sphinxcontrib-spelling; extra == \"docs\"",
+            "tornado>=6.2",
+            "traitlets>=5.3"
+          ],
+          "requires_python": ">=3.8",
+          "version": "8.6.3"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "4f7315d2f6b4bcf2e3e7cb6e46772eba760ae459cd1f59d29eb57b0a01bd7409",
+              "url": "https://files.pythonhosted.org/packages/c9/fb/108ecd1fe961941959ad0ee4e12ee7b8b1477247f30b1fdfd83ceaf017f0/jupyter_core-5.7.2-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "aa5f8d32bbf6b431ac830496da7392035d6f61b4f54872f15c4bd2a9c3f536d9",
+              "url": "https://files.pythonhosted.org/packages/00/11/b56381fa6c3f4cc5d2cf54a7dbf98ad9aa0b339ef7a601d6053538b079a7/jupyter_core-5.7.2.tar.gz"
+            }
+          ],
+          "project_name": "jupyter-core",
+          "requires_dists": [
+            "ipykernel; extra == \"test\"",
+            "myst-parser; extra == \"docs\"",
+            "platformdirs>=2.5",
+            "pre-commit; extra == \"test\"",
+            "pydata-sphinx-theme; extra == \"docs\"",
+            "pytest-cov; extra == \"test\"",
+            "pytest-timeout; extra == \"test\"",
+            "pytest<8; extra == \"test\"",
+            "pywin32>=300; sys_platform == \"win32\" and platform_python_implementation != \"PyPy\"",
+            "sphinx-autodoc-typehints; extra == \"docs\"",
+            "sphinxcontrib-github-alt; extra == \"docs\"",
+            "sphinxcontrib-spelling; extra == \"docs\"",
+            "traitlets; extra == \"docs\"",
+            "traitlets>=5.3"
+          ],
+          "requires_python": ">=3.8",
+          "version": "5.7.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "40fa14dbd66b8b8f470d5fc79c089a66185619d31645f9b0773b88b19f7223c4",
+              "url": "https://files.pythonhosted.org/packages/fd/71/1687c5c0a0be2cee39a5c9c389e546f9c6e215e46b691d00d9f646892083/kiwisolver-1.4.7-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e968b84db54f9d42046cf154e02911e39c0435c9801681e3fc9ce8a3c4130278",
+              "url": "https://files.pythonhosted.org/packages/06/5f/1f5eaab84355885e224a6fc8d73089e8713dc7e91c121f00b9a1c58a2195/kiwisolver-1.4.7-cp310-cp310-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "84ec80df401cfee1457063732d90022f93951944b5b58975d34ab56bb150dfb3",
+              "url": "https://files.pythonhosted.org/packages/07/c9/032267192e7828520dacb64dfdb1d74f292765f179e467c1cba97687f17d/kiwisolver-1.4.7-cp310-cp310-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "88a9ca9c710d598fd75ee5de59d5bda2684d9db36a9f50b6125eaea3969c2599",
+              "url": "https://files.pythonhosted.org/packages/12/5d/c36140313f2510e20207708adf36ae4919416d697ee0236b0ddfb6fd1050/kiwisolver-1.4.7-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "58370b1ffbd35407444d57057b57da5d6549d2d854fa30249771775c63b5fe17",
+              "url": "https://files.pythonhosted.org/packages/1e/46/e68fed66236b69dd02fcdb506218c05ac0e39745d696d22709498896875d/kiwisolver-1.4.7-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8f0ea6da6d393d8b2e187e6a5e3fb81f5862010a40c3945e2c6d12ae45cfb2ad",
+              "url": "https://files.pythonhosted.org/packages/26/f6/453d1904c52ac3b400f4d5e240ac5fec25263716723e44be65f4d7149d13/kiwisolver-1.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bd3de6481f4ed8b734da5df134cd5a6a64fe32124fe83dde1e5b5f29fe30b1e6",
+              "url": "https://files.pythonhosted.org/packages/3b/ef/2f009ac1f7aab9f81efb2d837301d255279d618d27b6015780115ac64bdd/kiwisolver-1.4.7-pp310-pypy310_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8d53103597a252fb3ab8b5845af04c7a26d5e7ea8122303dd7a021176a87e8b9",
+              "url": "https://files.pythonhosted.org/packages/42/9c/cc8d90f6ef550f65443bad5872ffa68f3dee36de4974768628bea7c14979/kiwisolver-1.4.7-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "88f17c5ffa8e9462fb79f62746428dd57b46eb931698e42e990ad63103f35e6c",
+              "url": "https://files.pythonhosted.org/packages/55/91/0a57ce324caf2ff5403edab71c508dd8f648094b18cfbb4c8cc0fde4a6ac/kiwisolver-1.4.7-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f4d742cb7af1c28303a51b7a27aaee540e71bb8e24f68c736f6f2ffc82f2bf05",
+              "url": "https://files.pythonhosted.org/packages/56/d0/786e524f9ed648324a466ca8df86298780ef2b29c25313d9a4f16992d3cf/kiwisolver-1.4.7-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5b7dfa3b546da08a9f622bb6becdb14b3e24aaa30adba66749d38f3cc7ea9706",
+              "url": "https://files.pythonhosted.org/packages/58/cc/fb239294c29a5656e99e3527f7369b174dd9cc7c3ef2dea7cb3c54a8737b/kiwisolver-1.4.7-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f106407dda69ae456dd1227966bf445b157ccc80ba0dff3802bb63f30b74e895",
+              "url": "https://files.pythonhosted.org/packages/5a/9a/d4968499441b9ae187e81745e3277a8b4d7c60840a52dc9d535a7909fac3/kiwisolver-1.4.7-cp310-cp310-musllinux_1_2_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e28c7fea2196bf4c2f8d46a0415c77a1c480cc0724722f23d7410ffe9842c407",
+              "url": "https://files.pythonhosted.org/packages/67/5a/77851f2f201e6141d63c10a0708e996a1363efaf9e1609ad0441b343763b/kiwisolver-1.4.7-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "a91b5f9f1205845d488c928e8570dcb62b893372f63b8b6e98b863ebd2368ff2",
+              "url": "https://files.pythonhosted.org/packages/81/e1/c64f50987f85b68b1c52b464bb5bf73e71570c0f7782d626d1eb283ad620/kiwisolver-1.4.7-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9893ff81bd7107f7b685d3017cc6583daadb4fc26e4a888350df530e41980a60",
+              "url": "https://files.pythonhosted.org/packages/85/4d/2255e1c76304cbd60b48cee302b66d1dde4468dc5b1160e4b7cb43778f2a/kiwisolver-1.4.7.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8a9c83f75223d5e48b0bc9cb1bf2776cf01563e00ade8775ffe13b0b6e1af3a6",
+              "url": "https://files.pythonhosted.org/packages/97/14/fc943dd65268a96347472b4fbe5dcc2f6f55034516f80576cd0dd3a8930f/kiwisolver-1.4.7-cp310-cp310-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "94252291e3fe68001b1dd747b4c0b3be12582839b95ad4d1b641924d68fd4643",
+              "url": "https://files.pythonhosted.org/packages/ac/59/741b79775d67ab67ced9bb38552da688c0305c16e7ee24bba7a2be253fb7/kiwisolver-1.4.7-pp310-pypy310_pp73-macosx_10_15_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0c18ec74c0472de033e1bebb2911c3c310eef5649133dd0bedf2a169a1b269e5",
+              "url": "https://files.pythonhosted.org/packages/b5/28/9152a3bfe976a0ae21d445415defc9d1cd8614b2910b7614b30b27a47270/kiwisolver-1.4.7-cp310-cp310-musllinux_1_2_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "aa0abdf853e09aff551db11fce173e2177d00786c688203f52c87ad7fcd91ef9",
+              "url": "https://files.pythonhosted.org/packages/ef/fa/65de49c85838681fc9cb05de2a68067a683717321e01ddafb5b8024286f0/kiwisolver-1.4.7-cp310-cp310-macosx_11_0_arm64.whl"
+            }
+          ],
+          "project_name": "kiwisolver",
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "1.4.7"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "eacade0527a62d6086cb76f7dbf1e94f2f445a696dd7168723bc7a86e4737a99",
+              "url": "https://files.pythonhosted.org/packages/b3/98/868d6b60a6a8847a53bca3b15b0e057fb3ed6395e5852f0c0c55bbaaa928/lifelines-0.28.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "eecf726453fd409c94fef8a521f8e593bcd09337f920fe885131f01cfe58b25e",
+              "url": "https://files.pythonhosted.org/packages/50/32/deebb9e76d73700a402f0ef310c21b038580bd9e0763a612963549f18082/lifelines-0.28.0.tar.gz"
+            }
+          ],
+          "project_name": "lifelines",
+          "requires_dists": [
+            "autograd-gamma>=0.3",
+            "autograd>=1.5",
+            "formulaic>=0.2.2",
+            "matplotlib>=3.0",
+            "numpy<2.0,>=1.14.0",
+            "pandas>=1.2.0",
+            "scipy>=1.2.0"
+          ],
+          "requires_python": ">=3.9",
+          "version": "0.28.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "960a0e7c077de0ca3053f1325d3edfc92ea815acf5176adcacdea0f635aeef9b",
+              "url": "https://files.pythonhosted.org/packages/4e/19/1b928cad70a4e1a3e2c37d5417ca2182510f2451eaadb6c91cd9ec692cae/lightgbm-4.5.0-py3-none-manylinux_2_28_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1301aa853e1fe4bf318539aa132f373862b04aa537af502508711ce03dffff09",
+              "url": "https://files.pythonhosted.org/packages/11/3f/49913ed111286e23bcc40daab54542d80924264dca8ae371514039ab83ab/lightgbm-4.5.0-py3-none-macosx_12_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2212e2166af6379bc005e6f7041dd2dcba3750238eccbc55d09d3c0717c51187",
+              "url": "https://files.pythonhosted.org/packages/1b/d2/46520b6e255298e920df26ff6e5e4fc788c927886e1e30a96b27c2f94924/lightgbm-4.5.0-py3-none-macosx_10_15_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e1cd7baf0318d4e308a26575a63a4635f08df866ad3622a9d8e3d71d9637a1ba",
+              "url": "https://files.pythonhosted.org/packages/4d/e6/41be1f8642257e21b4170e798c9a84e4268656ebfa3019586d82bfd281c9/lightgbm-4.5.0.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7f0a3dded769d83560845f2c3fe1966630ec1ca527c380d9d48d9b35579a796e",
+              "url": "https://files.pythonhosted.org/packages/84/6a/10c4921526600559530d49d70553d1bc1bd84c616808c629a620a6160305/lightgbm-4.5.0-py3-none-manylinux2014_aarch64.whl"
+            }
+          ],
+          "project_name": "lightgbm",
+          "requires_dists": [
+            "cffi>=1.15.1; extra == \"arrow\"",
+            "dask[array,dataframe,distributed]>=2.0.0; extra == \"dask\"",
+            "numpy>=1.17.0",
+            "pandas>=0.24.0; extra == \"dask\"",
+            "pandas>=0.24.0; extra == \"pandas\"",
+            "pyarrow>=6.0.1; extra == \"arrow\"",
+            "scikit-learn!=0.22.0; extra == \"scikit-learn\"",
+            "scipy"
+          ],
+          "requires_python": ">=3.7",
+          "version": "4.5.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "6912a87782acdff6eb8bf01675ed01d60ca1f2551f8176a300a886f09e836a6a",
+              "url": "https://files.pythonhosted.org/packages/c6/21/2ffbab5714e72f2483207b4a1de79b2eecd9debbf666ff4e7067bcc5c134/llvmlite-0.43.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "a289af9a1687c6cf463478f0fa8e8aa3b6fb813317b0d70bf1ed0759eab6f761",
+              "url": "https://files.pythonhosted.org/packages/23/ff/6ca7e98998b573b4bd6566f15c35e5c8bea829663a6df0c7aa55ab559da9/llvmlite-0.43.0-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7d434ec7e2ce3cc8f452d1cd9a28591745de022f931d67be688a737320dfcead",
+              "url": "https://files.pythonhosted.org/packages/7e/3c/4410f670ad0a911227ea2ecfcba9f672a77cf1924df5280c4562032ec32d/llvmlite-0.43.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ae2b5b5c3ef67354824fb75517c8db5fbe93bc02cd9671f3c62271626bc041d5",
+              "url": "https://files.pythonhosted.org/packages/9f/3d/f513755f285db51ab363a53e898b85562e950f79a2e6767a364530c2f645/llvmlite-0.43.0.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6d4fd101f571a31acb1559ae1af30f30b1dc4b3186669f92ad780e17c81e91bc",
+              "url": "https://files.pythonhosted.org/packages/ca/5c/a27f9257f86f0cda3f764ff21d9f4217b9f6a0d45e7a39ecfa7905f524ce/llvmlite-0.43.0-cp310-cp310-macosx_11_0_arm64.whl"
+            }
+          ],
+          "project_name": "llvmlite",
+          "requires_dists": [],
+          "requires_python": ">=3.9",
+          "version": "0.43.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "42f48953c7eb91332040ff567eb7eea69b22e7a4affbc5ba8e845e8f730f6627",
+              "url": "https://files.pythonhosted.org/packages/1e/bf/7a6a36ce2e4cafdfb202752be68850e22607fccd692847c45c1ae3c17ba6/Mako-1.3.8-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "577b97e414580d3e088d47c2dbbe9594aa7a5146ed2875d4dfa9075af2dd3cc8",
+              "url": "https://files.pythonhosted.org/packages/5f/d9/8518279534ed7dace1795d5a47e49d5299dd0994eed1053996402a8902f9/mako-1.3.8.tar.gz"
+            }
+          ],
+          "project_name": "mako",
+          "requires_dists": [
+            "Babel; extra == \"babel\"",
+            "MarkupSafe>=0.9.2",
+            "lingua; extra == \"lingua\"",
+            "pytest; extra == \"testing\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "1.3.8"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1",
+              "url": "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb",
+              "url": "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz"
+            }
+          ],
+          "project_name": "markdown-it-py",
+          "requires_dists": [
+            "commonmark~=0.9; extra == \"compare\"",
+            "coverage; extra == \"testing\"",
+            "gprof2dot; extra == \"profiling\"",
+            "jupyter_sphinx; extra == \"rtd\"",
+            "linkify-it-py<3,>=1; extra == \"linkify\"",
+            "markdown~=3.4; extra == \"compare\"",
+            "mdit-py-plugins; extra == \"plugins\"",
+            "mdit-py-plugins; extra == \"rtd\"",
+            "mdurl~=0.1",
+            "mistletoe~=1.0; extra == \"compare\"",
+            "mistune~=2.0; extra == \"compare\"",
+            "myst-parser; extra == \"rtd\"",
+            "panflute~=2.3; extra == \"compare\"",
+            "pre-commit~=3.0; extra == \"code-style\"",
+            "psutil; extra == \"benchmarking\"",
+            "pytest-benchmark; extra == \"benchmarking\"",
+            "pytest-cov; extra == \"testing\"",
+            "pytest-regressions; extra == \"testing\"",
+            "pytest; extra == \"benchmarking\"",
+            "pytest; extra == \"testing\"",
+            "pyyaml; extra == \"rtd\"",
+            "sphinx-copybutton; extra == \"rtd\"",
+            "sphinx-design; extra == \"rtd\"",
+            "sphinx; extra == \"rtd\"",
+            "sphinx_book_theme; extra == \"rtd\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "3.0.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "b424c77b206d63d500bcb69fa55ed8d0e6a3774056bdc4839fc9298a7edca171",
+              "url": "https://files.pythonhosted.org/packages/bd/6e/61ebf08d8940553afff20d1fb1ba7294b6f8d279df9fd0c0db911b4bbcfd/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8",
+              "url": "https://files.pythonhosted.org/packages/04/90/d08277ce111dd22f77149fd1a5d4653eeb3b3eaacbdfcbae5afb2600eebd/MarkupSafe-3.0.2-cp310-cp310-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9e2d922824181480953426608b81967de705c3cef4d1af983af849d7bd619158",
+              "url": "https://files.pythonhosted.org/packages/04/e1/6e2194baeae0bca1fae6629dc0cbbb968d4d941469cbab11a3872edff374/MarkupSafe-3.0.2-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "38a9ef736c01fccdd6600705b09dc574584b89bea478200c5fbf112a6b0d5579",
+              "url": "https://files.pythonhosted.org/packages/1d/69/35fa85a8ece0a437493dc61ce0bb6d459dcba482c34197e3efc829aa357f/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bbcb445fa71794da8f178f0f6d66789a28d7319071af7a496d4d507ed566270d",
+              "url": "https://files.pythonhosted.org/packages/22/35/137da042dfb4720b638d2937c38a9c2df83fe32d20e8c8f3185dbfef05f7/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e07c3764494e3776c602c1e78e298937c3315ccc9043ead7e685b7f2b8d47b3c",
+              "url": "https://files.pythonhosted.org/packages/29/01/84b57395b4cc062f9c4c55ce0df7d3108ca32397299d9df00fedd9117d3d/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "57cb5a3cf367aeb1d316576250f65edec5bb3be939e9247ae594b4bcbc317dfb",
+              "url": "https://files.pythonhosted.org/packages/29/28/6d029a903727a1b62edb51863232152fd335d602def598dade38996887f0/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0",
+              "url": "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3809ede931876f5b2ec92eef964286840ed3540dadf803dd570c3b7e13141a3b",
+              "url": "https://files.pythonhosted.org/packages/cc/cd/07438f95f83e8bc028279909d9c9bd39e24149b0d60053a97b2bc4f8aa51/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_aarch64.whl"
+            }
+          ],
+          "project_name": "markupsafe",
+          "requires_dists": [],
+          "requires_python": ">=3.9",
+          "version": "3.0.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "ae80dc3a4add4665cf2faa90138384a7ffe2a4e37c58d83e115b54287c4f06ef",
+              "url": "https://files.pythonhosted.org/packages/c9/b4/680aa700d99b48e8c4393fa08e9ab8c49c0555ee6f4c9c0a5e8ea8dfde5d/matplotlib-3.10.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "01d2b19f13aeec2e759414d3bfe19ddfb16b13a1250add08d46d5ff6f9be83c6",
+              "url": "https://files.pythonhosted.org/packages/09/5a/a113495110ae3e3395c72d82d7bc4802902e46dc797f6b041e572f195c56/matplotlib-3.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2c5829a5a1dd5a71f0e31e6e8bb449bc0ee9dbfb05ad28fc0c6b55101b3a4be6",
+              "url": "https://files.pythonhosted.org/packages/09/ec/3cdff7b5239adaaacefcc4f77c316dfbbdf853c4ed2beec467e0fec31b9f/matplotlib-3.10.0-cp310-cp310-macosx_10_12_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5e6c6461e1fc63df30bf6f80f0b93f5b6784299f721bc28530477acd51bfc3d1",
+              "url": "https://files.pythonhosted.org/packages/12/b1/8b1655b4c9ed4600c817c419f7eaaf70082630efd7556a5b2e77a8a3cdaf/matplotlib-3.10.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "81713dd0d103b379de4516b861d964b1d789a144103277769238c732229d7f03",
+              "url": "https://files.pythonhosted.org/packages/32/5f/29def7ce4e815ab939b56280976ee35afffb3bbdb43f332caee74cb8c951/matplotlib-3.10.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "a2a43cbefe22d653ab34bb55d42384ed30f611bcbdea1f8d7f431011a2e1c62e",
+              "url": "https://files.pythonhosted.org/packages/41/f2/b518f2c7f29895c9b167bf79f8529c63383ae94eaf49a247a4528e9a148d/matplotlib-3.10.0-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b886d02a581b96704c9d1ffe55709e49b4d2d52709ccebc4be42db856e511278",
+              "url": "https://files.pythonhosted.org/packages/68/dd/fa2e1a45fce2d09f4aea3cee169760e672c8262325aa5796c49d543dc7e6/matplotlib-3.10.0.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "359f87baedb1f836ce307f0e850d12bb5f1936f70d035561f90d41d305fdacea",
+              "url": "https://files.pythonhosted.org/packages/de/6d/d570383c9f7ca799d0a54161446f9ce7b17d6c50f2994b653514bcaa108f/matplotlib-3.10.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "607b16c8a73943df110f99ee2e940b8a1cbf9714b65307c040d422558397dac5",
+              "url": "https://files.pythonhosted.org/packages/ed/8d/45754b4affdb8f0d1a44e4e2bcd932cdf35b256b60d5eda9f455bb293ed0/matplotlib-3.10.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            }
+          ],
+          "project_name": "matplotlib",
+          "requires_dists": [
+            "contourpy>=1.0.1",
+            "cycler>=0.10",
+            "fonttools>=4.22.0",
+            "kiwisolver>=1.3.1",
+            "meson-python<0.17.0,>=0.13.1; extra == \"dev\"",
+            "numpy>=1.23",
+            "packaging>=20.0",
+            "pillow>=8",
+            "pybind11!=2.13.3,>=2.13.2; extra == \"dev\"",
+            "pyparsing>=2.3.1",
+            "python-dateutil>=2.7",
+            "setuptools>=64; extra == \"dev\"",
+            "setuptools_scm>=7; extra == \"dev\""
+          ],
+          "requires_python": ">=3.10",
+          "version": "3.10.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "df192d39a4ff8f21b1895d72e6a13f5fcc5099f00fa84384e0ea28c2cc0653ca",
+              "url": "https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90",
+              "url": "https://files.pythonhosted.org/packages/99/5b/a36a337438a14116b16480db471ad061c36c3694df7c2084a0da7ba538b7/matplotlib_inline-0.1.7.tar.gz"
+            }
+          ],
+          "project_name": "matplotlib-inline",
+          "requires_dists": [
+            "traitlets"
+          ],
+          "requires_python": ">=3.8",
+          "version": "0.1.7"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "d885bc015f5091a4b8a8138ff20a7ed166c33b5c36dbc0489f95a5cbc76a2ae5",
+              "url": "https://files.pythonhosted.org/packages/fe/a7/6e34cd021e9b668671909f67745cc062526c22e1c3971618d93d767dce5f/matplotlib-venn-1.1.1.tar.gz"
+            }
+          ],
+          "project_name": "matplotlib-venn",
+          "requires_dists": [
+            "matplotlib",
+            "numpy",
+            "scipy",
+            "shapely; extra == \"shapely\""
+          ],
+          "requires_python": null,
+          "version": "1.1.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
+              "url": "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba",
+              "url": "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
+            }
+          ],
+          "project_name": "mdurl",
+          "requires_dists": [],
+          "requires_python": ">=3.7",
+          "version": "0.1.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c",
+              "url": "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe",
+              "url": "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz"
+            }
+          ],
+          "project_name": "nest-asyncio",
+          "requires_dists": [],
+          "requires_python": ">=3.5",
+          "version": "1.6.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "fe0b28abb8d70f8160798f4de9d486143200f34458d34c4a214114e445d7124e",
+              "url": "https://files.pythonhosted.org/packages/79/58/cb4ac5b8f7ec64200460aef1fed88258fb872ceef504ab1f989d2ff0f684/numba-0.60.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1527dc578b95c7c4ff248792ec33d097ba6bef9eda466c948b68dfc995c25781",
+              "url": "https://files.pythonhosted.org/packages/28/98/7ea97ee75870a54f938a8c70f7e0be4495ba5349c5f9db09d467c4a5d5b7/numba-0.60.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5df6158e5584eece5fc83294b949fd30b9f1125df7708862205217e068aabf16",
+              "url": "https://files.pythonhosted.org/packages/3c/93/2849300a9184775ba274aba6f82f303343669b0592b7bb0849ea713dabb0/numba-0.60.0.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "159e618ef213fba758837f9837fb402bbe65326e60ba0633dbe6c7f274d42c1b",
+              "url": "https://files.pythonhosted.org/packages/ac/ba/4b57fa498564457c3cc9fc9e570a6b08e6086c74220f24baaf04e54b995f/numba-0.60.0-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5d761de835cd38fb400d2c26bb103a2726f548dc30368853121d66201672e651",
+              "url": "https://files.pythonhosted.org/packages/f7/cf/baa13a7e3556d73d9e38021e6d6aa4aeb30d8b94545aa8b70d0f24a1ccc4/numba-0.60.0-cp310-cp310-macosx_10_9_x86_64.whl"
+            }
+          ],
+          "project_name": "numba",
+          "requires_dists": [
+            "llvmlite<0.44,>=0.43.0dev0",
+            "numpy<2.1,>=1.22"
+          ],
+          "requires_python": ">=3.9",
+          "version": "0.60.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "a4abb4f9001ad2858e7ac189089c42178fcce737e4169dc61321660f1a96c7d2",
+              "url": "https://files.pythonhosted.org/packages/39/fe/39ada9b094f01f5a35486577c848fe274e374bbf8d8f472e1423a0bbd26d/numpy-1.26.4-cp310-cp310-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2e4ee3380d6de9c9ec04745830fd9e2eccb3e6cf790d39d7b98ffd19b0dd754a",
+              "url": "https://files.pythonhosted.org/packages/20/f7/b24208eba89f9d1b58c1668bc6c8c4fd472b20c45573cb767f59d49fb0f6/numpy-1.26.4-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "62b8e4b1e28009ef2846b4c7852046736bab361f7aeadeb6a5b89ebec3c7055a",
+              "url": "https://files.pythonhosted.org/packages/24/03/6f229fe3187546435c4f6f89f6d26c129d4f5bed40552899fcf1f0bf9e50/numpy-1.26.4-cp310-cp310-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ffa75af20b44f8dba823498024771d5ac50620e6915abac414251bd971b4529f",
+              "url": "https://files.pythonhosted.org/packages/4b/d7/ecf66c1cd12dc28b4040b15ab4d17b773b87fa9d29ca16125de01adb36cd/numpy-1.26.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010",
+              "url": "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9ff0f4f29c51e2803569d7a51c2304de5554655a60c5d776e35b4a41413830d0",
+              "url": "https://files.pythonhosted.org/packages/a7/94/ace0fdea5241a27d13543ee117cbc65868e82213fb31a8eb7fe9ff23f313/numpy-1.26.4-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d209d8969599b27ad20994c8e41936ee0964e6da07478d6c35016bc386b66ad4",
+              "url": "https://files.pythonhosted.org/packages/fc/a5/4beee6488160798683eed5bdb7eead455892c3b4e1f78d79d8d3f3b084ac/numpy-1.26.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            }
+          ],
+          "project_name": "numpy",
+          "requires_dists": [],
+          "requires_python": ">=3.9",
+          "version": "1.26.4"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "b097258d9aab2fa9f686e33c6fe40ae57b27df60cedbd15d139701bb5509e0c1",
+              "url": "https://files.pythonhosted.org/packages/ed/1f/6482380ec8dcec4894e7503490fc536d846b0d59694acad9cf99f27d0e7d/nvidia_nccl_cu12-2.23.4-py3-none-manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "aa946c8327e22ced28e7cef508a334673abc42064ec85f02d005ba1785ea4cec",
+              "url": "https://files.pythonhosted.org/packages/c8/3a/0112397396dec37ffc8edd7836d48261b4d14ca60ec8ed7bc857cce1d916/nvidia_nccl_cu12-2.23.4-py3-none-manylinux2014_aarch64.whl"
+            }
+          ],
+          "project_name": "nvidia-nccl-cu12",
+          "requires_dists": [],
+          "requires_python": ">=3",
+          "version": "2.23.4"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "1763856b01c9238594d9d21db92611aac9980e9a6300bd658a7c6464712c704e",
+              "url": "https://files.pythonhosted.org/packages/e8/30/35111dae435c640694d616a611b7ff6b2482cfd977f8f572ff960a321d66/optuna-4.1.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b364e87a2038f9946c5e2770c130597538aac528b4a82c1cab5267f337ea7679",
+              "url": "https://files.pythonhosted.org/packages/6d/e0/52f8b3dfa4bd61e80778ec9f287fe5beafc11af31e6d4cb8f182634f5937/optuna-4.1.0.tar.gz"
+            }
+          ],
+          "project_name": "optuna",
+          "requires_dists": [
+            "PyYAML",
+            "alembic>=1.5.0",
+            "ase; extra == \"document\"",
+            "asv>=0.5.0; extra == \"benchmark\"",
+            "black; extra == \"checking\"",
+            "blackdoc; extra == \"checking\"",
+            "boto3; extra == \"optional\"",
+            "cma; extra == \"benchmark\"",
+            "cmaes>=0.10.0; extra == \"document\"",
+            "cmaes>=0.10.0; extra == \"optional\"",
+            "colorlog",
+            "coverage; extra == \"test\"",
+            "fakeredis[lua]; extra == \"test\"",
+            "flake8; extra == \"checking\"",
+            "fvcore; extra == \"document\"",
+            "google-cloud-storage; extra == \"optional\"",
+            "isort; extra == \"checking\"",
+            "kaleido; extra == \"document\"",
+            "kaleido; extra == \"test\"",
+            "lightgbm; extra == \"document\"",
+            "matplotlib!=3.6.0; extra == \"document\"",
+            "matplotlib!=3.6.0; extra == \"optional\"",
+            "moto; extra == \"test\"",
+            "mypy-boto3-s3; extra == \"checking\"",
+            "mypy; extra == \"checking\"",
+            "numpy",
+            "packaging>=20.0",
+            "pandas; extra == \"document\"",
+            "pandas; extra == \"optional\"",
+            "pillow; extra == \"document\"",
+            "plotly>=4.9.0; extra == \"document\"",
+            "plotly>=4.9.0; extra == \"optional\"",
+            "pytest; extra == \"test\"",
+            "redis; extra == \"optional\"",
+            "scikit-learn; extra == \"document\"",
+            "scikit-learn>=0.24.2; extra == \"optional\"",
+            "scipy; extra == \"optional\"",
+            "scipy>=1.9.2; extra == \"test\"",
+            "sphinx-copybutton; extra == \"document\"",
+            "sphinx-gallery; extra == \"document\"",
+            "sphinx-rtd-theme>=1.2.0; extra == \"document\"",
+            "sphinx; extra == \"document\"",
+            "sqlalchemy>=1.4.2",
+            "torch; extra == \"document\"",
+            "torch; python_version <= \"3.12\" and extra == \"optional\"",
+            "torch; python_version <= \"3.12\" and extra == \"test\"",
+            "torchvision; extra == \"document\"",
+            "tqdm",
+            "types-PyYAML; extra == \"checking\"",
+            "types-redis; extra == \"checking\"",
+            "types-setuptools; extra == \"checking\"",
+            "types-tqdm; extra == \"checking\"",
+            "typing-extensions>=3.10.0.0; extra == \"checking\"",
+            "virtualenv; extra == \"benchmark\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "4.1.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759",
+              "url": "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f",
+              "url": "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz"
+            }
+          ],
+          "project_name": "packaging",
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "24.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "7a0a56cef15fd1586726dace5616db75ebcfec9179a3a55e78f72c5639fa2a23",
+              "url": "https://files.pythonhosted.org/packages/49/e2/79e46612dc25ebc7603dc11c560baa7266c90f9e48537ecf1a02a0dd6bff/pandas-1.5.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c3ac844a0fe00bfaeb2c9b51ab1424e5c8744f89860b138434a363b1f620f354",
+              "url": "https://files.pythonhosted.org/packages/27/c7/35b81ce5f680f2dac55eac14d103245cd8cf656ae4a2ff3be2e69fd1d330/pandas-1.5.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "972d8a45395f2a2d26733eb8d0f629b2f90bebe8e8eddbb8829b180c09639572",
+              "url": "https://files.pythonhosted.org/packages/5f/34/b7858bb7d6d6bf4d9df1dde777a11fcf3ff370e1d1b3956e3d0fcca8322c/pandas-1.5.3-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "74a3fd7e5a7ec052f183273dc7b0acd3a863edf7520f5d3a1765c04ffdb3b0b1",
+              "url": "https://files.pythonhosted.org/packages/74/ee/146cab1ff6d575b54ace8a6a5994048380dc94879b0125b25e62edcb9e52/pandas-1.5.3.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3749077d86e3a2f0ed51367f30bf5b82e131cc0f14260c4d3e499186fccc4406",
+              "url": "https://files.pythonhosted.org/packages/a9/cd/34f6b0780301be81be804d7aa71d571457369e6131e2b330af2b0fed1aad/pandas-1.5.3-cp310-cp310-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "50869a35cbb0f2e0cd5ec04b191e7b12ed688874bd05dd777c19b28cbea90996",
+              "url": "https://files.pythonhosted.org/packages/b8/6c/005bd604994f7cbede4d7bf030614ef49a2213f76bc3d738ecf5b0dcc810/pandas-1.5.3-cp310-cp310-macosx_11_0_arm64.whl"
+            }
+          ],
+          "project_name": "pandas",
+          "requires_dists": [
+            "hypothesis>=5.5.3; extra == \"test\"",
+            "numpy>=1.20.3; python_version < \"3.10\"",
+            "numpy>=1.21.0; python_version >= \"3.10\"",
+            "numpy>=1.23.2; python_version >= \"3.11\"",
+            "pytest-xdist>=1.31; extra == \"test\"",
+            "pytest>=6.0; extra == \"test\"",
+            "python-dateutil>=2.8.1",
+            "pytz>=2020.1"
+          ],
+          "requires_python": ">=3.8",
+          "version": "1.5.3"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "046d512a6a9b1d55cd1f51fec72df87dbb488152a6c4a9776347313e475f31d4",
+              "url": "https://files.pythonhosted.org/packages/98/87/ab5993ca57900bf68432d943d19efdeec8034ff3580060844bd345e54852/parameters_validation-1.2.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1db2aed4681b6c388c7334f8aa0d4f9fb373e8eca43d0f0851fb17a1db9ced1d",
+              "url": "https://files.pythonhosted.org/packages/fd/99/e1cdc904b097dd92064ae93a295f90839972932bcb9d6fd7b22056739bd4/parameters-validation-1.2.0.tar.gz"
+            }
+          ],
+          "project_name": "parameters-validation",
+          "requires_dists": [
+            "coveralls; extra == \"test\"",
+            "pytest-cov; extra == \"test\"",
+            "pytest; extra == \"test\""
+          ],
+          "requires_python": null,
+          "version": "1.2.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "a418670a20291dacd2dddc80c377c5c3791378ee1e8d12bffc35420643d43f18",
+              "url": "https://files.pythonhosted.org/packages/c6/ac/dac4a63f978e4dcb3c6d3a78c4d8e0192a113d288502a1216950c41b1027/parso-0.8.4-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "eb3a7b58240fb99099a345571deecc0f9540ea5f4dd2fe14c2a99d6b281ab92d",
+              "url": "https://files.pythonhosted.org/packages/66/94/68e2e17afaa9169cf6412ab0f28623903be73d1b32e208d9e8e541bb086d/parso-0.8.4.tar.gz"
+            }
+          ],
+          "project_name": "parso",
+          "requires_dists": [
+            "docopt; extra == \"testing\"",
+            "flake8==5.0.4; extra == \"qa\"",
+            "mypy==0.971; extra == \"qa\"",
+            "pytest; extra == \"testing\"",
+            "types-setuptools==67.2.0.1; extra == \"qa\""
+          ],
+          "requires_python": ">=3.6",
+          "version": "0.8.4"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "751fb38f9e97e62312e921a1954b81e1bb2bcda4f5eeabaf94db251ee791509c",
+              "url": "https://files.pythonhosted.org/packages/87/2b/b50d3d08ea0fc419c183a84210571eba005328efa62b6b98bc28e9ead32a/patsy-1.0.1-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e786a9391eec818c054e359b737bbce692f051aee4c661f4141cc88fb459c0c4",
+              "url": "https://files.pythonhosted.org/packages/d1/81/74f6a65b848ffd16c18f920620ce999fe45fe27f01ab3911260ce4ed85e4/patsy-1.0.1.tar.gz"
+            }
+          ],
+          "project_name": "patsy",
+          "requires_dists": [
+            "numpy>=1.4",
+            "pytest-cov; extra == \"test\"",
+            "pytest; extra == \"test\"",
+            "scipy; extra == \"test\""
+          ],
+          "requires_python": ">=3.6",
+          "version": "1.0.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523",
+              "url": "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f",
+              "url": "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz"
+            }
+          ],
+          "project_name": "pexpect",
+          "requires_dists": [
+            "ptyprocess>=0.5"
+          ],
+          "requires_python": null,
+          "version": "4.9.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "e58876c91f97b0952eb766123bfef372792ab3f4e3e1f1a2267834c2ab131734",
+              "url": "https://files.pythonhosted.org/packages/3d/30/38bd6149cf53da1db4bad304c543ade775d225961c4310f30425995cb9ec/pillow-11.0.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "88a58d8ac0cc0e7f3a014509f0455248a76629ca9b604eca7dc5927cc593c5e9",
+              "url": "https://files.pythonhosted.org/packages/0e/74/467af0146970a98349cdf39e9b79a6cc8a2e7558f2c01c28a7b6b85c5bda/pillow-11.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "73853108f56df97baf2bb8b522f3578221e56f646ba345a372c78326710d3830",
+              "url": "https://files.pythonhosted.org/packages/0e/75/689b4ec0483c42bfc7d1aacd32ade7a226db4f4fac57c6fdcdf90c0731e3/pillow-11.0.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "598b4e238f13276e0008299bd2482003f48158e2b11826862b1eb2ad7c768b97",
+              "url": "https://files.pythonhosted.org/packages/26/95/1495304448b0081e60c0c5d63f928ef48bb290acee7385804426fa395a21/pillow-11.0.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1187739620f2b365de756ce086fdb3604573337cc28a0d3ac4a01ab6b2d2a6d2",
+              "url": "https://files.pythonhosted.org/packages/36/57/42a4dd825eab762ba9e690d696d894ba366e06791936056e26e099398cda/pillow-11.0.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1a61b54f87ab5786b8479f81c4b11f4d61702830354520837f8cc791ebba0f5f",
+              "url": "https://files.pythonhosted.org/packages/41/c3/94f33af0762ed76b5a237c5797e088aa57f2b7fa8ee7932d399087be66a8/pillow-11.0.0-cp310-cp310-manylinux_2_28_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "21a0d3b115009ebb8ac3d2ebec5c2982cc693da935f4ab7bb5c8ebe2f47d36f2",
+              "url": "https://files.pythonhosted.org/packages/51/c0/570255b2866a0e4d500a14f950803a2ec273bac7badc43320120b9262450/pillow-11.0.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5d203af30149ae339ad1b4f710d9844ed8796e97fda23ffbc4cc472968a47d0b",
+              "url": "https://files.pythonhosted.org/packages/59/01/98ead48a6c2e31e6185d4c16c978a67fe3ccb5da5c2ff2ba8475379bb693/pillow-11.0.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b3c5ac4bed7519088103d9450a1107f76308ecf91d6dabc8a33a2fcfb18d0fba",
+              "url": "https://files.pythonhosted.org/packages/6a/1d/1f51e6e912d8ff316bb3935a8cda617c801783e0b998bf7a894e91d3bd4c/pillow-11.0.0-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c26845094b1af3c91852745ae78e3ea47abf3dbcd1cf962f16b9a5fbe3ee8488",
+              "url": "https://files.pythonhosted.org/packages/85/b1/d95d4f7ca3a6c1ae120959605875a31a3c209c4e50f0029dc1a87566cf46/pillow-11.0.0-cp310-cp310-manylinux_2_28_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "a65149d8ada1055029fcb665452b2814fe7d7082fcb0c5bed6db851cb69b2086",
+              "url": "https://files.pythonhosted.org/packages/90/83/e2077b0192ca8a9ef794dbb74700c7e48384706467067976c2a95a0f40a1/pillow-11.0.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "fbbcb7b57dc9c794843e3d1258c0fbf0f48656d46ffe9e09b63bbd6e8cd5d0a2",
+              "url": "https://files.pythonhosted.org/packages/98/f7/25f9f9e368226a1d6cf3507081a1a7944eddd3ca7821023377043f5a83c8/pillow-11.0.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6619654954dc4936fcff82db8eb6401d3159ec6be81e33c6000dfd76ae189947",
+              "url": "https://files.pythonhosted.org/packages/98/fb/a6ce6836bd7fd93fbf9144bf54789e02babc27403b50a9e1583ee877d6da/pillow-11.0.0-cp310-cp310-macosx_10_10_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "72bacbaf24ac003fea9bff9837d1eedb6088758d41e100c1552930151f677739",
+              "url": "https://files.pythonhosted.org/packages/a5/26/0d95c04c868f6bdb0c447e3ee2de5564411845e36a858cfd63766bc7b563/pillow-11.0.0.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "674629ff60030d144b7bca2b8330225a9b11c482ed408813924619c6f302fdbb",
+              "url": "https://files.pythonhosted.org/packages/ba/3c/443e7ef01f597497268899e1cca95c0de947c9bbf77a8f18b3c126681e5d/pillow-11.0.0-cp310-cp310-musllinux_1_2_aarch64.whl"
+            }
+          ],
+          "project_name": "pillow",
+          "requires_dists": [
+            "check-manifest; extra == \"tests\"",
+            "coverage; extra == \"tests\"",
+            "defusedxml; extra == \"tests\"",
+            "defusedxml; extra == \"xmp\"",
+            "furo; extra == \"docs\"",
+            "markdown2; extra == \"tests\"",
+            "olefile; extra == \"docs\"",
+            "olefile; extra == \"fpx\"",
+            "olefile; extra == \"mic\"",
+            "olefile; extra == \"tests\"",
+            "packaging; extra == \"tests\"",
+            "pyroma; extra == \"tests\"",
+            "pytest-cov; extra == \"tests\"",
+            "pytest-timeout; extra == \"tests\"",
+            "pytest; extra == \"tests\"",
+            "sphinx-copybutton; extra == \"docs\"",
+            "sphinx-inline-tabs; extra == \"docs\"",
+            "sphinx>=8.1; extra == \"docs\"",
+            "sphinxext-opengraph; extra == \"docs\"",
+            "typing-extensions; python_version < \"3.10\" and extra == \"typing\""
+          ],
+          "requires_python": ">=3.9",
+          "version": "11.0.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb",
+              "url": "https://files.pythonhosted.org/packages/3c/a6/bc1012356d8ece4d66dd75c4b9fc6c1f6650ddd5991e421177d9f8f671be/platformdirs-4.3.6-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907",
+              "url": "https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz"
+            }
+          ],
+          "project_name": "platformdirs",
+          "requires_dists": [
+            "appdirs==1.4.4; extra == \"test\"",
+            "covdefaults>=2.3; extra == \"test\"",
+            "furo>=2024.8.6; extra == \"docs\"",
+            "mypy>=1.11.2; extra == \"type\"",
+            "proselint>=0.14; extra == \"docs\"",
+            "pytest-cov>=5; extra == \"test\"",
+            "pytest-mock>=3.14; extra == \"test\"",
+            "pytest>=8.3.2; extra == \"test\"",
+            "sphinx-autodoc-typehints>=2.4; extra == \"docs\"",
+            "sphinx>=8.0.2; extra == \"docs\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "4.3.6"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "bc7d19272560f73fe4c2c989c31b00774a35d3a76891fab0b72c17616862d0e0",
+              "url": "https://files.pythonhosted.org/packages/b3/f4/23d4a698db9fe772f7fdf40ac17b743c4b0d80274732c59db5bd45acb3be/plotly-5.5.0-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "20b8a1a0f0434f9b8d10eb7caa66e947a9a1d698e5a53d40d447bbc0d2ae41f0",
+              "url": "https://files.pythonhosted.org/packages/fe/0b/592c54edd09d4844ce8c922cfafe8b4181fc42483c2126b58522417f4506/plotly-5.5.0.tar.gz"
+            }
+          ],
+          "project_name": "plotly",
+          "requires_dists": [
+            "six",
+            "tenacity>=6.2.0"
+          ],
+          "requires_python": ">=3.6",
+          "version": "5.5.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669",
+              "url": "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
+              "url": "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz"
+            }
+          ],
+          "project_name": "pluggy",
+          "requires_dists": [
+            "pre-commit; extra == \"dev\"",
+            "pytest-benchmark; extra == \"testing\"",
+            "pytest; extra == \"testing\"",
+            "tox; extra == \"dev\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "1.5.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "53a5984ebc86a025552264b459b46a2086e269b21823cb572f8f28ee759e45bf",
+              "url": "https://files.pythonhosted.org/packages/9b/fb/a70a4214956182e0d7a9099ab17d50bfcba1056188e9b14f35b9e2b62a0d/portalocker-2.10.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ef1bf844e878ab08aee7e40184156e1151f228f103aa5c6bd0724cc330960f8f",
+              "url": "https://files.pythonhosted.org/packages/ed/d3/c6c64067759e87af98cc668c1cc75171347d0f1577fab7ca3749134e3cd4/portalocker-2.10.1.tar.gz"
+            }
+          ],
+          "project_name": "portalocker",
+          "requires_dists": [
+            "pytest-cov>=2.8.1; extra == \"tests\"",
+            "pytest-mypy>=0.8.0; extra == \"tests\"",
+            "pytest-timeout>=2.1.0; extra == \"tests\"",
+            "pytest>=5.4.1; extra == \"tests\"",
+            "pywin32>=226; platform_system == \"Windows\"",
+            "redis; extra == \"redis\"",
+            "redis; extra == \"tests\"",
+            "sphinx>=1.7.1; extra == \"docs\"",
+            "sphinx>=6.0.0; extra == \"tests\"",
+            "types-redis; extra == \"tests\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "2.10.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "594b45c410d6f4f8888940fe80b5cc2521b305a1fafe1c58609ef715a001f301",
+              "url": "https://files.pythonhosted.org/packages/ff/c2/ab7d37426c179ceb9aeb109a85cda8948bb269b7561a0be870cc656eefe4/prometheus_client-0.21.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "252505a722ac04b0456be05c05f75f45d760c2911ffc45f2a06bcaed9f3ae3fb",
+              "url": "https://files.pythonhosted.org/packages/62/14/7d0f567991f3a9af8d1cd4f619040c93b68f09a02b6d0b6ab1b2d1ded5fe/prometheus_client-0.21.1.tar.gz"
+            }
+          ],
+          "project_name": "prometheus-client",
+          "requires_dists": [
+            "twisted; extra == \"twisted\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "0.21.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "f49a827f90062e411f1ce1f854f2aedb3c23353244f8108b89283587397ac10e",
+              "url": "https://files.pythonhosted.org/packages/a9/6a/fd08d94654f7e67c52ca30523a178b3f8ccc4237fce4be90d39c938a831a/prompt_toolkit-3.0.48-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d6623ab0477a80df74e646bdbc93621143f5caf104206aa29294d53de1a03d90",
+              "url": "https://files.pythonhosted.org/packages/2d/4f/feb5e137aff82f7c7f3248267b97451da3644f6cdc218edfe549fb354127/prompt_toolkit-3.0.48.tar.gz"
+            }
+          ],
+          "project_name": "prompt-toolkit",
+          "requires_dists": [
+            "wcwidth"
+          ],
+          "requires_python": ">=3.7.0",
+          "version": "3.0.48"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "fde4554c0e578a5a0bcc9a276339594848d1e89f9ea47b4427c80e5d72f90181",
+              "url": "https://files.pythonhosted.org/packages/f3/fd/c7924b4c2a1c61b8f4b64edd7a31ffacf63432135a2606f03a2f0d75a750/protobuf-5.29.2-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b6b0d416bbbb9d4fbf9d0561dbfc4e324fd522f61f7af0fe0f282ab67b22477e",
+              "url": "https://files.pythonhosted.org/packages/90/4d/c3d61e698e0e41d926dbff6aa4e57428ab1a6fc3b5e1deaa6c9ec0fd45cf/protobuf-5.29.2-cp38-abi3-manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b2cc8e8bb7c9326996f0e160137b0861f1a82162502658df2951209d0cb0309e",
+              "url": "https://files.pythonhosted.org/packages/a5/73/4e6295c1420a9d20c9c351db3a36109b4c9aa601916cb7c6871e3196a1ca/protobuf-5.29.2.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "a0c53d78383c851bfa97eb42e3703aefdc96d2036a41482ffd55dc5f529466eb",
+              "url": "https://files.pythonhosted.org/packages/cb/26/41debe0f6615fcb7e97672057524687ed86fcd85e3da3f031c30af8f0c51/protobuf-5.29.2-cp38-abi3-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "494229ecd8c9009dd71eda5fd57528395d1eacdf307dbece6c12ad0dd09e912e",
+              "url": "https://files.pythonhosted.org/packages/e4/20/38fc33b60dcfb380507b99494aebe8c34b68b8ac7d32808c4cebda3f6f6b/protobuf-5.29.2-cp38-abi3-manylinux2014_aarch64.whl"
+            }
+          ],
+          "project_name": "protobuf",
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "5.29.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "d905186d647b16755a800e7263d43df08b790d709d575105d419f8b6ef65423a",
+              "url": "https://files.pythonhosted.org/packages/27/c2/d034856ac47e3b3cdfa9720d0e113902e615f4190d5d1bdb8df4b2015fb2/psutil-6.1.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6e2dcd475ce8b80522e51d923d10c7871e45f20918e027ab682f94f1c6351688",
+              "url": "https://files.pythonhosted.org/packages/01/9e/8be43078a171381953cfee33c07c0d628594b5dbfc5157847b85022c2c1b/psutil-6.1.0-cp36-abi3-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0895b8414afafc526712c498bd9de2b063deaac4021a3b3c34566283464aff8e",
+              "url": "https://files.pythonhosted.org/packages/1d/cb/313e80644ea407f04f6602a9e23096540d9dc1878755f3952ea8d3d104be/psutil-6.1.0-cp36-abi3-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "353815f59a7f64cdaca1c0307ee13558a0512f6db064e92fe833784f08539c7a",
+              "url": "https://files.pythonhosted.org/packages/26/10/2a30b13c61e7cf937f4adf90710776b7918ed0a9c434e2c38224732af310/psutil-6.1.0.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "498c6979f9c6637ebc3a73b3f87f9eb1ec24e1ce53a7c5173b8508981614a90b",
+              "url": "https://files.pythonhosted.org/packages/58/4d/8245e6f76a93c98aab285a43ea71ff1b171bcd90c9d238bf81f7021fb233/psutil-6.1.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9dcbfce5d89f1d1f2546a2090f4fcf87c7f669d1d90aacb7d7582addece9fb38",
+              "url": "https://files.pythonhosted.org/packages/65/8e/bcbe2025c587b5d703369b6a75b65d41d1367553da6e3f788aff91eaf5bd/psutil-6.1.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            }
+          ],
+          "project_name": "psutil",
+          "requires_dists": [
+            "black; extra == \"dev\"",
+            "check-manifest; extra == \"dev\"",
+            "coverage; extra == \"dev\"",
+            "packaging; extra == \"dev\"",
+            "pylint; extra == \"dev\"",
+            "pyperf; extra == \"dev\"",
+            "pypinfo; extra == \"dev\"",
+            "pytest-cov; extra == \"dev\"",
+            "pytest-xdist; extra == \"test\"",
+            "pytest; extra == \"test\"",
+            "requests; extra == \"dev\"",
+            "rstcheck; extra == \"dev\"",
+            "ruff; extra == \"dev\"",
+            "setuptools; extra == \"test\"",
+            "sphinx-rtd-theme; extra == \"dev\"",
+            "sphinx; extra == \"dev\"",
+            "toml-sort; extra == \"dev\"",
+            "twine; extra == \"dev\"",
+            "virtualenv; extra == \"dev\"",
+            "wheel; extra == \"dev\""
+          ],
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
+          "version": "6.1.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35",
+              "url": "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220",
+              "url": "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz"
+            }
+          ],
+          "project_name": "ptyprocess",
+          "requires_dists": [],
+          "requires_python": null,
+          "version": "0.7.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0",
+              "url": "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42",
+              "url": "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz"
+            }
+          ],
+          "project_name": "pure-eval",
+          "requires_dists": [
+            "pytest; extra == \"tests\""
+          ],
+          "requires_python": null,
+          "version": "0.2.3"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "85defdfd2b2376eb3abf5ca6474b51ab7e0de341c75a02f46dc9b5976f5a5c1b",
+              "url": "https://files.pythonhosted.org/packages/10/30/a58b32568f1623aaad7db22aa9eafc4c6c194b429ff35bdc55ca2726da47/py4j-0.10.9.7-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0b6e5315bb3ada5cf62ac651d107bb2ebc02def3dee9d9548e3baac644ea8dbb",
+              "url": "https://files.pythonhosted.org/packages/1e/f2/b34255180c72c36ff7097f7c2cdca02abcbd89f5eebf7c7c41262a9a0637/py4j-0.10.9.7.tar.gz"
+            }
+          ],
+          "project_name": "py4j",
+          "requires_dists": [],
+          "requires_python": null,
+          "version": "0.10.9.7"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "3c35813c11a059056a22a3bef520461310f2f7eea5c8a11ef9de7062a23f8d56",
+              "url": "https://files.pythonhosted.org/packages/6d/84/8037c20005ccc7b869726465be0957bd9c29cfc88612962030f08292ad06/pyarrow-18.1.0-cp310-cp310-manylinux_2_28_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e21488d5cfd3d8b500b3238a6c4b075efabc18f0f6d80b29239737ebd69caa6c",
+              "url": "https://files.pythonhosted.org/packages/1a/bb/8d4a1573f66e0684f190dd2b55fd0b97a7214de8882d58a3867e777bf640/pyarrow-18.1.0-cp310-cp310-macosx_12_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b516dad76f258a702f7ca0250885fc93d1fa5ac13ad51258e39d402bd9e2e1e4",
+              "url": "https://files.pythonhosted.org/packages/30/90/893acfad917533b624a97b9e498c0e8393908508a0a72d624fe935e632bf/pyarrow-18.1.0-cp310-cp310-macosx_12_0_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9386d3ca9c145b5539a1cfc75df07757dff870168c959b473a0bccbc3abc8c73",
+              "url": "https://files.pythonhosted.org/packages/7f/7b/640785a9062bb00314caa8a387abce547d2a420cf09bd6c715fe659ccffb/pyarrow-18.1.0.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c0a03da7f2758645d17b7b4f83c8bffeae5bbb7f974523fe901f36288d2eab71",
+              "url": "https://files.pythonhosted.org/packages/8a/77/4b3fab91a30e19e233e738d0c5eca5a8f6dd05758bc349a2ca262c65de79/pyarrow-18.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4f443122c8e31f4c9199cb23dca29ab9427cef990f283f80fe15b8e124bcc49b",
+              "url": "https://files.pythonhosted.org/packages/a3/2a/526545a7464b5fb2fa6e2c4bad16ca90e59e1843025c534fd907b7f73e5a/pyarrow-18.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ba17845efe3aa358ec266cf9cc2800fa73038211fb27968bfa88acd09261a470",
+              "url": "https://files.pythonhosted.org/packages/aa/e2/a88e16c5e45e562449c52305bd3bc2f9d704295322d3434656e7ccac1444/pyarrow-18.1.0-cp310-cp310-manylinux_2_28_aarch64.whl"
+            }
+          ],
+          "project_name": "pyarrow",
+          "requires_dists": [
+            "cffi; extra == \"test\"",
+            "hypothesis; extra == \"test\"",
+            "pandas; extra == \"test\"",
+            "pytest; extra == \"test\"",
+            "pytz; extra == \"test\""
+          ],
+          "requires_python": ">=3.9",
+          "version": "18.1.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc",
+              "url": "https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6",
+              "url": "https://files.pythonhosted.org/packages/1d/b2/31537cf4b1ca988837256c910a668b553fceb8f069bedc4b1c826024b52c/pycparser-2.22.tar.gz"
+            }
+          ],
+          "project_name": "pycparser",
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "2.22"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "597e135ea68be3a37552fb524bc7d0d66dcf93d395acd93a00682f1efcb8ee3d",
+              "url": "https://files.pythonhosted.org/packages/f3/26/3e1bbe954fde7ee22a6e7d31582c642aad9e84ffe4b5fb61e63b87cd326f/pydantic-2.10.4-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "82f12e9723da6de4fe2ba888b5971157b3be7ad914267dea8f05f82b28254f06",
+              "url": "https://files.pythonhosted.org/packages/70/7e/fb60e6fee04d0ef8f15e4e01ff187a196fa976eb0f0ab524af4599e5754c/pydantic-2.10.4.tar.gz"
+            }
+          ],
+          "project_name": "pydantic",
+          "requires_dists": [
+            "annotated-types>=0.6.0",
+            "email-validator>=2.0.0; extra == \"email\"",
+            "pydantic-core==2.27.2",
+            "typing-extensions>=4.12.2",
+            "tzdata; (python_version >= \"3.9\" and platform_system == \"Windows\") and extra == \"timezone\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "2.10.4"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "0d75070718e369e452075a6017fbf187f788e17ed67a3abd47fa934d001863d9",
+              "url": "https://files.pythonhosted.org/packages/81/b0/5e74656e95623cbaa0a6278d16cf15e10a51f6002e3ec126541e95c29ea3/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "47956ae78b6422cbd46f772f1746799cbb862de838fd8d1fbd34a82e05b0983a",
+              "url": "https://files.pythonhosted.org/packages/32/90/3b15e31b88ca39e9e626630b4c4a1f5a0dfd09076366f4219429e6786076/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2d367ca20b2f14095a8f4fa1210f5a7b78b8a20009ecced6b12818f455b1e9fa",
+              "url": "https://files.pythonhosted.org/packages/3a/bc/fed5f74b5d802cf9a03e83f60f18864e90e3aed7223adaca5ffb7a8d8d64/pydantic_core-2.27.2-cp310-cp310-macosx_10_12_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2bf14caea37e91198329b828eae1618c068dfb8ef17bb33287a7ad4b61ac314e",
+              "url": "https://files.pythonhosted.org/packages/46/72/af70981a341500419e67d5cb45abe552a7c74b66326ac8877588488da1ac/pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7041c36f5680c6e0f08d922aed302e98b3745d97fe1589db0a3eebf6624523af",
+              "url": "https://files.pythonhosted.org/packages/4e/99/fe80f3ff8dd71a3ea15763878d464476e6cb0a2db95ff1c5c554133b6b83/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "82f986faf4e644ffc189a7f1aafc86e46ef70372bb153e7001e8afccc6e54133",
+              "url": "https://files.pythonhosted.org/packages/4f/5f/4784c6107731f89e0005a92ecb8a2efeafdb55eb992b8e9d0a2be5199335/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bec317a27290e2537f922639cafd54990551725fc844249e64c523301d0822fc",
+              "url": "https://files.pythonhosted.org/packages/6d/a7/61246562b651dff00de86a5f01b6e4befb518df314c54dec187a78d81c84/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "491a2b73db93fab69731eaee494f320faa4e093dbed776be1a829c2eb222c34c",
+              "url": "https://files.pythonhosted.org/packages/71/2a/185aff24ce844e39abb8dd680f4e959f0006944f4a8a0ea372d9f9ae2e53/pydantic_core-2.27.2-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "280d219beebb0752699480fe8f1dc61ab6615c2046d76b7ab7ee38858de0a4e7",
+              "url": "https://files.pythonhosted.org/packages/7a/67/61291ee98e07f0650eb756d44998214231f50751ba7e13f4f325d95249ab/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "337b443af21d488716f8d0b6164de833e788aa6bd7e3a39c005febc1284f4962",
+              "url": "https://files.pythonhosted.org/packages/7c/f7/89be1c8deb6e22618a74f0ca0d933fdcb8baa254753b26b25ad3acff8f74/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e2bb4d3e5873c37bb3dd58714d4cd0b0e6238cebc4177ac8fe878f8b3aa8e74c",
+              "url": "https://files.pythonhosted.org/packages/7d/39/e06fcbcc1c785daa3160ccf6c1c38fea31f5754b756e34b65f74e99780b5/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0296abcb83a797db256b773f45773da397da75a08f5fcaef41f2044adec05f50",
+              "url": "https://files.pythonhosted.org/packages/86/aa/837821ecf0c022bbb74ca132e117c358321e72e7f9702d1b6a03758545e2/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3de9961f2a346257caf0aa508a4da705467f53778e9ef6fe744c038119737ef5",
+              "url": "https://files.pythonhosted.org/packages/a2/d1/f2dfe1a2a637ce6800b799aa086d079998959f6f1215eb4497966efd2274/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b0cb791f5b45307caae8810c2023a184c74605ec3bcbb67d13846c28ff731ff8",
+              "url": "https://files.pythonhosted.org/packages/ad/3d/c5913cccdef93e0a6a95c2d057d2c2cba347815c845cda79ddd3c0f5e17d/pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "03d0f86ea3184a12f41a2d23f7ccb79cdb5a18e06993f8a45baa8dfec746f0e9",
+              "url": "https://files.pythonhosted.org/packages/b7/7d/8eb3e23206c00ef7feee17b83a4ffa0a623eb1a9d382e56e4aa46fd15ff2/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_armv7l.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7969e133a6f183be60e9f6f56bfae753585680f3b7307a8e555a948d443cc05a",
+              "url": "https://files.pythonhosted.org/packages/c3/43/fafabd3d94d159d4f1ed62e383e264f146a17dd4d48453319fd782e7979e/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3d591580c34f4d731592f0e9fe40f9cc1b430d297eecc70b962e93c5c668f15f",
+              "url": "https://files.pythonhosted.org/packages/d7/7a/7bbf241a04e9f9ea24cd5874354a83526d639b02674648af3f350554276c/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "688d3fd9fcb71f41c4c015c023d12a79d1c4c0732ec9eb35d96e3388a120dcf3",
+              "url": "https://files.pythonhosted.org/packages/f6/f0/a3ae8fbee269e4934f14e2e0e00928f9346c5943174f2811193113e58252/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "eb026e5a4c1fee05726072337ff51d1efb6f59090b7da90d30ea58625b1ffb39",
+              "url": "https://files.pythonhosted.org/packages/fc/01/f3e5ac5e7c25833db5eb555f7b7ab24cd6f8c322d3a3ad2d67a952dc0abc/pydantic_core-2.27.2.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "14d4a5c49d2f009d62a2a7140d3064f686d17a5d1a268bc641954ba181880236",
+              "url": "https://files.pythonhosted.org/packages/ff/83/c06d333ee3a67e2e13e07794995c1535565132940715931c1c43bfc85b11/pydantic_core-2.27.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl"
+            }
+          ],
+          "project_name": "pydantic-core",
+          "requires_dists": [
+            "typing-extensions!=4.7.0,>=4.6.0"
+          ],
+          "requires_python": ">=3.8",
+          "version": "2.27.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "66c98190c65b8d2e2382a441b4c0edfdb4f4c025ef9cb9874de478fb0793a451",
+              "url": "https://files.pythonhosted.org/packages/ea/76/75b1bb82e9bad3e3d656556eaa353d8cd17c4254393b08ec9786ac8ed273/pydot-1.4.2-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "248081a39bcb56784deb018977e428605c1c758f10897a339fce1dd728ff007d",
+              "url": "https://files.pythonhosted.org/packages/13/6e/916cdf94f9b38ae0777b254c75c3bdddee49a54cc4014aac1460a7a172b3/pydot-1.4.2.tar.gz"
+            }
+          ],
+          "project_name": "pydot",
+          "requires_dists": [
+            "pyparsing>=2.1.4"
+          ],
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7",
+          "version": "1.4.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a",
+              "url": "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199",
+              "url": "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz"
+            }
+          ],
+          "project_name": "pygments",
+          "requires_dists": [
+            "colorama>=0.4.6; extra == \"windows-terminal\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "2.18.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "93d9577b88da0bbea8cc8334ee8b918ed014968fd2ec383e868fb8afb1ccef84",
+              "url": "https://files.pythonhosted.org/packages/be/ec/2eb3cd785efd67806c46c13a17339708ddc346cbb684eade7a6e6f79536a/pyparsing-3.2.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "cbf74e27246d595d9a74b186b810f6fbb86726dbf3b9532efb343f6d7294fe9c",
+              "url": "https://files.pythonhosted.org/packages/8c/d5/e5aeee5387091148a19e1145f63606619cb5f20b83fccb63efae6474e7b2/pyparsing-3.2.0.tar.gz"
+            }
+          ],
+          "project_name": "pyparsing",
+          "requires_dists": [
+            "jinja2; extra == \"diagrams\"",
+            "railroad-diagrams; extra == \"diagrams\""
+          ],
+          "requires_python": ">=3.9",
+          "version": "3.2.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "72cd66ab8cf61a75854e5a753f75bea35ee075c3a96f9de4e2a66d02ec7fc652",
+              "url": "https://files.pythonhosted.org/packages/0c/66/3cf748ba7cd7c6a4a46ffcc8d062f11ddc24b786c5b82936c857dc13b7bd/pyspark-3.4.1.tar.gz"
+            }
+          ],
+          "project_name": "pyspark",
+          "requires_dists": [
+            "googleapis-common-protos>=1.56.4; extra == \"connect\"",
+            "grpcio-status>=1.48.1; extra == \"connect\"",
+            "grpcio>=1.48.1; extra == \"connect\"",
+            "numpy>=1.15; extra == \"connect\"",
+            "numpy>=1.15; extra == \"ml\"",
+            "numpy>=1.15; extra == \"mllib\"",
+            "numpy>=1.15; extra == \"pandas-on-spark\"",
+            "numpy>=1.15; extra == \"sql\"",
+            "pandas>=1.0.5; extra == \"connect\"",
+            "pandas>=1.0.5; extra == \"pandas-on-spark\"",
+            "pandas>=1.0.5; extra == \"sql\"",
+            "py4j==0.10.9.7",
+            "pyarrow>=1.0.0; extra == \"connect\"",
+            "pyarrow>=1.0.0; extra == \"pandas-on-spark\"",
+            "pyarrow>=1.0.0; extra == \"sql\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "3.4.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6",
+              "url": "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761",
+              "url": "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz"
+            }
+          ],
+          "project_name": "pytest",
+          "requires_dists": [
+            "argcomplete; extra == \"dev\"",
+            "attrs>=19.2; extra == \"dev\"",
+            "colorama; sys_platform == \"win32\"",
+            "exceptiongroup>=1.0.0rc8; python_version < \"3.11\"",
+            "hypothesis>=3.56; extra == \"dev\"",
+            "iniconfig",
+            "mock; extra == \"dev\"",
+            "packaging",
+            "pluggy<2,>=1.5",
+            "pygments>=2.7.2; extra == \"dev\"",
+            "requests; extra == \"dev\"",
+            "setuptools; extra == \"dev\"",
+            "tomli>=1; python_version < \"3.11\"",
+            "xmlschema; extra == \"dev\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "8.3.4"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "db5432d18eac6b7e28b46dcd9b69921b55c3b1086e85febfe04e70b18d9e81b3",
+              "url": "https://files.pythonhosted.org/packages/88/56/2ee0cab25c11d4e38738a2a98c645a8f002e2ecf7b5ed774c70d53b92bb1/pytest_asyncio-0.25.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8c0610303c9e0442a5db8604505fc0f545456ba1528824842b37b4a626cbf609",
+              "url": "https://files.pythonhosted.org/packages/94/18/82fcb4ee47d66d99f6cd1efc0b11b2a25029f303c599a5afda7c1bca4254/pytest_asyncio-0.25.0.tar.gz"
+            }
+          ],
+          "project_name": "pytest-asyncio",
+          "requires_dists": [
+            "coverage>=6.2; extra == \"testing\"",
+            "hypothesis>=5.7.1; extra == \"testing\"",
+            "pytest<9,>=8.2",
+            "sphinx-rtd-theme>=1; extra == \"docs\"",
+            "sphinx>=5.3; extra == \"docs\""
+          ],
+          "requires_python": ">=3.9",
+          "version": "0.25.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "cabfbcfca6a4876c5e03b151ba9217f3888fe5142154c1e885dd7902afa85a89",
+              "url": "https://files.pythonhosted.org/packages/fa/58/0a5820b4912e63f50b043170eeda56efab52104877818e2ac08c2eecc26d/pytest_spark-0.6.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "06e3fbfa2e7fa69d2976c10037c9ee3549c80580228bde5b9aa602f44b711f17",
+              "url": "https://files.pythonhosted.org/packages/ea/06/0a05e3bb6dbf86a45590d1192236fae6717bfc80d8cfdf1d86ac56af7928/pytest-spark-0.6.0.tar.gz"
+            }
+          ],
+          "project_name": "pytest-spark",
+          "requires_dists": [
+            "findspark",
+            "pytest"
+          ],
+          "requires_python": null,
+          "version": "0.6.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427",
+              "url": "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+              "url": "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz"
+            }
+          ],
+          "project_name": "python-dateutil",
+          "requires_dists": [
+            "six>=1.5"
+          ],
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7",
+          "version": "2.9.0.post0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a",
+              "url": "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca",
+              "url": "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz"
+            }
+          ],
+          "project_name": "python-dotenv",
+          "requires_dists": [
+            "click>=5.0; extra == \"cli\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "1.0.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8",
+              "url": "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856",
+              "url": "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz"
+            }
+          ],
+          "project_name": "python-slugify",
+          "requires_dists": [
+            "Unidecode>=1.1.1; extra == \"unidecode\"",
+            "text-unidecode>=1.3"
+          ],
+          "requires_python": ">=3.7",
+          "version": "8.0.4"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725",
+              "url": "https://files.pythonhosted.org/packages/11/c3/005fcca25ce078d2cc29fd559379817424e94885510568bc1bc53d7d5846/pytz-2024.2-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a",
+              "url": "https://files.pythonhosted.org/packages/3a/31/3c70bf7603cc2dca0f19bdc53b4537a797747a58875b552c8c413d963a3f/pytz-2024.2.tar.gz"
+            }
+          ],
+          "project_name": "pytz",
+          "requires_dists": [],
+          "requires_python": null,
+          "version": "2024.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "23502f431948090f597378482b4812b0caae32c22213aecf3b55325e049a6c68",
+              "url": "https://files.pythonhosted.org/packages/5c/20/8347dcabd41ef3a3cdc4f7b7a2aff3d06598c8779faa189cdbf878b626a4/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8824b5a04a04a047e72eea5cec3bc266db09e35de6bdfe34c9436ac5ee27d237",
+              "url": "https://files.pythonhosted.org/packages/49/ee/14c54df452143b9ee9f0f29074d7ca5516a36edb0b4cc40c3f280131656f/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7c36280e6fb8385e520936c3cb3b8042851904eba0e58d277dca80a5cfed590b",
+              "url": "https://files.pythonhosted.org/packages/4d/61/de363a97476e766574650d742205be468921a7b532aa2499fcd886b62530/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d584d9ec91ad65861cc08d42e834324ef890a082e591037abe114850ff7bbc3e",
+              "url": "https://files.pythonhosted.org/packages/54/ed/79a089b6be93607fa5cdaedf301d7dfb23af5f25c398d5ead2525b063e17/pyyaml-6.0.2.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ec031d5d2feb36d1d1a24380e4db6d43695f3748343d99434e6f5f9156aaa2ed",
+              "url": "https://files.pythonhosted.org/packages/6b/4e/1523cb902fd98355e2e9ea5e5eb237cbc5f3ad5f3075fa65087aa0ecb669/PyYAML-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0a9a2848a5b7feac301353437eb7d5957887edbf81d56e903999a75a3d743086",
+              "url": "https://files.pythonhosted.org/packages/9b/95/a3fac87cb7158e231b5a6012e438c647e1a87f09f8e0d123acec8ab8bf71/PyYAML-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "936d68689298c36b53b29f23c6dbb74de12b4ac12ca6cfe0e047bedceea56180",
+              "url": "https://files.pythonhosted.org/packages/b7/33/5504b3a9a4464893c32f118a9cc045190a91637b119a9c881da1cf6b7a72/PyYAML-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "29717114e51c84ddfba879543fb232a6ed60086602313ca38cce623c1d62cfbf",
+              "url": "https://files.pythonhosted.org/packages/c7/7a/68bd47624dab8fd4afbfd3c48e3b79efe09098ae941de5b58abcbadff5cb/PyYAML-6.0.2-cp310-cp310-macosx_11_0_arm64.whl"
+            }
+          ],
+          "project_name": "pyyaml",
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "6.0.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "2c4a71d5d6e7b28a47a394c0471b7e77a0661e2d651e7ae91e0cab0a587859ca",
+              "url": "https://files.pythonhosted.org/packages/71/43/91fa4ff25bbfdc914ab6bafa0f03241d69370ef31a761d16bb859f346582/pyzmq-26.2.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "a2224fa4a4c2ee872886ed00a571f5e967c85e078e8e8c2530a2fb01b3309b88",
+              "url": "https://files.pythonhosted.org/packages/16/29/ca99b4598a9dc7e468b5417eda91f372b595be1e3eec9b7cbe8e5d3584e8/pyzmq-26.2.0-cp310-cp310-manylinux_2_28_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ddf33d97d2f52d89f6e6e7ae66ee35a4d9ca6f36eda89c24591b0c40205a3629",
+              "url": "https://files.pythonhosted.org/packages/1f/a8/9837c39aba390eb7d01924ace49d761c8dbe7bc2d6082346d00c8332e431/pyzmq-26.2.0-cp310-cp310-macosx_10_15_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "706e794564bec25819d21a41c31d4df2d48e1cc4b061e8d345d7fb4dd3e94072",
+              "url": "https://files.pythonhosted.org/packages/53/fb/36b2b2548286e9444e52fcd198760af99fd89102b5be50f0660fcfe902df/pyzmq-26.2.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8ea039387c10202ce304af74def5021e9adc6297067f3441d348d2b633e8166a",
+              "url": "https://files.pythonhosted.org/packages/5e/3b/2eb1667c9b866f53e76ee8b0c301b0469745a23bd5a87b7ee3d5dd9eb6e5/pyzmq-26.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8b435f2753621cd36e7c1762156815e21c985c72b19135dac43a7f4f31d28dd1",
+              "url": "https://files.pythonhosted.org/packages/77/8f/6ce54f8979a01656e894946db6299e2273fcee21c8e5fa57c6295ef11f57/pyzmq-26.2.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b8f86dd868d41bea9a5f873ee13bf5551c94cf6bc51baebc6f85075971fe6eea",
+              "url": "https://files.pythonhosted.org/packages/87/84/e8bd321aa99b72f48d4606fc5a0a920154125bd0a4608c67eab742dab087/pyzmq-26.2.0-cp310-cp310-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "dacd995031a01d16eec825bf30802fceb2c3791ef24bcce48fa98ce40918c27b",
+              "url": "https://files.pythonhosted.org/packages/a2/1f/a006f2e8e4f7d41d464272012695da17fb95f33b54342612a6890da96ff6/pyzmq-26.2.0-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "28ad5233e9c3b52d76196c696e362508959741e1a005fb8fa03b51aea156088f",
+              "url": "https://files.pythonhosted.org/packages/ad/e5/9efaeb1d2f4f8c50da04144f639b042bc52869d3a206d6bf672ab3522163/pyzmq-26.2.0-cp310-cp310-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "89289a5ee32ef6c439086184529ae060c741334b8970a6855ec0b6ad3ff28764",
+              "url": "https://files.pythonhosted.org/packages/b6/09/b51b6683fde5ca04593a57bbe81788b6b43114d8f8ee4e80afc991e14760/pyzmq-26.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1c17211bc037c7d88e85ed8b7d8f7e52db6dc8eca5590d162717c654550f7282",
+              "url": "https://files.pythonhosted.org/packages/c3/62/c721b5608a8ac0a69bb83cbb7d07a56f3ff00b3991a138e44198a16f94c7/pyzmq-26.2.0-cp310-cp310-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5506f06d7dc6ecf1efacb4a013b1f05071bb24b76350832c96449f4a2d95091c",
+              "url": "https://files.pythonhosted.org/packages/c9/78/486f3e2e824f3a645238332bf5a4c4b4477c3063033a27c1e4052358dee2/pyzmq-26.2.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "160c7e0a5eb178011e72892f99f918c04a131f36056d10d9c1afb223fc952c2d",
+              "url": "https://files.pythonhosted.org/packages/ee/1c/bf8cd66730a866b16db8483286078892b7f6536f8c389fb46e4beba0a970/pyzmq-26.2.0-pp310-pypy310_pp73-manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "070672c258581c8e4f640b5159297580a9974b026043bd4ab0470be9ed324f1f",
+              "url": "https://files.pythonhosted.org/packages/fd/05/bed626b9f7bb2322cdbbf7b4bd8f54b1b617b0d2ab2d3547d6e39428a48e/pyzmq-26.2.0.tar.gz"
+            }
+          ],
+          "project_name": "pyzmq",
+          "requires_dists": [
+            "cffi; implementation_name == \"pypy\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "26.2.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "b2d17ce18e9e767471368380dd3bbc4a0e3a0e2061fedc9af3542084b48451e0",
+              "url": "https://files.pythonhosted.org/packages/68/c0/eef4fe9dad6d41333f7dc6567fa8144ffc1837c8a0edfc2317d50715335f/qdrant_client-1.12.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "35e8e646f75b7b883b3d2d0ee4c69c5301000bba41c82aa546e985db0f1aeb72",
+              "url": "https://files.pythonhosted.org/packages/15/5e/ec560881e086f893947c8798949c72de5cfae9453fd05c2250f8dfeaa571/qdrant_client-1.12.1.tar.gz"
+            }
+          ],
+          "project_name": "qdrant-client",
+          "requires_dists": [
+            "fastembed-gpu==0.3.6; python_version < \"3.13\" and extra == \"fastembed-gpu\"",
+            "fastembed==0.3.6; python_version < \"3.13\" and extra == \"fastembed\"",
+            "grpcio-tools>=1.41.0",
+            "grpcio>=1.41.0",
+            "httpx[http2]>=0.20.0",
+            "numpy<1.21; python_version < \"3.8\"",
+            "numpy>=1.21; python_version >= \"3.8\" and python_version < \"3.12\"",
+            "numpy>=1.26; python_version >= \"3.12\"",
+            "portalocker<3.0.0,>=2.7.0",
+            "pydantic>=1.10.8",
+            "urllib3<3,>=1.26.14"
+          ],
+          "requires_python": ">=3.8",
+          "version": "1.12.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "eda6d3234d62814d1c64e305c1331c9a3a6132da475ab6382eaa997b21ee75de",
+              "url": "https://files.pythonhosted.org/packages/b7/59/2056f61236782a2c86b33906c025d4f4a0b17be0161b63b70fd9e8775d36/referencing-0.35.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "25b42124a6c8b632a425174f24087783efb348a6f1e0008e63cd4466fedf703c",
+              "url": "https://files.pythonhosted.org/packages/99/5b/73ca1f8e72fff6fa52119dbd185f73a907b1989428917b24cff660129b6d/referencing-0.35.1.tar.gz"
+            }
+          ],
+          "project_name": "referencing",
+          "requires_dists": [
+            "attrs>=22.2.0",
+            "rpds-py>=0.7.0"
+          ],
+          "requires_python": ">=3.8",
+          "version": "0.35.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6",
+              "url": "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760",
+              "url": "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz"
+            }
+          ],
+          "project_name": "requests",
+          "requires_dists": [
+            "PySocks!=1.5.7,>=1.5.6; extra == \"socks\"",
+            "certifi>=2017.4.17",
+            "chardet<6,>=3.0.2; extra == \"use-chardet-on-py3\"",
+            "charset-normalizer<4,>=2",
+            "idna<4,>=2.5",
+            "urllib3<3,>=1.21.1"
+          ],
+          "requires_python": ">=3.8",
+          "version": "2.32.3"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90",
+              "url": "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098",
+              "url": "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz"
+            }
+          ],
+          "project_name": "rich",
+          "requires_dists": [
+            "ipywidgets<9,>=7.5.1; extra == \"jupyter\"",
+            "markdown-it-py>=2.2.0",
+            "pygments<3.0.0,>=2.13.0",
+            "typing-extensions<5.0,>=4.0.0; python_version < \"3.11\""
+          ],
+          "requires_python": ">=3.8.0",
+          "version": "13.9.4"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "26fd7cac7dd51011a245f29a2cc6489c4608b5a8ce8d75661bb4a1066c52dfbe",
+              "url": "https://files.pythonhosted.org/packages/8d/63/79c3602afd14d501f751e615a74a59040328da5ef29ed5754ae80d236b84/rpds_py-0.22.3-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e32fee8ab45d3c2db6da19a5323bc3362237c8b653c70194414b892fd06a080d",
+              "url": "https://files.pythonhosted.org/packages/01/80/cce854d0921ff2f0a9fa831ba3ad3c65cee3a46711addf39a2af52df2cfd/rpds_py-0.22.3.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "cff63a0272fcd259dcc3be1657b07c929c466b067ceb1c20060e8d10af56f5bf",
+              "url": "https://files.pythonhosted.org/packages/04/f2/5dced98b64874b84ca824292f9cee2e3f30f3bcf231d15a903126684f74d/rpds_py-0.22.3-cp310-cp310-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e35ba67d65d49080e8e5a1dd40101fccdd9798adb9b050ff670b7d74fa41c566",
+              "url": "https://files.pythonhosted.org/packages/11/23/cd8f566de444a137bc1ee5795e47069a947e60810ba4152886fe5308e1b7/rpds_py-0.22.3-pp310-pypy310_pp73-musllinux_1_2_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "eb0c341fa71df5a4595f9501df4ac5abfb5a09580081dffbd1ddd4654e6e9123",
+              "url": "https://files.pythonhosted.org/packages/13/b0/575c797377fdcd26cedbb00a3324232e4cb2c5d121f6e4b0dbf8468b12ef/rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e61b02c3f7a1e0b75e20c3978f7135fd13cb6cf551bf4a6d29b999a88830a338",
+              "url": "https://files.pythonhosted.org/packages/14/2a/6bed0b05233c291a94c7e89bc76ffa1c619d4e1979fbfe5d96024020c1fb/rpds_py-0.22.3-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e0fa2d4ec53dc51cf7d3bb22e0aa0143966119f42a0c3e4998293a3dd2856b09",
+              "url": "https://files.pythonhosted.org/packages/33/3b/45b6c58fb6aad5a569ae40fb890fc494c6b02203505a5008ee6dc68e65f7/rpds_py-0.22.3-cp310-cp310-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ac0a03221cdb5058ce0167ecc92a8c89e8d0decdc9e99a2ec23380793c4dcb96",
+              "url": "https://files.pythonhosted.org/packages/3a/7d/f4bc6d6fbe6af7a0d2b5f2ee77079efef7c8528712745659ec0026888998/rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6c7b99ca52c2c1752b544e310101b98a659b720b21db00e65edca34483259967",
+              "url": "https://files.pythonhosted.org/packages/42/2a/ead1d09e57449b99dcc190d8d2323e3a167421d8f8fdf0f217c6f6befe47/rpds_py-0.22.3-cp310-cp310-macosx_10_12_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bc27863442d388870c1809a87507727b799c8460573cfbb6dc0eeaef5a11b5ec",
+              "url": "https://files.pythonhosted.org/packages/4d/cf/96f1fd75512a017f8e07408b6d5dbeb492d9ed46bfe0555544294f3681b3/rpds_py-0.22.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bf9db5488121b596dbfc6718c76092fda77b703c1f7533a226a5a9f65248f8ad",
+              "url": "https://files.pythonhosted.org/packages/54/78/87157fa39d58f32a68d3326f8a81ad8fb99f49fe2aa7ad9a1b7d544f9478/rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0b8db6b5b2d4491ad5b6bdc2bc7c017eec108acbf4e6785f42a9eb0ba234f4c9",
+              "url": "https://files.pythonhosted.org/packages/59/69/860f89996065a88be1b6ff2d60e96a02b920a262d8aadab99e7903986597/rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "64607d4cbf1b7e3c3c8a14948b99345eda0e161b852e122c6bb71aab6d1d798c",
+              "url": "https://files.pythonhosted.org/packages/6d/62/96905d0a35ad4e4bc3c098b2f34b2e7266e211d08635baa690643d2227be/rpds_py-0.22.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "fda7cb070f442bf80b642cd56483b5548e43d366fe3f39b98e67cce780cded00",
+              "url": "https://files.pythonhosted.org/packages/83/62/3fdd2d3d47bf0bb9b931c4c73036b4ab3ec77b25e016ae26fab0f02be2af/rpds_py-0.22.3-cp310-cp310-musllinux_1_2_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d48424e39c2611ee1b84ad0f44fb3b2b53d473e65de061e3f460fc0be5f1939d",
+              "url": "https://files.pythonhosted.org/packages/8b/63/e29f8ee14fcf383574f73b6bbdcbec0fbc2e5fc36b4de44d1ac389b1de62/rpds_py-0.22.3-pp310-pypy310_pp73-macosx_10_12_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "be2eb3f2495ba669d2a985f9b426c1797b7d48d6963899276d22f23e33d47e37",
+              "url": "https://files.pythonhosted.org/packages/8f/7e/1254f406b7793b586c68e217a6a24ec79040f85e030fff7e9049069284f4/rpds_py-0.22.3-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4041711832360a9b75cfb11b25a6a97c8fb49c07b8bd43d0d02b45d0b499a4ff",
+              "url": "https://files.pythonhosted.org/packages/aa/13/2dbacd820466aa2a3c4b747afb18d71209523d353cf865bf8f4796c969ea/rpds_py-0.22.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "70eb60b3ae9245ddea20f8a4190bd79c705a22f8028aaf8bbdebe4716c3fab24",
+              "url": "https://files.pythonhosted.org/packages/aa/da/17c6a2c73730d426df53675ff9cc6653ac7a60b6438d03c18e1c822a576a/rpds_py-0.22.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e79dd39f1e8c3504be0607e5fc6e86bb60fe3584bec8b782578c3b0fde8d932c",
+              "url": "https://files.pythonhosted.org/packages/ab/f0/d1c5b501c8aea85aeb938b555bfdf7612110a2f8cdc21ae0482c93dd0c24/rpds_py-0.22.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b3d504047aba448d70cf6fa22e06cb09f7cbd761939fdd47604f5e007675c24e",
+              "url": "https://files.pythonhosted.org/packages/bd/d7/bc144e10d27e3cb350f98df2492a319edd3caaf52ddfe1293f37a9afbfd7/rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4b232061ca880db21fa14defe219840ad9b74b6158adb52ddf0e87bead9e8493",
+              "url": "https://files.pythonhosted.org/packages/cf/49/abad4c4a1e6f3adf04785a99c247bfabe55ed868133e2d1881200aa5d381/rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "24e8abb5878e250f2eb0d7859a8e561846f98910326d06c0d51381fed59357bd",
+              "url": "https://files.pythonhosted.org/packages/d3/e0/771ee28b02a24e81c8c0e645796a371350a2bb6672753144f36ae2d2afc9/rpds_py-0.22.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "81e69b0a0e2537f26d73b4e43ad7bc8c8efb39621639b4434b76a3de50c6966e",
+              "url": "https://files.pythonhosted.org/packages/eb/1b/d12770f2b6a9fc2c3ec0d810d7d440f6d465ccd8b7f16ae5385952c28b89/rpds_py-0.22.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            }
+          ],
+          "project_name": "rpds-py",
+          "requires_dists": [],
+          "requires_python": ">=3.9",
+          "version": "0.22.3"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "244a76a24355363a68164241438de1b72f8781664920260c48465896b712a41e",
+              "url": "https://files.pythonhosted.org/packages/66/05/7957af15543b8c9799209506df4660cba7afc4cf94bfb60513827e96bed6/s3transfer-0.10.4-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "29edc09801743c21eb5ecbc617a152df41d3c287f67b615f73e5f750583666a7",
+              "url": "https://files.pythonhosted.org/packages/c0/0a/1cdbabf9edd0ea7747efdf6c9ab4e7061b085aa7f9bfc36bb1601563b069/s3transfer-0.10.4.tar.gz"
+            }
+          ],
+          "project_name": "s3transfer",
+          "requires_dists": [
+            "botocore<2.0a.0,>=1.33.2",
+            "botocore[crt]<2.0a.0,>=1.33.2; extra == \"crt\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "0.10.4"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "a46d3ca0f11a540b8eaddaf5e38172d8cd65a86cb3e3632161ec96c0cffb774c",
+              "url": "https://files.pythonhosted.org/packages/50/79/d21599fc44d2d497ced440480670b6314ebc00308e3bae0d0ebca44cd481/scikit_learn-1.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "efa7a579606c73a0b3d210e33ea410ea9e1af7933fe324cb7e6fbafae4ea5948",
+              "url": "https://files.pythonhosted.org/packages/25/9f/61544f2a5cae1bc27c97f0ec9ffcc9837e469f215817608840a4ccbb277a/scikit_learn-1.6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "59cd96a8d9f8dfd546f5d6e9787e1b989e981388d7803abbc9efdcde61e47460",
+              "url": "https://files.pythonhosted.org/packages/36/7b/8c5dfc64a8344ebf2ae493d59af4b3650588051f654e164ff4f9952877b3/scikit_learn-1.6.0-cp310-cp310-macosx_12_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "366fb3fa47dce90afed3d6106183f4978d6f24cfd595c2373424171b915ee718",
+              "url": "https://files.pythonhosted.org/packages/c0/97/55060f91a5e7c4df945e5a69b16148b5f2256e6e1ea3f17da8e27edf9953/scikit_learn-1.6.0-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9d58481f9f7499dff4196927aedd4285a0baec8caa3790efbe205f13de37dd6e",
+              "url": "https://files.pythonhosted.org/packages/fa/19/5aa2002044afc297ecaf1e3517ed07bba4aece3b5613b5160c1212995fc8/scikit_learn-1.6.0.tar.gz"
+            }
+          ],
+          "project_name": "scikit-learn",
+          "requires_dists": [
+            "Pillow>=7.1.2; extra == \"docs\"",
+            "black>=24.3.0; extra == \"tests\"",
+            "conda-lock==2.5.6; extra == \"maintenance\"",
+            "cython>=3.0.10; extra == \"build\"",
+            "joblib>=1.2.0",
+            "joblib>=1.2.0; extra == \"install\"",
+            "matplotlib>=3.3.4; extra == \"benchmark\"",
+            "matplotlib>=3.3.4; extra == \"docs\"",
+            "matplotlib>=3.3.4; extra == \"examples\"",
+            "matplotlib>=3.3.4; extra == \"tests\"",
+            "memory_profiler>=0.57.0; extra == \"benchmark\"",
+            "memory_profiler>=0.57.0; extra == \"docs\"",
+            "meson-python>=0.16.0; extra == \"build\"",
+            "mypy>=1.9; extra == \"tests\"",
+            "numpy>=1.19.5",
+            "numpy>=1.19.5; extra == \"build\"",
+            "numpy>=1.19.5; extra == \"install\"",
+            "numpydoc>=1.2.0; extra == \"docs\"",
+            "numpydoc>=1.2.0; extra == \"tests\"",
+            "pandas>=1.1.5; extra == \"benchmark\"",
+            "pandas>=1.1.5; extra == \"docs\"",
+            "pandas>=1.1.5; extra == \"examples\"",
+            "pandas>=1.1.5; extra == \"tests\"",
+            "plotly>=5.14.0; extra == \"docs\"",
+            "plotly>=5.14.0; extra == \"examples\"",
+            "polars>=0.20.30; extra == \"docs\"",
+            "polars>=0.20.30; extra == \"tests\"",
+            "pooch>=1.6.0; extra == \"docs\"",
+            "pooch>=1.6.0; extra == \"examples\"",
+            "pooch>=1.6.0; extra == \"tests\"",
+            "pyamg>=4.0.0; extra == \"tests\"",
+            "pyarrow>=12.0.0; extra == \"tests\"",
+            "pydata-sphinx-theme>=0.15.3; extra == \"docs\"",
+            "pytest-cov>=2.9.0; extra == \"tests\"",
+            "pytest>=7.1.2; extra == \"tests\"",
+            "ruff>=0.5.1; extra == \"tests\"",
+            "scikit-image>=0.17.2; extra == \"docs\"",
+            "scikit-image>=0.17.2; extra == \"examples\"",
+            "scikit-image>=0.17.2; extra == \"tests\"",
+            "scipy>=1.6.0",
+            "scipy>=1.6.0; extra == \"build\"",
+            "scipy>=1.6.0; extra == \"install\"",
+            "seaborn>=0.9.0; extra == \"docs\"",
+            "seaborn>=0.9.0; extra == \"examples\"",
+            "sphinx-copybutton>=0.5.2; extra == \"docs\"",
+            "sphinx-design>=0.5.0; extra == \"docs\"",
+            "sphinx-design>=0.6.0; extra == \"docs\"",
+            "sphinx-gallery>=0.17.1; extra == \"docs\"",
+            "sphinx-prompt>=1.4.0; extra == \"docs\"",
+            "sphinx-remove-toctrees>=1.0.0.post1; extra == \"docs\"",
+            "sphinx>=7.3.7; extra == \"docs\"",
+            "sphinxcontrib-sass>=0.3.4; extra == \"docs\"",
+            "sphinxext-opengraph>=0.9.1; extra == \"docs\"",
+            "threadpoolctl>=3.1.0",
+            "threadpoolctl>=3.1.0; extra == \"install\"",
+            "towncrier>=24.8.0; extra == \"docs\""
+          ],
+          "requires_python": ">=3.9",
+          "version": "1.6.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "8426251ad1e4ad903a4514712d2fa8fdd5382c978010d1c6f5f37ef286a713ad",
+              "url": "https://files.pythonhosted.org/packages/5d/aa/994b45c34b897637b853ec04334afa55a85650a0d11dacfa67232260fb0a/scipy-1.14.1-cp310-cp310-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8bddf15838ba768bb5f5083c1ea012d64c9a444e16192762bd858f1e126196d0",
+              "url": "https://files.pythonhosted.org/packages/07/42/0e0bea9666fcbf2cb6ea0205db42c81b1f34d7b729ba251010edf9c80ebd/scipy-1.14.1-cp310-cp310-macosx_14_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "97c5dddd5932bd2a1a31c927ba5e1463a53b87ca96b5c9bdf5dfd6096e27efc3",
+              "url": "https://files.pythonhosted.org/packages/15/47/298ab6fef5ebf31b426560e978b8b8548421d4ed0bf99263e1eb44532306/scipy-1.14.1-cp310-cp310-macosx_14_0_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d0d2821003174de06b69e58cef2316a6622b60ee613121199cb2852a873f8cf3",
+              "url": "https://files.pythonhosted.org/packages/43/a5/8d02f9c372790326ad405d94f04d4339482ec082455b9e6e288f7100513b/scipy-1.14.1-cp310-cp310-macosx_12_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8e32dced201274bf96899e6491d9ba3e9a5f6b336708656466ad0522d8528f69",
+              "url": "https://files.pythonhosted.org/packages/47/78/b0c2c23880dd1e99e938ad49ccfb011ae353758a2dc5ed7ee59baff684c3/scipy-1.14.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5a275584e726026a5699459aa72f828a610821006228e841b94275c4a7c08417",
+              "url": "https://files.pythonhosted.org/packages/62/11/4d44a1f274e002784e4dbdb81e0ea96d2de2d1045b2132d5af62cc31fd28/scipy-1.14.1.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b28d2ca4add7ac16ae8bb6632a3c86e4b9e4d52d3e34267f6e1b0c1f8d87e389",
+              "url": "https://files.pythonhosted.org/packages/64/68/3bc0cfaf64ff507d82b1e5d5b64521df4c8bf7e22bc0b897827cbee9872c/scipy-1.14.1-cp310-cp310-macosx_10_13_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2ff0a7e01e422c15739ecd64432743cf7aae2b03f3084288f399affcefe5222d",
+              "url": "https://files.pythonhosted.org/packages/d8/df/cdb6be5274bc694c4c22862ac3438cb04f360ed9df0aecee02ce0b798380/scipy-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            }
+          ],
+          "project_name": "scipy",
+          "requires_dists": [
+            "Cython; extra == \"test\"",
+            "array-api-strict>=2.0; extra == \"test\"",
+            "asv; extra == \"test\"",
+            "cython-lint>=0.12.2; extra == \"dev\"",
+            "doit>=0.36.0; extra == \"dev\"",
+            "gmpy2; extra == \"test\"",
+            "hypothesis>=6.30; extra == \"test\"",
+            "jupyterlite-pyodide-kernel; extra == \"doc\"",
+            "jupyterlite-sphinx>=0.13.1; extra == \"doc\"",
+            "jupytext; extra == \"doc\"",
+            "matplotlib>=3.5; extra == \"doc\"",
+            "meson; extra == \"test\"",
+            "mpmath; extra == \"test\"",
+            "mypy==1.10.0; extra == \"dev\"",
+            "myst-nb; extra == \"doc\"",
+            "ninja; sys_platform != \"emscripten\" and extra == \"test\"",
+            "numpy<2.3,>=1.23.5",
+            "numpydoc; extra == \"doc\"",
+            "pooch; extra == \"doc\"",
+            "pooch; extra == \"test\"",
+            "pycodestyle; extra == \"dev\"",
+            "pydata-sphinx-theme>=0.15.2; extra == \"doc\"",
+            "pydevtool; extra == \"dev\"",
+            "pytest-cov; extra == \"test\"",
+            "pytest-timeout; extra == \"test\"",
+            "pytest-xdist; extra == \"test\"",
+            "pytest; extra == \"test\"",
+            "rich-click; extra == \"dev\"",
+            "ruff>=0.0.292; extra == \"dev\"",
+            "scikit-umfpack; extra == \"test\"",
+            "sphinx-design>=0.4.0; extra == \"doc\"",
+            "sphinx<=7.3.7,>=5.0.0; extra == \"doc\"",
+            "threadpoolctl; extra == \"test\"",
+            "types-psutil; extra == \"dev\"",
+            "typing_extensions; extra == \"dev\""
+          ],
+          "requires_python": ">=3.10",
+          "version": "1.14.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987",
+              "url": "https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7",
+              "url": "https://files.pythonhosted.org/packages/86/59/a451d7420a77ab0b98f7affa3a1d78a313d2f7281a57afb1a34bae8ab412/seaborn-0.13.2.tar.gz"
+            }
+          ],
+          "project_name": "seaborn",
+          "requires_dists": [
+            "flake8; extra == \"dev\"",
+            "flit; extra == \"dev\"",
+            "ipykernel; extra == \"docs\"",
+            "matplotlib!=3.6.1,>=3.4",
+            "mypy; extra == \"dev\"",
+            "nbconvert; extra == \"docs\"",
+            "numpy!=1.24.0,>=1.20",
+            "numpydoc; extra == \"docs\"",
+            "pandas-stubs; extra == \"dev\"",
+            "pandas>=1.2",
+            "pre-commit; extra == \"dev\"",
+            "pydata_sphinx_theme==0.10.0rc2; extra == \"docs\"",
+            "pytest-cov; extra == \"dev\"",
+            "pytest-xdist; extra == \"dev\"",
+            "pytest; extra == \"dev\"",
+            "pyyaml; extra == \"docs\"",
+            "scipy>=1.7; extra == \"stats\"",
+            "sphinx-copybutton; extra == \"docs\"",
+            "sphinx-design; extra == \"docs\"",
+            "sphinx-issues; extra == \"docs\"",
+            "sphinx<6.0.0; extra == \"docs\"",
+            "statsmodels>=0.12; extra == \"stats\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "0.13.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "ebdc08228b4d131128e568d696c210d846e5b9d70aa0327dec6b1272d9d40b84",
+              "url": "https://files.pythonhosted.org/packages/31/4d/74597bb6bcc23abc774b8901277652c61331a9d4d0a8d1bdb20679b9bbcb/sentry_sdk-2.19.2-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "467df6e126ba242d39952375dd816fbee0f217d119bf454a8ce74cf1e7909e8d",
+              "url": "https://files.pythonhosted.org/packages/36/4a/eccdcb8c2649d53440ae1902447b86e2e2ad1bc84207c80af9696fa07614/sentry_sdk-2.19.2.tar.gz"
+            }
+          ],
+          "project_name": "sentry-sdk",
+          "requires_dists": [
+            "aiohttp>=3.5; extra == \"aiohttp\"",
+            "anthropic>=0.16; extra == \"anthropic\"",
+            "apache-beam>=2.12; extra == \"beam\"",
+            "arq>=0.23; extra == \"arq\"",
+            "asttokens; extra == \"pure-eval\"",
+            "asyncpg>=0.23; extra == \"asyncpg\"",
+            "blinker>=1.1; extra == \"flask\"",
+            "blinker>=1.1; extra == \"quart\"",
+            "bottle>=0.12.13; extra == \"bottle\"",
+            "celery-redbeat>=2; extra == \"celery-redbeat\"",
+            "celery>=3; extra == \"celery\"",
+            "certifi",
+            "chalice>=1.16.0; extra == \"chalice\"",
+            "clickhouse-driver>=0.2.0; extra == \"clickhouse-driver\"",
+            "django>=1.8; extra == \"django\"",
+            "executing; extra == \"pure-eval\"",
+            "falcon>=1.4; extra == \"falcon\"",
+            "fastapi>=0.79.0; extra == \"fastapi\"",
+            "flask>=0.11; extra == \"flask\"",
+            "grpcio>=1.21.1; extra == \"grpcio\"",
+            "httpcore[http2]==1.*; extra == \"http2\"",
+            "httpx>=0.16.0; extra == \"httpx\"",
+            "huey>=2; extra == \"huey\"",
+            "huggingface_hub>=0.22; extra == \"huggingface-hub\"",
+            "langchain>=0.0.210; extra == \"langchain\"",
+            "launchdarkly-server-sdk>=9.8.0; extra == \"launchdarkly\"",
+            "litestar>=2.0.0; extra == \"litestar\"",
+            "loguru>=0.5; extra == \"loguru\"",
+            "markupsafe; extra == \"flask\"",
+            "openai>=1.0.0; extra == \"openai\"",
+            "openfeature-sdk>=0.7.1; extra == \"openfeature\"",
+            "opentelemetry-distro; extra == \"opentelemetry-experimental\"",
+            "opentelemetry-distro>=0.35b0; extra == \"opentelemetry\"",
+            "protobuf>=3.8.0; extra == \"grpcio\"",
+            "pure_eval; extra == \"pure-eval\"",
+            "pymongo>=3.1; extra == \"pymongo\"",
+            "pyspark>=2.4.4; extra == \"pyspark\"",
+            "quart>=0.16.1; extra == \"quart\"",
+            "rq>=0.6; extra == \"rq\"",
+            "sanic>=0.8; extra == \"sanic\"",
+            "sqlalchemy>=1.2; extra == \"sqlalchemy\"",
+            "starlette>=0.19.1; extra == \"starlette\"",
+            "starlite>=1.48; extra == \"starlite\"",
+            "tiktoken>=0.3.0; extra == \"openai\"",
+            "tornado>=6; extra == \"tornado\"",
+            "urllib3>=1.26.11"
+          ],
+          "requires_python": ">=3.6",
+          "version": "2.19.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "ce74b49e8f7110f9bf04883b730f4765b774ef3ef28f722cce7c273d253aaf7d",
+              "url": "https://files.pythonhosted.org/packages/55/21/47d163f615df1d30c094f6c8bbb353619274edccf0327b185cc2493c2c33/setuptools-75.6.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8199222558df7c86216af4f84c30e9b34a61d8ba19366cc914424cdbd28252f6",
+              "url": "https://files.pythonhosted.org/packages/43/54/292f26c208734e9a7f067aea4a7e282c080750c4546559b58e2e45413ca0/setuptools-75.6.0.tar.gz"
+            }
+          ],
+          "project_name": "setuptools",
+          "requires_dists": [
+            "build[virtualenv]>=1.0.3; extra == \"test\"",
+            "filelock>=3.4.0; extra == \"test\"",
+            "furo; extra == \"doc\"",
+            "importlib_metadata>=6; python_version < \"3.10\" and extra == \"core\"",
+            "importlib_metadata>=7.0.2; python_version < \"3.10\" and extra == \"type\"",
+            "ini2toml[lite]>=0.14; extra == \"test\"",
+            "jaraco.collections; extra == \"core\"",
+            "jaraco.develop>=7.21; (python_version >= \"3.9\" and sys_platform != \"cygwin\") and extra == \"test\"",
+            "jaraco.develop>=7.21; sys_platform != \"cygwin\" and extra == \"type\"",
+            "jaraco.envs>=2.2; extra == \"test\"",
+            "jaraco.functools>=4; extra == \"core\"",
+            "jaraco.packaging>=9.3; extra == \"doc\"",
+            "jaraco.path>=3.2.0; extra == \"test\"",
+            "jaraco.test>=5.5; extra == \"test\"",
+            "jaraco.text>=3.7; extra == \"core\"",
+            "jaraco.tidelift>=1.4; extra == \"doc\"",
+            "more_itertools; extra == \"core\"",
+            "more_itertools>=8.8; extra == \"core\"",
+            "mypy<1.14,>=1.12; extra == \"type\"",
+            "packaging; extra == \"core\"",
+            "packaging>=24.2; extra == \"core\"",
+            "packaging>=24.2; extra == \"test\"",
+            "pip>=19.1; extra == \"test\"",
+            "platformdirs>=4.2.2; extra == \"core\"",
+            "pygments-github-lexers==0.0.5; extra == \"doc\"",
+            "pyproject-hooks!=1.1; extra == \"doc\"",
+            "pyproject-hooks!=1.1; extra == \"test\"",
+            "pytest!=8.1.*,>=6; extra == \"test\"",
+            "pytest-checkdocs>=2.4; extra == \"check\"",
+            "pytest-cov; extra == \"cover\"",
+            "pytest-enabler>=2.2; extra == \"enabler\"",
+            "pytest-home>=0.5; extra == \"test\"",
+            "pytest-mypy; extra == \"type\"",
+            "pytest-perf; sys_platform != \"cygwin\" and extra == \"test\"",
+            "pytest-ruff>=0.2.1; sys_platform != \"cygwin\" and extra == \"check\"",
+            "pytest-subprocess; extra == \"test\"",
+            "pytest-timeout; extra == \"test\"",
+            "pytest-xdist>=3; extra == \"test\"",
+            "rst.linker>=1.9; extra == \"doc\"",
+            "ruff>=0.7.0; sys_platform != \"cygwin\" and extra == \"check\"",
+            "sphinx-favicon; extra == \"doc\"",
+            "sphinx-inline-tabs; extra == \"doc\"",
+            "sphinx-lint; extra == \"doc\"",
+            "sphinx-notfound-page<2,>=1; extra == \"doc\"",
+            "sphinx-reredirects; extra == \"doc\"",
+            "sphinx>=3.5; extra == \"doc\"",
+            "sphinxcontrib-towncrier; extra == \"doc\"",
+            "tomli-w>=1.0.0; extra == \"test\"",
+            "tomli>=2.0.1; python_version < \"3.11\" and extra == \"core\"",
+            "towncrier<24.7; extra == \"doc\"",
+            "virtualenv>=13.0.0; extra == \"test\"",
+            "wheel>=0.43.0; extra == \"core\"",
+            "wheel>=0.44.0; extra == \"test\""
+          ],
+          "requires_python": ">=3.9",
+          "version": "75.6.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "0cf7c6e3f056cf3bfd16bcfd5744d0cc25b851555b1e750a3ab889b3077d2d05",
+              "url": "https://files.pythonhosted.org/packages/b4/fc/dd28e6838630cd436914116aa07a019753a40b956a05831b71bd3f7ce914/shap-0.46.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bccbb30ffbf8b9ed53e476d0c1319fdfcbeac455fe9df277fb0d570d92790e80",
+              "url": "https://files.pythonhosted.org/packages/00/b3/2795a586a4446c8cbf04b6e8f15c19b4a6fb867e5c6cf9fcbca97d56a20b/shap-0.46.0-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9633d3d7174acc01455538169ca6e6344f570530384548631aeadcf7bfdaaaea",
+              "url": "https://files.pythonhosted.org/packages/13/a6/b75760a52664dd82d530f9e232918bb74d1d6c39abcf34523c4f75cd4264/shap-0.46.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "905b2d7a0262ef820785a7c0e3c7f24c9d281e6f934edb65cbe811fe0e971187",
+              "url": "https://files.pythonhosted.org/packages/13/a8/97442ec8e7aaad01d860768232b3b7051adb0560a9c79e52ce5e1222cbf1/shap-0.46.0-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c6097eb2ab7e8c194254bac3e462266490fbdd43bfe35a1014e9ee21c4ef10ee",
+              "url": "https://files.pythonhosted.org/packages/35/13/70e07364855b05d8aa628ec5aec4f038444ede0e26eee2be00c38077ee72/shap-0.46.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bdaa5b098be5a958348015e940f6fd264339b5db1e651f9898a3117be95b05a0",
+              "url": "https://files.pythonhosted.org/packages/47/46/1b497452be642e19af56044814dfe32ee795805b443378821136729017a0/shap-0.46.0.tar.gz"
+            }
+          ],
+          "project_name": "shap",
+          "requires_dists": [
+            "catboost; extra == \"test\"",
+            "cloudpickle",
+            "datasets; extra == \"test-notebooks\"",
+            "gpboost; extra == \"test\"",
+            "ipython; extra == \"docs\"",
+            "ipython; extra == \"plots\"",
+            "jupyter; extra == \"test-notebooks\"",
+            "keras; extra == \"test-notebooks\"",
+            "lightgbm; extra == \"test\"",
+            "lime; extra == \"others\"",
+            "matplotlib; extra == \"docs\"",
+            "matplotlib; extra == \"plots\"",
+            "myst-parser==2.0.0; extra == \"docs\"",
+            "nbconvert; extra == \"test-notebooks\"",
+            "nbformat; extra == \"test-notebooks\"",
+            "nbsphinx==0.9.3; extra == \"docs\"",
+            "ngboost; extra == \"test\"",
+            "nlp; extra == \"test-notebooks\"",
+            "numba",
+            "numpy",
+            "numpydoc; extra == \"docs\"",
+            "opencv-python; extra == \"test\"",
+            "packaging>20.9",
+            "pandas",
+            "protobuf==3.20.3; extra == \"test\"",
+            "pyod; extra == \"test\"",
+            "pyspark; extra == \"test\"",
+            "pytest-cov; extra == \"test\"",
+            "pytest-cov; extra == \"test-core\"",
+            "pytest-mpl; extra == \"test\"",
+            "pytest-mpl; extra == \"test-core\"",
+            "pytest; extra == \"test\"",
+            "pytest; extra == \"test-core\"",
+            "requests; extra == \"docs\"",
+            "scikit-learn",
+            "scipy",
+            "sentencepiece; extra == \"test\"",
+            "slicer==0.0.8",
+            "sphinx-github-changelog==1.2.1; extra == \"docs\"",
+            "sphinx-rtd-theme==2.0.0; extra == \"docs\"",
+            "sphinx==7.2.6; extra == \"docs\"",
+            "tensorflow; extra == \"test\"",
+            "tf-keras; extra == \"test\"",
+            "torch; sys_platform != \"darwin\" and extra == \"test\"",
+            "torch==2.2.0; sys_platform == \"darwin\" and extra == \"test\"",
+            "torchvision; extra == \"test\"",
+            "tqdm>=4.27.0",
+            "transformers; extra == \"test\"",
+            "transformers; extra == \"test-notebooks\"",
+            "xgboost; extra == \"test\""
+          ],
+          "requires_python": ">=3.9",
+          "version": "0.46.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686",
+              "url": "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de",
+              "url": "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz"
+            }
+          ],
+          "project_name": "shellingham",
+          "requires_dists": [],
+          "requires_python": ">=3.7",
+          "version": "1.5.4"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
+              "url": "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81",
+              "url": "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz"
+            }
+          ],
+          "project_name": "six",
+          "requires_dists": [],
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7",
+          "version": "1.17.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "6c206258543aecd010d497dc2eca9d2805860a0b3758673903456b7df7934dc3",
+              "url": "https://files.pythonhosted.org/packages/63/81/9ef641ff4e12cbcca30e54e72fb0951a2ba195d0cda0ba4100e532d929db/slicer-0.0.8-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2e7553af73f0c0c2d355f4afcc3ecf97c6f2156fcf4593955c3f56cf6c4d6eb7",
+              "url": "https://files.pythonhosted.org/packages/d3/f9/b4bce2825b39b57760b361e6131a3dacee3d8951c58cb97ad120abb90317/slicer-0.0.8.tar.gz"
+            }
+          ],
+          "project_name": "slicer",
+          "requires_dists": [],
+          "requires_python": ">=3.6",
+          "version": "0.0.8"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2",
+              "url": "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc",
+              "url": "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz"
+            }
+          ],
+          "project_name": "sniffio",
+          "requires_dists": [],
+          "requires_python": ">=3.7",
+          "version": "1.3.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "fddbe92b4760c6f5d48162aef14824add991aeda8ddadb3c31d56eb15ca69f8e",
+              "url": "https://files.pythonhosted.org/packages/b8/49/21633706dd6feb14cd3f7935fc00b60870ea057686035e1a99ae6d9d9d53/SQLAlchemy-2.0.36-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c245b1fbade9c35e5bd3b64270ab49ce990369018289ecfde3f9c318411aaa07",
+              "url": "https://files.pythonhosted.org/packages/07/15/68ef91de5b8b7f80fb2d2b3b31ed42180c6227fe0a701aed9d01d34f98ec/SQLAlchemy-2.0.36-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f9511d8dd4a6e9271d07d150fb2f81874a3c8c95e11ff9af3a2dfc35fe42ee44",
+              "url": "https://files.pythonhosted.org/packages/16/a5/fcfde8e74ea5f683b24add22463bfc21e431d4a5531c8a5b55bc6fbea164/SQLAlchemy-2.0.36-cp310-cp310-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "37350015056a553e442ff672c2d20e6f4b6d0b2495691fa239d8aa18bb3bc908",
+              "url": "https://files.pythonhosted.org/packages/1e/59/333fcbca58b79f5b8b61853d6137530198823392151fa8fd9425f367519e/SQLAlchemy-2.0.36-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7f2767680b6d2398aea7082e45a774b2b0767b5c8d8ffb9c8b683088ea9b29c5",
+              "url": "https://files.pythonhosted.org/packages/50/65/9cbc9c4c3287bed2499e05033e207473504dc4df999ce49385fb1f8b058a/sqlalchemy-2.0.36.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8318f4776c85abc3f40ab185e388bee7a6ea99e7fa3a30686580b209eaa35c08",
+              "url": "https://files.pythonhosted.org/packages/6c/a0/ec3c188d2b0c1bc742262e76408d44104598d7247c23f5b06bb97ee21bfa/SQLAlchemy-2.0.36-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "59b8f3adb3971929a3e660337f5dacc5942c2cdb760afcabb2614ffbda9f9f72",
+              "url": "https://files.pythonhosted.org/packages/db/72/14ab694b8b3f0e35ef5beb74a8fea2811aa791ba1611c44dc90cdf46af17/SQLAlchemy-2.0.36-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "69f93723edbca7342624d09f6704e7126b152eaed3cdbb634cb657a54332a3c5",
+              "url": "https://files.pythonhosted.org/packages/e2/4c/9dfea5e63b87325eef6d9cdaac913459aa6a157a05a05ea6ff20004aee8e/SQLAlchemy-2.0.36-cp310-cp310-musllinux_1_2_aarch64.whl"
+            }
+          ],
+          "project_name": "sqlalchemy",
+          "requires_dists": [
+            "aiomysql>=0.2.0; extra == \"aiomysql\"",
+            "aioodbc; extra == \"aioodbc\"",
+            "aiosqlite; extra == \"aiosqlite\"",
+            "asyncmy!=0.2.4,!=0.2.6,>=0.2.3; extra == \"asyncmy\"",
+            "asyncpg; extra == \"postgresql-asyncpg\"",
+            "cx-oracle>=8; extra == \"oracle\"",
+            "greenlet!=0.4.17; extra == \"aiomysql\"",
+            "greenlet!=0.4.17; extra == \"aioodbc\"",
+            "greenlet!=0.4.17; extra == \"aiosqlite\"",
+            "greenlet!=0.4.17; extra == \"asyncio\"",
+            "greenlet!=0.4.17; extra == \"asyncmy\"",
+            "greenlet!=0.4.17; extra == \"postgresql-asyncpg\"",
+            "greenlet!=0.4.17; python_version < \"3.13\" and (platform_machine == \"aarch64\" or (platform_machine == \"ppc64le\" or (platform_machine == \"x86_64\" or (platform_machine == \"amd64\" or (platform_machine == \"AMD64\" or (platform_machine == \"win32\" or platform_machine == \"WIN32\"))))))",
+            "importlib-metadata; python_version < \"3.8\"",
+            "mariadb!=1.1.10,!=1.1.2,!=1.1.5,>=1.0.1; extra == \"mariadb-connector\"",
+            "mypy>=0.910; extra == \"mypy\"",
+            "mysql-connector-python; extra == \"mysql-connector\"",
+            "mysqlclient>=1.4.0; extra == \"mysql\"",
+            "oracledb>=1.0.1; extra == \"oracle-oracledb\"",
+            "pg8000>=1.29.1; extra == \"postgresql-pg8000\"",
+            "psycopg2-binary; extra == \"postgresql-psycopg2binary\"",
+            "psycopg2>=2.7; extra == \"postgresql\"",
+            "psycopg2cffi; extra == \"postgresql-psycopg2cffi\"",
+            "psycopg>=3.0.7; extra == \"postgresql-psycopg\"",
+            "psycopg[binary]>=3.0.7; extra == \"postgresql-psycopgbinary\"",
+            "pymssql; extra == \"mssql-pymssql\"",
+            "pymysql; extra == \"pymysql\"",
+            "pyodbc; extra == \"mssql\"",
+            "pyodbc; extra == \"mssql-pyodbc\"",
+            "sqlcipher3-binary; extra == \"sqlcipher\"",
+            "typing-extensions!=3.10.0.1; extra == \"aiosqlite\"",
+            "typing-extensions>=4.6.0"
+          ],
+          "requires_python": ">=3.7",
+          "version": "2.0.36"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695",
+              "url": "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9",
+              "url": "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz"
+            }
+          ],
+          "project_name": "stack-data",
+          "requires_dists": [
+            "asttokens>=2.1.0",
+            "cython; extra == \"tests\"",
+            "executing>=1.2.0",
+            "littleutils; extra == \"tests\"",
+            "pure-eval",
+            "pygments; extra == \"tests\"",
+            "pytest; extra == \"tests\"",
+            "typeguard; extra == \"tests\""
+          ],
+          "requires_python": null,
+          "version": "0.6.3"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "44cedb2b7c77a9de33a8b74b2b90e9f50d11fcf25d8270ea525ad71a25374ff7",
+              "url": "https://files.pythonhosted.org/packages/96/00/2b325970b3060c7cecebab6d295afe763365822b1306a12eeab198f74323/starlette-0.41.3-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0e4ab3d16522a255be6b28260b938eae2482f98ce5cc934cb08dce8dc3ba5835",
+              "url": "https://files.pythonhosted.org/packages/1a/4c/9b5764bd22eec91c4039ef4c55334e9187085da2d8a2df7bd570869aae18/starlette-0.41.3.tar.gz"
+            }
+          ],
+          "project_name": "starlette",
+          "requires_dists": [
+            "anyio<5,>=3.4.0",
+            "httpx>=0.22.0; extra == \"full\"",
+            "itsdangerous; extra == \"full\"",
+            "jinja2; extra == \"full\"",
+            "python-multipart>=0.0.7; extra == \"full\"",
+            "pyyaml; extra == \"full\"",
+            "typing-extensions>=3.10.0; python_version < \"3.10\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "0.41.3"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "3bb2e580d382545a65f298589809af29daeb15f9da2eb252af8f79693e618abc",
+              "url": "https://files.pythonhosted.org/packages/35/64/df81426924fcc48a0402534efa96cde13275629ae52f123189d16c4b75ff/statsmodels-0.14.4-cp310-cp310-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5d69e0f39060dc72c067f9bb6e8033b6dccdb0bae101d76a7ef0bcc94e898b67",
+              "url": "https://files.pythonhosted.org/packages/1f/3b/963a015dd8ea17e10c7b0e2f14d7c4daec903baf60a017e756b57953a4bf/statsmodels-0.14.4.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "631bb52159117c5da42ba94bd94859276b68cab25dc4cac86475bc24671143bc",
+              "url": "https://files.pythonhosted.org/packages/78/44/d72c634211797ed07dd8c63ced4ae11debd7a40b24ee80e79346a526194f/statsmodels-0.14.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2a337b731aa365d09bb0eab6da81446c04fde6c31976b1d8e3d3a911f0f1e07b",
+              "url": "https://files.pythonhosted.org/packages/93/6a/b86f8c9b799dc93e5b4a3267eb809843e6328e34248a53496b96f50d732e/statsmodels-0.14.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7a62f1fc9086e4b7ee789a6f66b3c0fc82dd8de1edda1522d30901a0aa45e42b",
+              "url": "https://files.pythonhosted.org/packages/af/2c/23bf5ad9e8a77c0c8d9750512bff89e32154dea91998114118e0e147ae67/statsmodels-0.14.4-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "46ac7ddefac0c9b7b607eed1d47d11e26fe92a1bc1f4d9af48aeed4e21e87981",
+              "url": "https://files.pythonhosted.org/packages/ba/a5/2f09ab918296e534ea5d132e90efac51ae12ff15992d77539bbfca1158fa/statsmodels-0.14.4-cp310-cp310-macosx_11_0_arm64.whl"
+            }
+          ],
+          "project_name": "statsmodels",
+          "requires_dists": [
+            "colorama; extra == \"develop\"",
+            "cython<4,>=3.0.10; extra == \"develop\"",
+            "cython>=3.0.10; extra == \"build\"",
+            "cython>=3.0.10; extra == \"develop\"",
+            "flake8; extra == \"develop\"",
+            "ipykernel; extra == \"docs\"",
+            "isort; extra == \"develop\"",
+            "joblib; extra == \"develop\"",
+            "jupyter-client; extra == \"docs\"",
+            "matplotlib; extra == \"docs\"",
+            "matplotlib>=3; extra == \"develop\"",
+            "nbconvert; extra == \"docs\"",
+            "nbformat; extra == \"docs\"",
+            "numpy<3,>=1.22.3",
+            "numpydoc; extra == \"docs\"",
+            "packaging>=21.3",
+            "pandas!=2.1.0,>=1.4",
+            "pandas-datareader; extra == \"docs\"",
+            "patsy>=0.5.6",
+            "pytest-cov; extra == \"develop\"",
+            "pytest-randomly; extra == \"develop\"",
+            "pytest-xdist; extra == \"develop\"",
+            "pytest<8,>=7.3.0; extra == \"develop\"",
+            "pywinpty; os_name == \"nt\" and extra == \"develop\"",
+            "scipy!=1.9.2,>=1.8",
+            "setuptools-scm[toml]~=8.0; extra == \"develop\"",
+            "sphinx; extra == \"docs\""
+          ],
+          "requires_python": ">=3.9",
+          "version": "0.14.4"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f",
+              "url": "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c",
+              "url": "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz"
+            }
+          ],
+          "project_name": "tabulate",
+          "requires_dists": [
+            "wcwidth; extra == \"widechars\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "0.9.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539",
+              "url": "https://files.pythonhosted.org/packages/b6/cb/b86984bed139586d01532a587464b5805f12e397594f19f931c4c2fbfa61/tenacity-9.0.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b",
+              "url": "https://files.pythonhosted.org/packages/cd/94/91fccdb4b8110642462e653d5dcb27e7b674742ad68efd146367da7bdb10/tenacity-9.0.0.tar.gz"
+            }
+          ],
+          "project_name": "tenacity",
+          "requires_dists": [
+            "pytest; extra == \"test\"",
+            "reno; extra == \"doc\"",
+            "sphinx; extra == \"doc\"",
+            "tornado>=4.5; extra == \"test\"",
+            "typeguard; extra == \"test\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "9.0.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8",
+              "url": "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93",
+              "url": "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz"
+            }
+          ],
+          "project_name": "text-unidecode",
+          "requires_dists": [],
+          "requires_python": null,
+          "version": "1.3"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "56c1e26c150397e58c4926da8eeee87533b1e32bef131bd4bf6a2f45f3185467",
+              "url": "https://files.pythonhosted.org/packages/4b/2c/ffbf7a134b9ab11a67b0cf0726453cedd9c5043a4fe7a35d1cefa9a1bcfb/threadpoolctl-3.5.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "082433502dd922bf738de0d8bcc4fdcbf0979ff44c42bd40f5af8a282f6fa107",
+              "url": "https://files.pythonhosted.org/packages/bd/55/b5148dcbf72f5cde221f8bfe3b6a540da7aa1842f6b491ad979a6c8b84af/threadpoolctl-3.5.0.tar.gz"
+            }
+          ],
+          "project_name": "threadpoolctl",
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "3.5.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc",
+              "url": "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "cd45e1dc79c835ce60f7404ec8119f2eb06d38b1deba146f07ced3bbc44505ff",
+              "url": "https://files.pythonhosted.org/packages/18/87/302344fed471e44a87289cf4967697d07e532f2421fdaf868a303cbae4ff/tomli-2.2.1.tar.gz"
+            }
+          ],
+          "project_name": "tomli",
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "2.2.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "932d195ca9015956fa502c6b56af9eb06106140d844a335590c1ec7f5277d10c",
+              "url": "https://files.pythonhosted.org/packages/2b/ae/c1b22d4524b0e10da2f29a176fb2890386f7bd1f63aacf186444873a88a0/tornado-6.4.2-cp38-abi3-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bca9eb02196e789c9cb5c3c7c0f04fb447dc2adffd95265b2c7223a8a615ccbf",
+              "url": "https://files.pythonhosted.org/packages/22/55/b78a464de78051a30599ceb6983b01d8f732e6f69bf37b4ed07f642ac0fc/tornado-6.4.2-cp38-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e828cce1123e9e44ae2a50a9de3055497ab1d0aeb440c5ac23064d9e44880da1",
+              "url": "https://files.pythonhosted.org/packages/26/7e/71f604d8cea1b58f82ba3590290b66da1e72d840aeb37e0d5f7291bd30db/tornado-6.4.2-cp38-abi3-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c36e62ce8f63409301537222faffcef7dfc5284f27eec227389f2ad11b09d946",
+              "url": "https://files.pythonhosted.org/packages/4f/3b/e31aeffffc22b475a64dbeb273026a21b5b566f74dee48742817626c47dc/tornado-6.4.2-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "92bad5b4746e9879fd7bf1eb21dce4e3fc5128d71601f80005afa39237ad620b",
+              "url": "https://files.pythonhosted.org/packages/59/45/a0daf161f7d6f36c3ea5fc0c2de619746cc3dd4c76402e9db545bd920f63/tornado-6.4.2.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "304463bd0772442ff4d0f5149c6f1c2135a1fae045adf070821c6cdc76980634",
+              "url": "https://files.pythonhosted.org/packages/79/5e/be4fb0d1684eb822c9a62fb18a3e44a06188f78aa466b2ad991d2ee31104/tornado-6.4.2-cp38-abi3-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "072ce12ada169c5b00b7d92a99ba089447ccc993ea2143c9ede887e0937aa803",
+              "url": "https://files.pythonhosted.org/packages/96/44/87543a3b99016d0bf54fdaab30d24bf0af2e848f1d13d34a3a5380aabe16/tornado-6.4.2-cp38-abi3-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1a017d239bd1bb0919f72af256a970624241f070496635784d9bf0db640d3fec",
+              "url": "https://files.pythonhosted.org/packages/cb/fb/fdf679b4ce51bcb7210801ef4f11fdac96e9885daa402861751353beea6e/tornado-6.4.2-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c82c46813ba483a385ab2a99caeaedf92585a1f90defb5693351fa7e4ea0bf73",
+              "url": "https://files.pythonhosted.org/packages/f5/33/4f91fdd94ea36e1d796147003b490fe60a0215ac5737b6f9c65e160d4fe0/tornado-6.4.2-cp38-abi3-musllinux_1_2_i686.whl"
+            }
+          ],
+          "project_name": "tornado",
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "6.4.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2",
+              "url": "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2",
+              "url": "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz"
+            }
+          ],
+          "project_name": "tqdm",
+          "requires_dists": [
+            "colorama; platform_system == \"Windows\"",
+            "ipywidgets>=6; extra == \"notebook\"",
+            "nbval; extra == \"dev\"",
+            "pytest-asyncio>=0.24; extra == \"dev\"",
+            "pytest-cov; extra == \"dev\"",
+            "pytest-timeout; extra == \"dev\"",
+            "pytest>=6; extra == \"dev\"",
+            "requests; extra == \"discord\"",
+            "requests; extra == \"telegram\"",
+            "slack-sdk; extra == \"slack\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "4.67.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f",
+              "url": "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7",
+              "url": "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz"
+            }
+          ],
+          "project_name": "traitlets",
+          "requires_dists": [
+            "argcomplete>=3.0.3; extra == \"test\"",
+            "mypy>=1.7.0; extra == \"test\"",
+            "myst-parser; extra == \"docs\"",
+            "pre-commit; extra == \"test\"",
+            "pydata-sphinx-theme; extra == \"docs\"",
+            "pytest-mock; extra == \"test\"",
+            "pytest-mypy-testing; extra == \"test\"",
+            "pytest<8.2,>=7.0; extra == \"test\"",
+            "sphinx; extra == \"docs\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "5.14.3"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "7994fb7b8155b64d3402518560648446072864beefd44aa2dc36972a5972e847",
+              "url": "https://files.pythonhosted.org/packages/d0/cc/0a838ba5ca64dc832aa43f727bd586309846b0ffb2ce52422543e6075e8a/typer-0.15.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "a0588c0a7fa68a1978a069818657778f86abe6ff5ea6abf472f940a08bfe4f0a",
+              "url": "https://files.pythonhosted.org/packages/cb/ce/dca7b219718afd37a0068f4f2530a727c2b74a8b6e8e0c0080a4c0de4fcd/typer-0.15.1.tar.gz"
+            }
+          ],
+          "project_name": "typer",
+          "requires_dists": [
+            "click>=8.0.0",
+            "rich>=10.11.0",
+            "shellingham>=1.3.0",
+            "typing-extensions>=3.7.4.3"
+          ],
+          "requires_python": ">=3.7",
+          "version": "0.15.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+              "url": "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8",
+              "url": "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz"
+            }
+          ],
+          "project_name": "typing-extensions",
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "4.12.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac",
+              "url": "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9",
+              "url": "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz"
+            }
+          ],
+          "project_name": "urllib3",
+          "requires_dists": [
+            "brotli>=1.0.9; platform_python_implementation == \"CPython\" and extra == \"brotli\"",
+            "brotlicffi>=0.8.0; platform_python_implementation != \"CPython\" and extra == \"brotli\"",
+            "h2<5,>=4; extra == \"h2\"",
+            "pysocks!=1.5.7,<2.0,>=1.5.6; extra == \"socks\"",
+            "zstandard>=0.18.0; extra == \"zstd\""
+          ],
+          "requires_python": ">=3.8",
+          "version": "2.2.3"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "023dc038422502fa28a09c7a30bf2b6991512da7dcdb8fd35fe57cfc154126f4",
+              "url": "https://files.pythonhosted.org/packages/61/14/33a3a1352cfa71812a3a21e8c9bfb83f60b0011f5e36f2b1399d51928209/uvicorn-0.34.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9",
+              "url": "https://files.pythonhosted.org/packages/4b/4d/938bd85e5bf2edeec766267a5015ad969730bb91e31b44021dfe8b22df6c/uvicorn-0.34.0.tar.gz"
+            }
+          ],
+          "project_name": "uvicorn",
+          "requires_dists": [
+            "click>=7.0",
+            "colorama>=0.4; sys_platform == \"win32\" and extra == \"standard\"",
+            "h11>=0.8",
+            "httptools>=0.6.3; extra == \"standard\"",
+            "python-dotenv>=0.13; extra == \"standard\"",
+            "pyyaml>=5.1; extra == \"standard\"",
+            "typing-extensions>=4.0; python_version < \"3.11\"",
+            "uvloop!=0.15.0,!=0.15.1,>=0.14.0; (sys_platform != \"win32\" and (sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\")) and extra == \"standard\"",
+            "watchfiles>=0.13; extra == \"standard\"",
+            "websockets>=10.4; extra == \"standard\""
+          ],
+          "requires_python": ">=3.9",
+          "version": "0.34.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "67dd654b8ca23aed0a8e99010b4c34aca62f4b7fce88f39d452ed7622c94845c",
+              "url": "https://files.pythonhosted.org/packages/26/dd/c7179618e46092a77e036650c1f056041a028a35c4d76945089fcfc38af8/uvloop-0.21.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "196274f2adb9689a289ad7d65700d37df0c0930fd8e4e743fa4834e850d7719d",
+              "url": "https://files.pythonhosted.org/packages/35/5a/62d5800358a78cc25c8a6c72ef8b10851bdb8cca22e14d9c74167b7f86da/uvloop-0.21.0-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ec7e6b09a6fdded42403182ab6b832b71f4edaf7f37a9a0e371a01db5f0cb45f",
+              "url": "https://files.pythonhosted.org/packages/3d/76/44a55515e8c9505aa1420aebacf4dd82552e5e15691654894e90d0bd051a/uvloop-0.21.0-cp310-cp310-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "87c43e0f13022b998eb9b973b5e97200c8b90823454d4bc06ab33829e09fb9bb",
+              "url": "https://files.pythonhosted.org/packages/61/e0/f0f8ec84979068ffae132c58c79af1de9cceeb664076beea86d941af1a30/uvloop-0.21.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3bf12b0fda68447806a7ad847bfa591613177275d35b6724b1ee573faa3704e3",
+              "url": "https://files.pythonhosted.org/packages/af/c0/854216d09d33c543f12a44b393c402e89a920b1a0a7dc634c42de91b9cf6/uvloop-0.21.0.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "10d66943def5fcb6e7b37310eb6b5639fd2ccbc38df1177262b0640c3ca68c1f",
+              "url": "https://files.pythonhosted.org/packages/bf/fe/5e94a977d058a54a19df95f12f7161ab6e323ad49f4dabc28822eb2df7ea/uvloop-0.21.0-cp310-cp310-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f38b2e090258d051d68a5b14d1da7203a3c3677321cf32a95a6f4db4dd8b6f26",
+              "url": "https://files.pythonhosted.org/packages/f3/96/63695e0ebd7da6c741ccd4489b5947394435e198a1382349c17b1146bb97/uvloop-0.21.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            }
+          ],
+          "project_name": "uvloop",
+          "requires_dists": [
+            "Cython~=3.0; extra == \"dev\"",
+            "Sphinx~=4.1.2; extra == \"docs\"",
+            "aiohttp>=3.10.5; extra == \"test\"",
+            "flake8~=5.0; extra == \"test\"",
+            "mypy>=0.800; extra == \"test\"",
+            "psutil; extra == \"test\"",
+            "pyOpenSSL~=23.0.0; extra == \"test\"",
+            "pycodestyle~=2.9.0; extra == \"test\"",
+            "setuptools>=60; extra == \"dev\"",
+            "sphinx-rtd-theme~=0.5.2; extra == \"docs\"",
+            "sphinxcontrib-asyncio~=0.3.0; extra == \"docs\""
+          ],
+          "requires_python": ">=3.8.0",
+          "version": "0.21.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "7ca05cacf2e5c4a97d02a2878a24020daca21dbb8823b023b978210a75c79098",
+              "url": "https://files.pythonhosted.org/packages/4d/8c/a95d3ba1ccfa33a43649668f699150cce1ea795e4300c33b4c3e974a444b/watchfiles-1.0.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "275c1b0e942d335fccb6014d79267d1b9fa45b5ac0639c297f1e856f2f532552",
+              "url": "https://files.pythonhosted.org/packages/0d/d0/3d27a26f276ef07ca4cd3c6766684444317ddd147943e00bdb157cfdf3c3/watchfiles-1.0.3-cp310-cp310-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0b90651b4cf9e158d01faa0833b073e2e37719264bcee3eac49fc3c74e7d304b",
+              "url": "https://files.pythonhosted.org/packages/13/70/af75edf5b763f09e31a0f19ce045f3731db22599cb521807760b7d82b196/watchfiles-1.0.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "84fac88278f42d61c519a6c75fb5296fd56710b05bbdcc74bdf85db409a03780",
+              "url": "https://files.pythonhosted.org/packages/26/48/5a75b18ad40cc69ea6e0003bb748db162a3215bbe44a1293e073876d51bd/watchfiles-1.0.3-pp310-pypy310_pp73-macosx_10_12_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f3ff7da165c99a5412fe5dd2304dd2dbaaaa5da718aad942dcb3a178eaa70c56",
+              "url": "https://files.pythonhosted.org/packages/3c/7e/4569184ea04b501840771b8fcecee19b2233a8b72c196061263c0ef23c0b/watchfiles-1.0.3.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c2e9fe695ff151b42ab06501820f40d01310fbd58ba24da8923ace79cf6d702d",
+              "url": "https://files.pythonhosted.org/packages/4a/6e/8723f4b0967cc8d94f33fc531c33d66b596090b024f449983d3a8d97cfca/watchfiles-1.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "34e87c7b3464d02af87f1059fedda5484e43b153ef519e4085fe1a03dd94801e",
+              "url": "https://files.pythonhosted.org/packages/88/93/b10295ce8696e5e37f480ba4ae89e387e88ba425d72808c87d30f4cdefb1/watchfiles-1.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "889a37e2acf43c377b5124166bece139b4c731b61492ab22e64d371cce0e6e80",
+              "url": "https://files.pythonhosted.org/packages/ab/0c/38914f56a95aa6ec911bb7cee617762d93aaf5a11efecadbb698d6b0b9a2/watchfiles-1.0.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2b961b86cd3973f5822826017cad7f5a75795168cb645c3a6b30c349094e02e3",
+              "url": "https://files.pythonhosted.org/packages/bd/d6/99438baa225891bda882adefefc14c9023ef3cdaf9772cd47973bb566e96/watchfiles-1.0.3-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "90b0fe1fcea9bd6e3084b44875e179b4adcc4057a3b81402658d0eb58c98edf8",
+              "url": "https://files.pythonhosted.org/packages/c3/1a/8f928800d038d4fdb1e9df6e0c380c8cee17e6fb180e1faceb3f94de6df7/watchfiles-1.0.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d9dd2b89a16cf7ab9c1170b5863e68de6bf83db51544875b25a5f05a7269e678",
+              "url": "https://files.pythonhosted.org/packages/c5/3a/0359b7bddb1b7cbe6fb7096805b6e2f859f0de3d6130dcab9ac635db87e2/watchfiles-1.0.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1da46bb1eefb5a37a8fb6fd52ad5d14822d67c498d99bda8754222396164ae42",
+              "url": "https://files.pythonhosted.org/packages/cd/6c/7be04641c81209ea281b83b1174aa9d5ba53bec2a896d75a6b10428b4063/watchfiles-1.0.3-cp310-cp310-macosx_10_12_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c68be72b1666d93b266714f2d4092d78dc53bd11cf91ed5a3c16527587a52e29",
+              "url": "https://files.pythonhosted.org/packages/dc/b2/03ce3447a3271483b030b8bafc39be19739f9a4a23edec31c6688e8a066d/watchfiles-1.0.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2b4691234d31686dca133c920f94e478b548a8e7c750f28dbbc2e4333e0d3da9",
+              "url": "https://files.pythonhosted.org/packages/e2/a7/3400b4f105c68804495b76398165ffe6c00af93eab395279285f43cd0e42/watchfiles-1.0.3-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "62691f1c0894b001c7cde1195c03b7801aaa794a837bd6eef24da87d1542838d",
+              "url": "https://files.pythonhosted.org/packages/ee/5d/f3ca68a71d978d43168a65a1b4e1f72290c5350379aa148917e4ed0b2c46/watchfiles-1.0.3-cp310-cp310-musllinux_1_1_aarch64.whl"
+            }
+          ],
+          "project_name": "watchfiles",
+          "requires_dists": [
+            "anyio>=3.0.0"
+          ],
+          "requires_python": ">=3.9",
+          "version": "1.0.3"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859",
+              "url": "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5",
+              "url": "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz"
+            }
+          ],
+          "project_name": "wcwidth",
+          "requires_dists": [
+            "backports.functools-lru-cache>=1.2.1; python_version < \"3.2\""
+          ],
+          "requires_python": null,
+          "version": "0.2.13"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "4d4fc827a20abe6d544a119896f6b78ee13fe81cbfef416f3f2ddf09a03f0e2e",
+              "url": "https://files.pythonhosted.org/packages/b0/0b/c7e5d11020242984d9d37990310520ed663b942333b83a033c2f20191113/websockets-14.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "660c308dabd2b380807ab64b62985eaccf923a78ebc572bd485375b9ca2b7dc7",
+              "url": "https://files.pythonhosted.org/packages/13/97/b76979401f2373af1fe3e08f960b265cecab112e7dac803446fb98351a52/websockets-14.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3f14a96a0034a27f9d47fd9788913924c89612225878f8078bb9d55f859272b0",
+              "url": "https://files.pythonhosted.org/packages/3f/e6/752a2f5e8321ae2a613062676c08ff2fccfb37dc837a2ee919178a372e8a/websockets-14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1f874ba705deea77bcf64a9da42c1f5fc2466d8f14daf410bc7d4ceae0a9fcb0",
+              "url": "https://files.pythonhosted.org/packages/60/27/ca62de7877596926321b99071639275e94bb2401397130b7cf33dbf2106a/websockets-14.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "90b5d9dfbb6d07a84ed3e696012610b6da074d97453bd01e0e30744b472c8179",
+              "url": "https://files.pythonhosted.org/packages/61/8f/4d52f272d3ebcd35e1325c646e98936099a348374d4a6b83b524bded8116/websockets-14.1-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "034feb9f4286476f273b9a245fb15f02c34d9586a5bc936aff108c3ba1b21beb",
+              "url": "https://files.pythonhosted.org/packages/7a/2e/f12bbb41a8f2abb76428ba4fdcd9e67b5b364a3e7fa97c88f4d6950aa2d4/websockets-14.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9607b9a442392e690a57909c362811184ea429585a71061cd5d3c2b98065c199",
+              "url": "https://files.pythonhosted.org/packages/7e/db/f556a1d06635c680ef376be626c632e3f2bbdb1a0189d1d1bffb061c3b70/websockets-14.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ad2ab2547761d79926effe63de21479dfaf29834c50f98c4bf5b5480b5838434",
+              "url": "https://files.pythonhosted.org/packages/ac/98/7ac2e4eeada19bdbc7a3a66a58e3ebdf33648b9e1c5b3f08c3224df168cf/websockets-14.1-cp310-cp310-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "a0adf84bc2e7c86e8a202537b4fd50e6f7f0e4a6b6bf64d7ccb96c4cd3330b29",
+              "url": "https://files.pythonhosted.org/packages/af/91/b1b375dbd856fd5fff3f117de0e520542343ecaf4e8fc60f1ac1e9f5822c/websockets-14.1-cp310-cp310-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bea45f19b7ca000380fbd4e02552be86343080120d074b87f25593ce1700ad58",
+              "url": "https://files.pythonhosted.org/packages/b3/bc/99e5f511838c365ac6ecae19674eb5e94201aa4235bd1af3e6fa92c12905/websockets-14.1-cp310-cp310-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "04a97aca96ca2acedf0d1f332c861c5a4486fdcba7bcef35873820f940c4231e",
+              "url": "https://files.pythonhosted.org/packages/b7/a0/fa7c62e2952ef028b422fbf420f9353d9dd4dfaa425de3deae36e98c0784/websockets-14.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "df174ece723b228d3e8734a6f2a6febbd413ddec39b3dc592f5a4aa0aff28098",
+              "url": "https://files.pythonhosted.org/packages/c1/94/954b4924f868db31d5f0935893c7a8446515ee4b36bb8ad75a929469e453/websockets-14.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2177ee3901075167f01c5e335a6685e71b162a54a89a56001f1c3e9e3d2ad250",
+              "url": "https://files.pythonhosted.org/packages/c4/b1/29e87b53eb1937992cdee094a0988aadc94f25cf0b37e90c75eed7123d75/websockets-14.1-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "219c8187b3ceeadbf2afcf0f25a4918d02da7b944d703b97d12fb01510869078",
+              "url": "https://files.pythonhosted.org/packages/c6/e7/251491585bad61c79e525ac60927d96e4e17b18447cc9c3cfab47b2eb1b8/websockets-14.1-cp310-cp310-musllinux_1_2_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "398b10c77d471c0aab20a845e7a60076b6390bfdaac7a6d2edb0d2c59d75e8d8",
+              "url": "https://files.pythonhosted.org/packages/f4/1b/380b883ce05bb5f45a905b61790319a28958a9ab1e4b6b95ff5464b60ca1/websockets-14.1.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e5dc25a9dbd1a7f61eca4b7cb04e74ae4b963d658f9e4f9aad9cd00b688692c8",
+              "url": "https://files.pythonhosted.org/packages/fb/cd/382a05a1ba2a93bd9fb807716a660751295df72e77204fb130a102fcdd36/websockets-14.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl"
+            }
+          ],
+          "project_name": "websockets",
+          "requires_dists": [],
+          "requires_python": ">=3.9",
+          "version": "14.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "d2c63b93548eda58abf5188e505ffed0229bf675f7c3090f8e36ad55b8cbc371",
+              "url": "https://files.pythonhosted.org/packages/4b/d9/a8ba5e9507a9af1917285d118388c5eb7a81834873f45df213a6fe923774/wrapt-1.17.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "879591c2b5ab0a7184258274c42a126b74a2c3d5a329df16d69f9cee07bba6ea",
+              "url": "https://files.pythonhosted.org/packages/19/7c/5977aefa8460906c1ff914fd42b11cf6c09ded5388e46e1cc6cea4ab15e9/wrapt-1.17.0-cp310-cp310-musllinux_1_2_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "16187aa2317c731170a88ef35e8937ae0f533c402872c1ee5e6d079fcf320801",
+              "url": "https://files.pythonhosted.org/packages/24/a1/fc03dca9b0432725c2e8cdbf91a349d2194cf03d8523c124faebe581de09/wrapt-1.17.0.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0698d3a86f68abc894d537887b9bbf84d29bcfbc759e23f4644be27acf6da301",
+              "url": "https://files.pythonhosted.org/packages/93/81/b6c32d8387d9cfbc0134f01585dee7583315c3b46dfd3ae64d47693cd078/wrapt-1.17.0-cp310-cp310-musllinux_1_2_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2a0c23b8319848426f305f9cb0c98a6e32ee68a36264f45948ccf8e7d2b941f8",
+              "url": "https://files.pythonhosted.org/packages/99/f9/85220321e9bb1a5f72ccce6604395ae75fcb463d87dad0014dc1010bd1f1/wrapt-1.17.0-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e185ec6060e301a7e5f8461c86fb3640a7beb1a0f0208ffde7a65ec4074931df",
+              "url": "https://files.pythonhosted.org/packages/9f/0a/814d4a121a643af99cfe55a43e9e6dd08f4a47cdac8e8f0912c018794715/wrapt-1.17.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "fce6fee67c318fdfb7f285c29a82d84782ae2579c0e1b385b7f36c6e8074fffb",
+              "url": "https://files.pythonhosted.org/packages/ae/e7/233402d7bd805096bb4a8ec471f5a141421a01de3c8c957cce569772c056/wrapt-1.17.0-cp310-cp310-musllinux_1_2_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bb90765dd91aed05b53cd7a87bd7f5c188fcd95960914bae0d32c5e7f899719d",
+              "url": "https://files.pythonhosted.org/packages/cd/c7/b8c89bf5ca5c4e6a2d0565d149d549cdb4cffb8916d1d1b546b62fb79281/wrapt-1.17.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b1ca5f060e205f72bec57faae5bd817a1560fcfc4af03f414b08fa29106b7e2d",
+              "url": "https://files.pythonhosted.org/packages/ff/71/ff624ff3bde91ceb65db6952cdf8947bc0111d91bd2359343bc2fa7c57fd/wrapt-1.17.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            }
+          ],
+          "project_name": "wrapt",
+          "requires_dists": [],
+          "requires_python": ">=3.8",
+          "version": "1.17.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "8d85d38553855a1f8c40b8fbccca86af19202f91b244e2c7f77afbb2a6d9d785",
+              "url": "https://files.pythonhosted.org/packages/32/93/66826e2f50cefecbb0a44bd1e667316bf0a3c8e78cd1f0cdf52f5b2c5c6f/xgboost-2.1.3-py3-none-manylinux_2_28_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5d33090880f3d474f8cf5dda557c7bf8dbceefb62f2fd655c77efcabb9cac222",
+              "url": "https://files.pythonhosted.org/packages/0f/c8/f679a816c06a4a6d23da3f4b448d5f0615b51de2886ad3e3e695d17121b3/xgboost-2.1.3-py3-none-manylinux_2_28_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "fcbf1912a852bd07a7007be350c8dc3a484c5e775b612f2b3cd082fc76240eb3",
+              "url": "https://files.pythonhosted.org/packages/28/3c/ddf5d9eb742cdb7fbcd5c854bce07471bad01194ac37de91db64fbef0c58/xgboost-2.1.3-py3-none-macosx_12_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7699ec4226156887d3afc665c63ab87469db9d46e361c702ba9fccd22535730c",
+              "url": "https://files.pythonhosted.org/packages/48/b0/131ffc4a15fd3acee9be3a7baa6b2fa6faa479799c51b880de9fc3ddf550/xgboost-2.1.3.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "32a43526208fe676527c698cb852e0e9515e6d7294143780e476d335290a131b",
+              "url": "https://files.pythonhosted.org/packages/48/bc/05d7db90d421c5e3d681a12fd1eb087e37bf2e9bbe2b105422d6319ecc92/xgboost-2.1.3-py3-none-manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "27af88df1162cee016c67f267a0a16c3db1c48f256e12f64c45c8f8edf9571cd",
+              "url": "https://files.pythonhosted.org/packages/4a/3a/8cd69a216993fd9d54ceb079d1b357b7ef50678b3c2695d8a71962b8d0aa/xgboost-2.1.3-py3-none-manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c9b0c92f13e3650e1e1cf92ff9ecef3efc6f5dc3d10ce17858df2081a89976ef",
+              "url": "https://files.pythonhosted.org/packages/cd/c6/773ebd84414879bd0566788868ae46a6574f6efaf81e694f01ea1fed3277/xgboost-2.1.3-py3-none-macosx_10_15_x86_64.macosx_11_0_x86_64.macosx_12_0_x86_64.whl"
+            }
+          ],
+          "project_name": "xgboost",
+          "requires_dists": [
+            "cloudpickle; extra == \"pyspark\"",
+            "dask; extra == \"dask\"",
+            "datatable; extra == \"datatable\"",
+            "distributed; extra == \"dask\"",
+            "graphviz; extra == \"plotting\"",
+            "matplotlib; extra == \"plotting\"",
+            "numpy",
+            "nvidia-nccl-cu12; platform_system == \"Linux\" and platform_machine != \"aarch64\"",
+            "pandas; extra == \"dask\"",
+            "pandas>=1.2; extra == \"pandas\"",
+            "pyspark; extra == \"pyspark\"",
+            "scikit-learn; extra == \"pyspark\"",
+            "scikit-learn; extra == \"scikit-learn\"",
+            "scipy"
+          ],
+          "requires_python": ">=3.8",
+          "version": "2.1.3"
+        }
+      ],
+      "platform_tag": null
+    }
+  ],
+  "only_builds": [],
+  "only_wheels": [],
+  "path_mappings": {},
+  "pex_version": "2.3.1",
+  "pip_version": "24.0",
+  "prefer_older_binary": false,
+  "requirements": [
+    "IPython",
+    "Pillow>=8.4.0",
+    "PyYAML>=5.4.1",
+    "acsylla==0.2.0",
+    "awswrangler",
+    "boto3>=1.17.5",
+    "botocore",
+    "cassandra-driver",
+    "confluent-kafka>=1.9.2",
+    "fastapi<1.0.0",
+    "h3<4.0",
+    "httpx",
+    "ipykernel",
+    "joblib>=1.0.1",
+    "jsonschema",
+    "lifelines",
+    "lightgbm",
+    "matplotlib",
+    "matplotlib-venn",
+    "numpy<=1.24.4,>=1.21.4; python_version < \"3.9\"",
+    "numpy<=1.26.4; python_version >= \"3.9\"",
+    "optuna",
+    "pandas<2.0,>=1.4.0",
+    "parameters-validation>=1.2.0",
+    "plotly==5.5.0",
+    "prometheus-client",
+    "pyarrow!=12.0.1,>=5.0.0",
+    "pydantic!=2.6.0,>=2.5.0",
+    "pydot<2.0.0,>=1.4.2",
+    "pyspark==3.2.1; python_version == \"3.8\"",
+    "pyspark==3.4.1; python_version == \"3.10\"",
+    "pytest",
+    "pytest-asyncio",
+    "pytest-spark",
+    "python-slugify",
+    "qdrant-client",
+    "requests",
+    "scikit-learn>=1.2.0",
+    "scipy",
+    "seaborn",
+    "sentry-sdk[fastapi]",
+    "setuptools",
+    "shap",
+    "statsmodels",
+    "tabulate",
+    "typer",
+    "typing_extensions",
+    "uvicorn[standard]<1.0.0",
+    "xgboost"
+  ],
+  "requires_python": [
+    "<3.11,>=3.10"
+  ],
+  "resolver_version": "pip-2020-resolver",
+  "style": "universal",
+  "target_systems": [
+    "linux",
+    "mac"
+  ],
+  "transitive": true,
+  "use_pep517": null
+}
+

--- a/tests/integration/cli/commands/test_lock_subset.py
+++ b/tests/integration/cli/commands/test_lock_subset.py
@@ -17,6 +17,7 @@ from pex.resolve.locked_resolve import LockedRequirement
 from pex.resolve.lockfile import json_codec
 from pex.resolve.lockfile.model import Lockfile
 from pex.sorted_tuple import SortedTuple
+from testing import PY_VER, data
 from testing.cli import run_pex3
 from testing.pytest.tmp import Tempdir
 
@@ -176,3 +177,18 @@ def test_lock_subset_extra_miss(
             "requirement.".format(lock=lock)
         )
     )
+
+
+@pytest.mark.skipif(
+    PY_VER < (3, 7), reason="The test locks click 8.1.7 which requires Python >=3.7"
+)
+def test_lock_subset_target_systems_and_ics_issue_2683(tmpdir):
+    # type: (Tempdir) -> None
+
+    lock = data.path("locks", "issue-2683.lock.json")
+    subset_lock = tmpdir.join("subset-lock.json")
+    run_pex3("lock", "subset", "--lock", lock, "click", "-o", subset_lock, "--indent", "2").assert_success()
+
+    subset_lockfile, subset_locked_reqs = index(subset_lock)
+    assert SortedTuple([Requirement.parse("click")]) == subset_lockfile.requirements
+    assert {ProjectName("click")} == set(subset_locked_reqs)

--- a/tests/integration/cli/commands/test_lock_subset.py
+++ b/tests/integration/cli/commands/test_lock_subset.py
@@ -187,7 +187,9 @@ def test_lock_subset_target_systems_and_ics_issue_2683(tmpdir):
 
     lock = data.path("locks", "issue-2683.lock.json")
     subset_lock = tmpdir.join("subset-lock.json")
-    run_pex3("lock", "subset", "--lock", lock, "click", "-o", subset_lock, "--indent", "2").assert_success()
+    run_pex3(
+        "lock", "subset", "--lock", lock, "click", "-o", subset_lock, "--indent", "2"
+    ).assert_success()
 
     subset_lockfile, subset_locked_reqs = index(subset_lock)
     assert SortedTuple([Requirement.parse("click")]) == subset_lockfile.requirements


### PR DESCRIPTION
Lock subsetting could crash previously. Also fix
`pex3 lock {create,sync,update} --elide-unused-requires-dist`, which
would not crash, but would fail to elide some dists.

Fixes #2683