### PR TITLE
Consistently use `\n` for EOL in output.

### DIFF
--- a/pex/cli/commands/lock.py
+++ b/pex/cli/commands/lock.py
@@ -2077,7 +2077,7 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
             )
             if sync_target.command:
                 return Ok(
-                    os.linesep.join(
+                    "\n".join(
                         (
                             would_update_venv_msg + " and run the following command in it:",
                             "  " + " ".join(shlex_quote(arg) for arg in sync_target.command),

--- a/pex/dist_metadata.py
+++ b/pex/dist_metadata.py
@@ -705,7 +705,7 @@ def requires_dists(location):
                 project_name=metadata_files.metadata.project_name,
                 count=len(legacy_requires),
                 field=pluralize(legacy_requires, "field"),
-                requires=os.linesep.join(
+                requires="\n".join(
                     "{index}.) Requires: {req}".format(index=index, req=req)
                     for index, req in enumerate(legacy_requires, start=1)
                 ),

--- a/pex/docs/server.py
+++ b/pex/docs/server.py
@@ -78,7 +78,7 @@ class Pidfile(object):
         while time.time() - start < timeout:
             with open(server_log) as fp:
                 for line in fp:
-                    if line.endswith(os.linesep):
+                    if line.endswith(("\r", "\n")):
                         match = re.search(r"Serving HTTP on 0\.0\.0\.0 port (?P<port>\d+)", line)
                         if match:
                             port = match.group("port")
@@ -140,7 +140,7 @@ class LaunchError(Exception):
         if self.additional_msg:
             lines.append(self.additional_msg)
         lines.append("See the log at {log} for more details.".format(log=self.log))
-        return os.linesep.join(lines)
+        return "\n".join(lines)
 
 
 def launch(

--- a/pex/pep_723.py
+++ b/pex/pep_723.py
@@ -3,7 +3,6 @@
 
 from __future__ import absolute_import
 
-import os
 import re
 from collections import OrderedDict
 
@@ -53,7 +52,7 @@ class MetadataBlock(object):
 
     def parse_metadata(self):
         # type: () -> Mapping[str, Any]
-        stripped_content = os.linesep.join(
+        stripped_content = "\n".join(
             line[2:] if line.startswith("# ") else line[1:] for line in self.content
         )
         try:

--- a/pex/repl/pex_repl.py
+++ b/pex/repl/pex_repl.py
@@ -231,7 +231,7 @@ def _create_repl_data(
             """
         )
         .format(
-            pex_header=os.linesep.join(pex_header),
+            pex_header="\n".join(pex_header),
             python_version=sys.version,
             platform=sys.platform,
             more_info_footer=more_info_footer,
@@ -241,7 +241,7 @@ def _create_repl_data(
 
     return _REPLData(
         banner=banner,
-        pex_info_summary=os.linesep.join(pex_info_summary),
+        pex_info_summary="\n".join(pex_info_summary),
         ps1=">>>",
         ps2="...",
     )

--- a/pex/resolve/downloads.py
+++ b/pex/resolve/downloads.py
@@ -175,7 +175,7 @@ class ArtifactDownloader(object):
             except Job.Error as e:
                 error_lines = list(e.contextualized_stderr()) or str(e).splitlines()
                 return Error(
-                    os.linesep.join(error_lines)
+                    "\n".join(error_lines)
                     if "See above for details" in error_lines[-1]
                     else error_lines[-1]
                 )

--- a/pex/resolve/lockfile/updater.py
+++ b/pex/resolve/lockfile/updater.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 import itertools
 import logging
-import os
 from collections import OrderedDict
 from contextlib import contextmanager
 
@@ -423,7 +422,7 @@ class ResolveUpdater(object):
             return
 
         with named_temporary_file(prefix="lock_update.", suffix=".constraints.txt", mode="w") as fp:
-            fp.write(os.linesep.join(constraints))
+            fp.write("\n".join(constraints))
             fp.flush()
             constraint_files = [fp.name]
             if self.requirement_configuration.constraint_files:

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -416,15 +416,14 @@ class BuildResult(object):
                             incompatible = not wheel_tag_match
             if incompatible:
                 raise ValueError(
-                    "No pre-built wheel was available for {project_name} {version}.{eol}"
+                    "No pre-built wheel was available for {project_name} {version}.\n"
                     "Successfully built the wheel {wheel} from the sdist {sdist} but it is not "
-                    "compatible with the requested foreign target {target}.{eol}"
+                    "compatible with the requested foreign target {target}.\n"
                     "You'll need to build a wheel from {sdist} on the foreign target platform and "
                     "make it available to Pex via a `--find-links` repo or a custom "
                     "`--index`.".format(
                         project_name=wheel.project_name,
                         version=wheel.version,
-                        eol=os.linesep,
                         wheel=os.path.basename(wheel_path),
                         sdist=os.path.basename(self.request.source_path),
                         target=self.request.target.render_description(),

--- a/pex/venv/venv_pex.py
+++ b/pex/venv/venv_pex.py
@@ -198,9 +198,7 @@ def boot(
     if ignored_pex_env_vars:
         maybe_log(
             "Ignoring the following environment variables in Pex venv mode:\n"
-            "{ignored_env_vars}".format(
-                ignored_env_vars=os.linesep.join(sorted(ignored_pex_env_vars))
-            )
+            "{ignored_env_vars}".format(ignored_env_vars="\n".join(sorted(ignored_pex_env_vars)))
         )
 
     os.environ["VIRTUAL_ENV"] = venv_dir

--- a/pex/ziputils.py
+++ b/pex/ziputils.py
@@ -46,7 +46,7 @@ class _Zip64Error(ZipError):
             "Please file an issue at https://github.com/pex-tool/pex/issues/new that includes "
             "this full backtrace if you need this support."
         )
-        return os.linesep.join(message_lines)
+        return "\n".join(message_lines)
 
 
 _MAX_2_BYTES = 0xFFFF

--- a/scripts/analyze-CI-shard-timeout.py
+++ b/scripts/analyze-CI-shard-timeout.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import os
 import re
 import sys
 from pathlib import Path
@@ -28,7 +27,8 @@ def analyze(log: Path) -> Any:
 
     hung_tests = sorted(test for test, complete in tests.items() if not complete)
     if hung_tests:
-        return f"The following tests never finished:\n{os.linesep.join(hung_tests)}"
+        hung_tests_lines = "\n".join(hung_tests)
+        return f"The following tests never finished:\n{hung_tests_lines}"
 
 
 def main() -> Any:

--- a/scripts/build-cache-image.py
+++ b/scripts/build-cache-image.py
@@ -253,7 +253,7 @@ def main() -> Any:
         bad_tox_envs = selected_tox_envs - all_tox_envs
         if bad_tox_envs:
             return colors.red(
-                os.linesep.join(
+                "\n".join(
                     (
                         "The following selected tox envs are not used in Linux CI test shards:",
                         *(f"  {bad_tox_env}" for bad_tox_env in sorted(bad_tox_envs)),

--- a/scripts/create-packages.py
+++ b/scripts/create-packages.py
@@ -141,9 +141,9 @@ def build_pex_scies(
         artifacts = glob.glob(f"{output_file}*")
         scie_artifacts = [artifact for artifact in artifacts if not artifact.endswith(".sha256")]
         if len(scie_artifacts) != 1:
+            artifact_lines = "\n".join(sorted(artifacts))
             raise SystemExit(
-                f"Found unexpected artifacts after generating Pex scie:{os.linesep}"
-                f"{os.linesep.join(sorted(artifacts))}"
+                f"Found unexpected artifacts after generating Pex scie:\n{artifact_lines}"
             )
         scie_name = os.path.basename(scie_artifacts[0])
         for artifact in artifacts:

--- a/tests/integration/cli/commands/test_lock.py
+++ b/tests/integration/cli/commands/test_lock.py
@@ -923,7 +923,7 @@ def test_update_targeted_impossible(
                 pip_to="pip" if pip_version.version < PipVersion.v24_1.version else "pip to"
             ),
         ]
-    assert expected_lines == error_lines[12:], os.linesep.join(
+    assert expected_lines == error_lines[12:], "\n".join(
         difflib.unified_diff(expected_lines, error_lines[12:])
     )
 
@@ -1023,7 +1023,7 @@ def test_update_add_impossible(
                 pip_to="pip" if pip_version.version < PipVersion.v24_1.version else "pip to"
             ),
         ]
-    assert expected_lines == error_lines[13:], os.linesep.join(
+    assert expected_lines == error_lines[13:], "\n".join(
         difflib.unified_diff(expected_lines, error_lines[12:])
     )
 

--- a/tests/integration/scie/test_pex_scie.py
+++ b/tests/integration/scie/test_pex_scie.py
@@ -908,7 +908,7 @@ def test_scie_busybox_console_script_inject_python_args(
             in output_lines
         )
         stderr_import_logging = any(line.startswith("import ") for line in output_lines)
-        assert expect_python_verbose is stderr_import_logging, os.linesep.join(output_lines)
+        assert expect_python_verbose is stderr_import_logging, "\n".join(output_lines)
 
     assert_output(
         args=[busybox, "foo-script-ad-hoc"],

--- a/tests/resolve/test_pex_repository_resolver.py
+++ b/tests/resolve/test_pex_repository_resolver.py
@@ -1,6 +1,8 @@
 # Copyright 2022 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import absolute_import, print_function
+
 import os
 import re
 from collections import defaultdict
@@ -62,7 +64,7 @@ def create_constraints_file(*requirements):
     constraints_file = os.path.join(safe_mkdtemp(), "constraints.txt")
     with open(constraints_file, "w") as fp:
         for requirement in requirements:
-            fp.write(requirement + os.linesep)
+            print(requirement, file=fp)
     return constraints_file
 
 

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -516,7 +516,7 @@ def test_sys_path(python):
     # type: (str) -> None
 
     interp = PythonInterpreter.from_binary(python)
-    _, stdout, _ = interp.execute(args=["-c", "import os, sys; print(os.linesep.join(sys.path))"])
+    _, stdout, _ = interp.execute(args=["-c", r"import sys; print('\n'.join(sys.path))"])
     assert tuple(entry for entry in stdout.splitlines() if entry) == interp.sys_path, (
         'Its expected the sys_path matches the runtime sys.path with the exception of the PWD ("") '
         "head entry."


### PR DESCRIPTION
It's up to tests to use `os.linesep` when reading and testing outputs.
Many tests still are not fixed, but all production outputs are.

More work towards #2658.