### PR TITLE
Fix inappropriate `":"` -> `os.pathsep` in tests.

### DIFF
--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -325,20 +325,24 @@ def test_pex_run_extra_sys_path():
     with named_temporary_file() as fake_stdout:
         with temporary_dir() as temp_dir:
             pex = write_simple_pex(
-                temp_dir, 'import sys; sys.stdout.write(":".join(sys.path)); sys.exit(0)'
+                temp_dir, "import os, sys; sys.stdout.write(os.pathsep.join(sys.path)); sys.exit(0)"
             )
             rc = PEX(pex.path()).run(
                 stdin=None,
                 stdout=fake_stdout,
                 stderr=None,
-                env={"PEX_EXTRA_SYS_PATH": "extra/syspath/entry1:extra/syspath/entry2"},
+                env={
+                    "PEX_EXTRA_SYS_PATH": os.pathsep.join(
+                        ("extra/syspath/entry1", "extra/syspath/entry2")
+                    )
+                },
             )
             assert rc == 0
 
             fake_stdout.seek(0)
-            syspath = fake_stdout.read().split(b":")
-            assert b"extra/syspath/entry1" in syspath
-            assert b"extra/syspath/entry2" in syspath
+            syspath = fake_stdout.read().decode("utf-8").split(os.pathsep)
+            assert "extra/syspath/entry1" in syspath
+            assert "extra/syspath/entry2" in syspath
 
 
 @attr.s(frozen=True)

--- a/tests/test_pex_bootstrapper.py
+++ b/tests/test_pex_bootstrapper.py
@@ -278,7 +278,7 @@ def test_pp_exact_on_ppp():
 
     with ENV.patch(
         PEX_PYTHON=py310,
-        PEX_PYTHON_PATH=":".join(os.path.dirname(py) for py in (py38, py39, py310)),
+        PEX_PYTHON_PATH=os.pathsep.join(os.path.dirname(py) for py in (py38, py39, py310)),
     ):
         assert PythonInterpreter.from_binary(py310) == find_compatible_interpreter()
 
@@ -325,7 +325,8 @@ def test_pp_exact_not_on_ppp():
     py310 = ensure_python_interpreter(PY310)
 
     with ENV.patch(
-        PEX_PYTHON=py310, PEX_PYTHON_PATH=":".join(os.path.dirname(py) for py in (py38, py39))
+        PEX_PYTHON=py310,
+        PEX_PYTHON_PATH=os.pathsep.join(os.path.dirname(py) for py in (py38, py39)),
     ):
         with pytest.raises(
             UnsatisfiableInterpreterConstraintsError,


### PR DESCRIPTION
More work towards #2658.