### PR TITLE
Tests: `os.execv` -> `sys.exit(subprocess.call())`.

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1477,6 +1477,7 @@ def test_unzip_mode(tmpdir):
             dedent(
                 """\
                 import os
+                import subprocess
                 import sys
 
                 if 'quit' == sys.argv[-1]:
@@ -1486,7 +1487,7 @@ def test_unzip_mode(tmpdir):
                 print(' '.join(sys.argv[1:]))
                 sys.stdout.flush()
                 sys.stderr.flush()
-                os.execv(sys.executable, [sys.executable] + sys.argv[:-1])
+                sys.exit(subprocess.call([sys.executable] + sys.argv[:-1]))
                 """
             )
         )

--- a/tests/integration/venv_ITs/test_issue_2065.py
+++ b/tests/integration/venv_ITs/test_issue_2065.py
@@ -36,6 +36,7 @@ def test_venv_pex_script_non_hermetic(
             dedent(
                 """\
                 import os
+                import subprocess
                 import sys
 
                 def run():
@@ -45,7 +46,7 @@ def test_venv_pex_script_non_hermetic(
                         pythonpath.extend(existing_pythonpath.split(os.pathsep))
                     os.environ["PYTHONPATH"] = os.pathsep.join(pythonpath)
 
-                    os.execv(sys.argv[1], sys.argv[1:])
+                    sys.exit(subprocess.call(sys.argv[1:]))
                 """
             )
         )


### PR DESCRIPTION
To accommodate Windows.

More work towards #2658.