### PR TITLE
Switch tests to use custom subprocess module.

### DIFF
--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -10,7 +10,6 @@ import os
 import platform
 import random
 import re
-import subprocess
 import sys
 from collections import Counter
 from contextlib import contextmanager
@@ -33,6 +32,10 @@ from pex.sysconfig import SCRIPT_DIR, script_name
 from pex.typing import TYPE_CHECKING, cast
 from pex.util import named_temporary_file
 from pex.venv.virtualenv import InstallationChoice, Virtualenv
+
+# Explicitly re-export subprocess to enable a transparent substitution in tests that supports
+# executing PEX files directly on Windows.
+from testing import subprocess as subprocess
 
 try:
     from unittest import mock

--- a/testing/subprocess.py
+++ b/testing/subprocess.py
@@ -1,0 +1,78 @@
+# Copyright 2025 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os
+import subprocess
+import sys
+
+from pex.executables import is_python_script
+from pex.os import WINDOWS
+from pex.pex_info import PexInfo
+from pex.typing import TYPE_CHECKING, cast
+from pex.venv.virtualenv import InvalidVirtualenvError, Virtualenv
+
+if TYPE_CHECKING:
+    from typing import Any, List, Optional, Sequence
+
+
+PIPE = subprocess.PIPE
+STDOUT = subprocess.STDOUT
+CalledProcessError = subprocess.CalledProcessError
+
+
+def _maybe_load_pex_info(path):
+    # type: (str) -> Optional[PexInfo]
+    try:
+        return PexInfo.from_pex(path)
+    except (KeyError, IOError, OSError):
+        return None
+
+
+def _safe_args(args):
+    # type: (Sequence[str]) -> List[str]
+    if WINDOWS:
+        argv0 = args[0]
+        pex_info = _maybe_load_pex_info(argv0)
+        if pex_info and is_python_script(argv0, check_executable=False):
+            try:
+                return [Virtualenv(os.path.dirname(argv0)).interpreter.binary] + list(args)
+            except InvalidVirtualenvError:
+                pass
+        if pex_info or argv0.endswith(".py"):
+            return [sys.executable] + list(args)
+    return args if isinstance(args, list) else list(args)
+
+
+def call(
+    args,  # type: Sequence[str]
+    **kwargs  # type: Any
+):
+    # type: (...) -> int
+    return subprocess.call(args=_safe_args(args), **kwargs)
+
+
+def check_call(
+    args,  # type: Sequence[str]
+    **kwargs  # type: Any
+):
+    # type: (...) -> None
+    subprocess.check_call(args=_safe_args(args), **kwargs)
+
+
+def check_output(
+    args,  # type: Sequence[str]
+    **kwargs  # type: Any
+):
+    # type: (...) -> bytes
+    return cast(bytes, subprocess.check_output(args=_safe_args(args), **kwargs))
+
+
+class Popen(subprocess.Popen):
+    def __init__(
+        self,
+        args,  # type: Sequence[str]
+        **kwargs  # type: Any
+    ):
+        super(Popen, self).__init__(_safe_args(args), **kwargs)  # type: ignore[call-arg]

--- a/tests/build_system/test_pep_518.py
+++ b/tests/build_system/test_pep_518.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-import subprocess
 from textwrap import dedent
 
 from pex.build_system import pep_518
@@ -15,6 +14,7 @@ from pex.targets import LocalInterpreter
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
 from pex.venv.virtualenv import Virtualenv
+from testing import subprocess
 from testing.build_system import hatchling_only_supports_37_and_greater
 
 if TYPE_CHECKING:

--- a/tests/integration/build_system/test_pep_518.py
+++ b/tests/integration/build_system/test_pep_518.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-import subprocess
 
 from pex.build_system.pep_518 import BuildSystem, load_build_system
 from pex.pip.version import PipVersion
@@ -10,7 +9,7 @@ from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.resolver_configuration import PipConfiguration, ReposConfiguration
 from pex.targets import LocalInterpreter
 from pex.typing import TYPE_CHECKING
-from testing import make_env, run_pex_command
+from testing import make_env, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/cli/commands/test_cache_prune.py
+++ b/tests/integration/cli/commands/test_cache_prune.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 import os.path
 import shutil
-import subprocess
 import time
 from datetime import datetime, timedelta
 from textwrap import dedent
@@ -33,7 +32,7 @@ from pex.pex_info import PexInfo
 from pex.pip.version import PipVersion, PipVersionValue
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 from testing.cli import run_pex3
 from testing.pytest.tmp import Tempdir
 

--- a/tests/integration/cli/commands/test_issue_1413.py
+++ b/tests/integration/cli/commands/test_issue_1413.py
@@ -3,7 +3,6 @@
 
 import os
 import shutil
-import subprocess
 
 import pytest
 
@@ -15,7 +14,7 @@ from pex.resolve.lockfile.model import Lockfile
 from pex.resolve.path_mappings import PathMapping, PathMappings
 from pex.resolve.resolved_requirement import ArtifactURL, Pin
 from pex.typing import TYPE_CHECKING
-from testing import make_env, run_pex_command
+from testing import make_env, run_pex_command, subprocess
 from testing.cli import run_pex3
 from testing.pytest.tmp import Tempdir, TempdirFactory
 

--- a/tests/integration/cli/commands/test_issue_1667.py
+++ b/tests/integration/cli/commands/test_issue_1667.py
@@ -2,14 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-import subprocess
 import sys
 
 import pytest
 
 from pex.interpreter import PythonInterpreter
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 from testing.cli import run_pex3
 
 if TYPE_CHECKING:

--- a/tests/integration/cli/commands/test_issue_1688.py
+++ b/tests/integration/cli/commands/test_issue_1688.py
@@ -2,13 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 
 from pex.interpreter import PythonInterpreter
 from pex.pex_info import PexInfo
 from pex.resolve.lockfile import json_codec
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 from testing.cli import run_pex3
 
 if TYPE_CHECKING:

--- a/tests/integration/cli/commands/test_issue_1734.py
+++ b/tests/integration/cli/commands/test_issue_1734.py
@@ -3,12 +3,11 @@
 
 import os
 import re
-import subprocess
 
 from pex.interpreter import PythonInterpreter
 from pex.interpreter_constraints import InterpreterConstraint
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 from testing.cli import run_pex3
 
 if TYPE_CHECKING:

--- a/tests/integration/cli/commands/test_issue_2050.py
+++ b/tests/integration/cli/commands/test_issue_2050.py
@@ -3,7 +3,6 @@
 import json
 import os
 import re
-import subprocess
 import sys
 import tempfile
 from textwrap import dedent
@@ -23,7 +22,15 @@ from pex.sorted_tuple import SortedTuple
 from pex.targets import LocalInterpreter
 from pex.third_party.packaging.specifiers import SpecifierSet
 from pex.typing import TYPE_CHECKING
-from testing import IS_LINUX, PY310, PY_VER, ensure_python_interpreter, make_env, run_pex_command
+from testing import (
+    IS_LINUX,
+    PY310,
+    PY_VER,
+    ensure_python_interpreter,
+    make_env,
+    run_pex_command,
+    subprocess,
+)
 from testing.cli import run_pex3
 
 if TYPE_CHECKING:

--- a/tests/integration/cli/commands/test_issue_2057.py
+++ b/tests/integration/cli/commands/test_issue_2057.py
@@ -3,7 +3,6 @@
 
 import os.path
 import shutil
-import subprocess
 import tempfile
 from textwrap import dedent
 
@@ -12,7 +11,7 @@ import pytest
 
 from pex.resolve.lockfile import json_codec
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 from testing.cli import run_pex3
 
 if TYPE_CHECKING:

--- a/tests/integration/cli/commands/test_local_project_lock.py
+++ b/tests/integration/cli/commands/test_local_project_lock.py
@@ -4,7 +4,6 @@
 import os
 import re
 import shutil
-import subprocess
 
 import pytest
 
@@ -12,7 +11,7 @@ from pex.common import touch
 from pex.interpreter import PythonInterpreter
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import InstallationChoice, Virtualenv
-from testing import PY27, ensure_python_interpreter, run_pex_command
+from testing import PY27, ensure_python_interpreter, run_pex_command, subprocess
 from testing.cli import run_pex3
 
 if TYPE_CHECKING:

--- a/tests/integration/cli/commands/test_lock.py
+++ b/tests/integration/cli/commands/test_lock.py
@@ -5,7 +5,6 @@ import json
 import os
 import re
 import shutil
-import subprocess
 import sys
 from textwrap import dedent
 
@@ -43,6 +42,7 @@ from testing import (
     ensure_python_interpreter,
     make_env,
     run_pex_command,
+    subprocess,
 )
 from testing.build_system import hatchling_only_supports_37_and_greater
 from testing.cli import run_pex3

--- a/tests/integration/cli/commands/test_lock_foreign_platform_sdist.py
+++ b/tests/integration/cli/commands/test_lock_foreign_platform_sdist.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import
 
 import os.path
-import subprocess
 from textwrap import dedent
 
 import pytest
@@ -15,7 +14,7 @@ from pex.common import safe_open
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.result import try_
 from pex.typing import TYPE_CHECKING
-from testing import PY_VER, data, run_pex_command
+from testing import PY_VER, data, run_pex_command, subprocess
 from testing.cli import run_pex3
 
 if TYPE_CHECKING:

--- a/tests/integration/cli/commands/test_lock_reproducibility_hash_seed.py
+++ b/tests/integration/cli/commands/test_lock_reproducibility_hash_seed.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 import filecmp
 import os.path
-import subprocess
 from textwrap import dedent
 
 import pytest
@@ -13,6 +12,7 @@ from tools.commands.test_venv import make_env
 
 from pex.common import safe_open
 from pex.typing import TYPE_CHECKING
+from testing import subprocess
 from testing.cli import run_pex3
 
 if TYPE_CHECKING:

--- a/tests/integration/cli/commands/test_lock_sync.py
+++ b/tests/integration/cli/commands/test_lock_sync.py
@@ -7,7 +7,6 @@ import filecmp
 import os.path
 import re
 import shutil
-import subprocess
 import sys
 from textwrap import dedent
 
@@ -46,6 +45,7 @@ from testing import (
     ensure_python_interpreter,
     make_env,
     re_exact,
+    subprocess,
 )
 from testing.cli import run_pex3
 from testing.find_links import FindLinksRepo

--- a/tests/integration/cli/commands/test_lock_update.py
+++ b/tests/integration/cli/commands/test_lock_update.py
@@ -5,7 +5,6 @@ import itertools
 import os
 import re
 import shutil
-import subprocess
 
 import pytest
 
@@ -17,7 +16,7 @@ from pex.resolve.lockfile import json_codec
 from pex.resolve.lockfile.model import Lockfile
 from pex.resolve.resolved_requirement import ArtifactURL
 from pex.typing import TYPE_CHECKING
-from testing import make_env, run_pex_command
+from testing import make_env, run_pex_command, subprocess
 from testing.cli import run_pex3
 
 if TYPE_CHECKING:

--- a/tests/integration/cli/commands/test_vcs_lock.py
+++ b/tests/integration/cli/commands/test_vcs_lock.py
@@ -4,7 +4,6 @@
 import filecmp
 import os.path
 import shutil
-import subprocess
 import sys
 import tempfile
 from textwrap import dedent
@@ -17,7 +16,7 @@ from pex.common import safe_open
 from pex.resolve.locked_resolve import VCSArtifact
 from pex.resolve.lockfile import json_codec
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 from testing.cli import run_pex3
 
 if TYPE_CHECKING:

--- a/tests/integration/cli/commands/test_venv_create.py
+++ b/tests/integration/cli/commands/test_venv_create.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import
 import glob
 import os.path
 import shutil
-import subprocess
 import sys
 from textwrap import dedent
 
@@ -25,7 +24,15 @@ from pex.pex import PEX
 from pex.resolve import abbreviated_platforms
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import Virtualenv
-from testing import IS_MAC, PY39, PY310, ensure_python_interpreter, make_env, run_pex_command
+from testing import (
+    IS_MAC,
+    PY39,
+    PY310,
+    ensure_python_interpreter,
+    make_env,
+    run_pex_command,
+    subprocess,
+)
 from testing.cli import run_pex3
 from testing.pytest.tmp import Tempdir, TempdirFactory
 

--- a/tests/integration/cli/commands/test_venv_inspect.py
+++ b/tests/integration/cli/commands/test_venv_inspect.py
@@ -3,7 +3,6 @@
 
 import json
 import os.path
-import subprocess
 import sys
 
 import pytest
@@ -21,6 +20,7 @@ from testing import (
     ensure_python_venv,
     make_env,
     run_pex_command,
+    subprocess,
 )
 from testing.cli import run_pex3
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 import glob
 import os
-import subprocess
 
 import pytest
 
@@ -14,7 +13,7 @@ from pex.common import temporary_dir
 from pex.interpreter import PythonInterpreter
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import Virtualenv
-from testing import PY310, data, ensure_python_interpreter, make_env, run_pex_command
+from testing import PY310, data, ensure_python_interpreter, make_env, run_pex_command, subprocess
 from testing.mitmproxy import Proxy
 
 if TYPE_CHECKING:

--- a/tests/integration/resolve/test_dependency_groups.py
+++ b/tests/integration/resolve/test_dependency_groups.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import
 
 import os.path
-import subprocess
 from textwrap import dedent
 
 import colors  # vendor:skip
@@ -13,7 +12,7 @@ from pex.common import safe_open
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.pex import PEX
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 from testing.pytest.tmp import Tempdir
 
 

--- a/tests/integration/resolve/test_issue_1907.py
+++ b/tests/integration/resolve/test_issue_1907.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import
 import glob
 import os.path
 import re
-import subprocess
 import sys
 from textwrap import dedent
 
@@ -19,7 +18,7 @@ from pex.pep_503 import ProjectName
 from pex.pex import PEX
 from pex.pip.version import PipVersion
 from pex.typing import TYPE_CHECKING
-from testing import IS_PYPY, PY_VER, data, run_pex_command
+from testing import IS_PYPY, PY_VER, data, run_pex_command, subprocess
 from testing.cli import run_pex3
 
 if TYPE_CHECKING:

--- a/tests/integration/resolve/test_issue_1918.py
+++ b/tests/integration/resolve/test_issue_1918.py
@@ -3,7 +3,6 @@
 
 import itertools
 import os.path
-import subprocess
 
 import pytest
 
@@ -17,7 +16,7 @@ from pex.resolve.resolved_requirement import ArtifactURL
 from pex.resolve.resolver_configuration import ResolverVersion
 from pex.sorted_tuple import SortedTuple
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 from testing.cli import run_pex3
 
 if TYPE_CHECKING:

--- a/tests/integration/resolve/test_issue_2412.py
+++ b/tests/integration/resolve/test_issue_2412.py
@@ -7,7 +7,6 @@ import filecmp
 import os.path
 import re
 import shutil
-import subprocess
 from textwrap import dedent
 
 from colors import color  # vendor:skip
@@ -15,7 +14,7 @@ from colors import color  # vendor:skip
 from pex.common import safe_open, touch
 from pex.targets import LocalInterpreter
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 from testing.cli import run_pex3
 
 if TYPE_CHECKING:

--- a/tests/integration/resolve/test_issue_2532.py
+++ b/tests/integration/resolve/test_issue_2532.py
@@ -4,11 +4,10 @@
 from __future__ import absolute_import
 
 import os
-import subprocess
 from textwrap import dedent
 
 from pex.typing import TYPE_CHECKING
-from testing import WheelBuilder
+from testing import WheelBuilder, subprocess
 from testing.docker import skip_unless_docker
 
 if TYPE_CHECKING:

--- a/tests/integration/scie/test_discussion_2516.py
+++ b/tests/integration/scie/test_discussion_2516.py
@@ -5,13 +5,12 @@ from __future__ import absolute_import
 
 import glob
 import os.path
-import subprocess
 from textwrap import dedent
 
 from pex.common import safe_open
 from pex.sysconfig import SysPlatform
 from pex.typing import TYPE_CHECKING
-from testing import make_env, run_pex_command
+from testing import make_env, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/scie/test_pex_scie.py
+++ b/tests/integration/scie/test_pex_scie.py
@@ -8,7 +8,6 @@ import json
 import os.path
 import re
 import shutil
-import subprocess
 import sys
 from textwrap import dedent
 from typing import Optional
@@ -27,7 +26,7 @@ from pex.sysconfig import SysPlatform
 from pex.targets import LocalInterpreter
 from pex.typing import TYPE_CHECKING
 from pex.version import __version__
-from testing import IS_PYPY, PY_VER, make_env, run_pex_command
+from testing import IS_PYPY, PY_VER, make_env, run_pex_command, subprocess
 from testing.scie import skip_if_no_provider
 
 if TYPE_CHECKING:

--- a/tests/integration/test_excludes.py
+++ b/tests/integration/test_excludes.py
@@ -8,7 +8,6 @@ import json
 import os.path
 import re
 import shutil
-import subprocess
 from os.path import commonprefix
 from textwrap import dedent
 from typing import Iterator
@@ -28,7 +27,7 @@ from pex.resolve.resolver_configuration import ResolverVersion
 from pex.sorted_tuple import SortedTuple
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import InstallationChoice, Virtualenv
-from testing import PY_VER, IntegResults, data, make_env, run_pex_command
+from testing import PY_VER, IntegResults, data, make_env, run_pex_command, subprocess
 from testing.cli import run_pex3
 from testing.lock import extract_lock_option_args, index_lock_artifacts
 from testing.pytest.tmp import Tempdir, TempdirFactory

--- a/tests/integration/test_executuon_mode_venv.py
+++ b/tests/integration/test_executuon_mode_venv.py
@@ -6,10 +6,9 @@ from __future__ import absolute_import
 import json
 import os
 import re
-import subprocess
 
 from pex.typing import TYPE_CHECKING
-from testing import IS_PYPY, PY_VER, make_env, run_pex_command
+from testing import IS_PYPY, PY_VER, make_env, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_inject_env_and_args.py
+++ b/tests/integration/test_inject_env_and_args.py
@@ -7,7 +7,6 @@ import os.path
 import re
 import signal
 import socket
-import subprocess
 from contextlib import closing
 from textwrap import dedent
 
@@ -16,7 +15,7 @@ import pytest
 from pex.common import safe_open
 from pex.fetcher import URLFetcher
 from pex.typing import TYPE_CHECKING
-from testing import IS_PYPY, PY_VER, make_env, run_pex_command
+from testing import IS_PYPY, PY_VER, make_env, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, Iterable, List, Optional

--- a/tests/integration/test_inject_python_args.py
+++ b/tests/integration/test_inject_python_args.py
@@ -4,14 +4,13 @@
 import json
 import os.path
 import shutil
-import subprocess
 import sys
 from textwrap import dedent
 
 import pytest
 
 from pex.typing import TYPE_CHECKING
-from testing import IS_PYPY, run_pex_command
+from testing import IS_PYPY, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, Iterable, List

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -9,7 +9,6 @@ import os
 import re
 import shlex
 import shutil
-import subprocess
 import sys
 from contextlib import closing, contextmanager
 from textwrap import dedent
@@ -53,6 +52,7 @@ from testing import (
     run_pex_command,
     run_simple_pex,
     run_simple_pex_test,
+    subprocess,
     temporary_content,
 )
 from testing.mitmproxy import Proxy
@@ -1310,7 +1310,7 @@ def build_and_execute_pex_with_warnings(*extra_build_args, **extra_runtime_env):
         env.update(**extra_runtime_env)
         process = subprocess.Popen(cmd, env=env, stderr=subprocess.PIPE)
         _, stderr = process.communicate()
-        return stderr
+        return cast(bytes, stderr)
 
 
 def test_emit_warnings_default():

--- a/tests/integration/test_interpreter.py
+++ b/tests/integration/test_interpreter.py
@@ -1,14 +1,13 @@
 # Copyright 2024 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import os.path
-import subprocess
 import sys
 
 from pex.compatibility import commonpath
 from pex.interpreter import PythonInterpreter
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
-from testing import PY310, ensure_python_interpreter, run_pex_command
+from testing import PY310, ensure_python_interpreter, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_1018.py
+++ b/tests/integration/test_issue_1018.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 from textwrap import dedent
 
 import pytest
@@ -10,7 +9,7 @@ import pytest
 from pex.common import safe_open
 from pex.layout import Layout
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, Iterable, List

--- a/tests/integration/test_issue_1201.py
+++ b/tests/integration/test_issue_1201.py
@@ -2,10 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_1202.py
+++ b/tests/integration/test_issue_1202.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-import subprocess
 
 import pytest
 
@@ -10,7 +9,7 @@ from pex.interpreter import PythonInterpreter
 from pex.pex import PEX
 from pex.third_party.packaging import tags
 from pex.typing import TYPE_CHECKING
-from testing import PY27, ensure_python_interpreter, run_pex_command
+from testing import PY27, ensure_python_interpreter, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_1232.py
+++ b/tests/integration/test_issue_1232.py
@@ -3,11 +3,10 @@
 
 import os
 import shutil
-import subprocess
 
 from pex.cache.dirs import CacheDir
 from pex.typing import TYPE_CHECKING
-from testing import PY38, PY310, ensure_python_interpreter, make_env, run_pex_command
+from testing import PY38, PY310, ensure_python_interpreter, make_env, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, Dict, FrozenSet, Iterator, List

--- a/tests/integration/test_issue_1302.py
+++ b/tests/integration/test_issue_1302.py
@@ -3,10 +3,9 @@
 
 import json
 import os
-import subprocess
 
 from pex.typing import TYPE_CHECKING
-from testing import built_wheel, make_env, run_pex_command
+from testing import built_wheel, make_env, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_1316.py
+++ b/tests/integration/test_issue_1316.py
@@ -2,13 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 import sys
 
 import pytest
 
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_1336.py
+++ b/tests/integration/test_issue_1336.py
@@ -2,11 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 
 from pex.compatibility import commonpath
 from pex.typing import TYPE_CHECKING
-from testing import PY310, ensure_python_interpreter, run_pex_command
+from testing import PY310, ensure_python_interpreter, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_1422.py
+++ b/tests/integration/test_issue_1422.py
@@ -3,11 +3,18 @@
 
 import os
 import re
-import subprocess
 import sys
 
 from pex.typing import TYPE_CHECKING
-from testing import PY38, PY39, PY310, ensure_python_interpreter, make_env, run_pex_command
+from testing import (
+    PY38,
+    PY39,
+    PY310,
+    ensure_python_interpreter,
+    make_env,
+    run_pex_command,
+    subprocess,
+)
 
 if TYPE_CHECKING:
     from typing import Any, Iterable, Optional, Tuple

--- a/tests/integration/test_issue_1447.py
+++ b/tests/integration/test_issue_1447.py
@@ -2,13 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import os
 import shutil
-import subprocess
 import sys
 
 from pex.pex_info import PexInfo
 from pex.typing import TYPE_CHECKING
 from pex.variables import unzip_dir
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_1479.py
+++ b/tests/integration/test_issue_1479.py
@@ -4,12 +4,11 @@
 
 import os.path
 import platform
-import subprocess
 import sys
 
 from pex.common import safe_rmtree
 from pex.typing import TYPE_CHECKING
-from testing import make_env, run_pex_command
+from testing import make_env, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_1520.py
+++ b/tests/integration/test_issue_1520.py
@@ -3,14 +3,13 @@
 
 import os
 import shutil
-import subprocess
 from textwrap import dedent
 
 import pytest
 
 from pex.cache.dirs import CacheDir
 from pex.typing import TYPE_CHECKING
-from testing import IS_LINUX, IS_MAC, PY_VER, run_pex_command
+from testing import IS_LINUX, IS_MAC, PY_VER, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_1537.py
+++ b/tests/integration/test_issue_1537.py
@@ -5,10 +5,9 @@ from __future__ import absolute_import
 
 import os.path
 import shutil
-import subprocess
 
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 from testing.mitmproxy import Proxy
 
 if TYPE_CHECKING:

--- a/tests/integration/test_issue_1550.py
+++ b/tests/integration/test_issue_1550.py
@@ -1,14 +1,13 @@
 # Copyright 2021 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import os.path
-import subprocess
 
 from pex import dist_metadata
 from pex.dist_metadata import ProjectNameAndVersion
 from pex.orderedset import OrderedSet
 from pex.pex_info import PexInfo
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_1560.py
+++ b/tests/integration/test_issue_1560.py
@@ -3,14 +3,20 @@
 
 import os.path
 import re
-import subprocess
 from textwrap import dedent
 
 import pytest
 
 from pex.common import safe_open, touch
 from pex.typing import TYPE_CHECKING
-from testing import IntegResults, VenvFactory, all_python_venvs, make_source_dir, run_pex_command
+from testing import (
+    IntegResults,
+    VenvFactory,
+    all_python_venvs,
+    make_source_dir,
+    run_pex_command,
+    subprocess,
+)
 from testing.pytest.tmp import Tempdir
 from testing.pythonPI import skip_flit_core_39
 

--- a/tests/integration/test_issue_157.py
+++ b/tests/integration/test_issue_157.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import
 
 import os
-import subprocess
 from contextlib import closing, contextmanager
 from textwrap import dedent
 from typing import Mapping, Text
@@ -18,7 +17,7 @@ from pex.common import environment_as
 from pex.pex_info import PexInfo
 from pex.typing import TYPE_CHECKING
 from pex.version import __version__
-from testing import IS_PYPY, make_env, run_pex_command, scie
+from testing import IS_PYPY, make_env, run_pex_command, scie, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, Iterable, Iterator, List, Tuple

--- a/tests/integration/test_issue_1656.py
+++ b/tests/integration/test_issue_1656.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 import sys
 
 import pytest
@@ -10,7 +9,7 @@ import pytest
 from pex.interpreter import PythonInterpreter
 from pex.pex_info import PexInfo
 from pex.typing import TYPE_CHECKING
-from testing import IS_PYPY, PY_VER, make_env, run_pex_command
+from testing import IS_PYPY, PY_VER, make_env, run_pex_command, subprocess
 from testing.pytest.tmp import TempdirFactory
 
 if TYPE_CHECKING:

--- a/tests/integration/test_issue_1683.py
+++ b/tests/integration/test_issue_1683.py
@@ -2,14 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-import subprocess
 from textwrap import dedent
 
 from colors import crossed, red  # vendor:skip
 
 from pex.common import safe_open
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_1802.py
+++ b/tests/integration/test_issue_1802.py
@@ -1,7 +1,6 @@
 # Copyright 2022 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import os.path
-import subprocess
 from textwrap import dedent
 
 import pytest
@@ -9,7 +8,7 @@ import pytest
 from pex.common import safe_open
 from pex.compatibility import PY2
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_1809.py
+++ b/tests/integration/test_issue_1809.py
@@ -3,7 +3,6 @@
 
 import os.path
 import shutil
-import subprocess
 import sys
 from textwrap import dedent
 
@@ -11,7 +10,7 @@ import pytest
 
 from pex.common import safe_open
 from pex.typing import TYPE_CHECKING
-from testing import PY310, ensure_python_distribution, run_pex_command
+from testing import PY310, ensure_python_distribution, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_1825.py
+++ b/tests/integration/test_issue_1825.py
@@ -3,7 +3,6 @@
 
 import json
 import os.path
-import subprocess
 from textwrap import dedent
 
 import pytest
@@ -12,7 +11,7 @@ from pex.common import safe_open
 from pex.inherit_path import InheritPath
 from pex.orderedset import OrderedSet
 from pex.typing import TYPE_CHECKING, cast
-from testing import make_env, run_pex_command
+from testing import make_env, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, List

--- a/tests/integration/test_issue_1870.py
+++ b/tests/integration/test_issue_1870.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 
 import colors  # vendor:skip
 import pytest
@@ -10,7 +9,7 @@ import pytest
 from pex.inherit_path import InheritPath
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import Virtualenv
-from testing import PY_VER, make_env, run_pex_command
+from testing import PY_VER, make_env, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_1872.py
+++ b/tests/integration/test_issue_1872.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 import sys
 
 from pex.pep_440 import Version
@@ -12,7 +11,7 @@ from pex.resolve.lockfile import json_codec
 from pex.resolve.resolved_requirement import Pin
 from pex.typing import TYPE_CHECKING
 from pex.version import __version__
-from testing import PY310, ensure_python_interpreter, make_env, run_pex_command
+from testing import PY310, ensure_python_interpreter, make_env, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_1933.py
+++ b/tests/integration/test_issue_1933.py
@@ -2,12 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 
 import pytest
 
 from pex.typing import TYPE_CHECKING
-from testing import IS_X86_64, run_pex_command
+from testing import IS_X86_64, run_pex_command, subprocess
 from testing.docker import skip_unless_docker
 
 if TYPE_CHECKING:

--- a/tests/integration/test_issue_1936.py
+++ b/tests/integration/test_issue_1936.py
@@ -2,10 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-import subprocess
 
 from pex.typing import TYPE_CHECKING
-from testing import make_env, run_pex_command
+from testing import make_env, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_1995.py
+++ b/tests/integration/test_issue_1995.py
@@ -2,13 +2,19 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-import subprocess
 import sys
 
 import pytest
 
 from pex.typing import TYPE_CHECKING
-from testing import IS_LINUX, PY310, ensure_python_interpreter, make_env, run_pex_command
+from testing import (
+    IS_LINUX,
+    PY310,
+    ensure_python_interpreter,
+    make_env,
+    run_pex_command,
+    subprocess,
+)
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_2001.py
+++ b/tests/integration/test_issue_2001.py
@@ -1,9 +1,8 @@
 import os.path
-import subprocess
 import sys
 
 from pex.typing import TYPE_CHECKING
-from testing import make_env, run_pex_command
+from testing import make_env, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_2006.py
+++ b/tests/integration/test_issue_2006.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-import subprocess
 import sys
 
 import pytest
@@ -10,7 +9,7 @@ import pytest
 from pex.compatibility import PY3
 from pex.fs import safe_symlink
 from pex.typing import TYPE_CHECKING
-from testing import PY38, ensure_python_interpreter, run_pex_command
+from testing import PY38, ensure_python_interpreter, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, List

--- a/tests/integration/test_issue_2017.py
+++ b/tests/integration/test_issue_2017.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 import os.path
 import shutil
-import subprocess
 import tarfile
 from textwrap import dedent
 
@@ -18,7 +17,7 @@ from pex.fetcher import URLFetcher
 from pex.os import is_exe
 from pex.pip.version import PipVersion, PipVersionValue
 from pex.typing import TYPE_CHECKING
-from testing import IS_LINUX, run_pex_command
+from testing import IS_LINUX, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, Iterator

--- a/tests/integration/test_issue_2023.py
+++ b/tests/integration/test_issue_2023.py
@@ -3,7 +3,6 @@
 
 import os.path
 import shutil
-import subprocess
 import sys
 from textwrap import dedent
 
@@ -13,7 +12,7 @@ from colors import colors  # vendor:skip
 from pex.layout import Layout
 from pex.pep_427 import InstallableType
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 from testing.pep_427 import get_installable_type_flag
 
 if TYPE_CHECKING:

--- a/tests/integration/test_issue_2038.py
+++ b/tests/integration/test_issue_2038.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 
 import glob
 import os.path
-import subprocess
 import sys
 from textwrap import dedent
 
@@ -13,7 +12,7 @@ import pytest
 
 from pex.common import touch
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_2073.py
+++ b/tests/integration/test_issue_2073.py
@@ -3,12 +3,11 @@
 
 import os.path
 import re
-import subprocess
 
 from pex.resolve import abbreviated_platforms
 from pex.targets import AbbreviatedPlatform
 from pex.typing import TYPE_CHECKING
-from testing import IS_LINUX, IntegResults, run_pex_command
+from testing import IS_LINUX, IntegResults, run_pex_command, subprocess
 from testing.cli import run_pex3
 
 if TYPE_CHECKING:

--- a/tests/integration/test_issue_2088.py
+++ b/tests/integration/test_issue_2088.py
@@ -1,7 +1,6 @@
 # Copyright 2023 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import os.path
-import subprocess
 import sys
 
 import pytest
@@ -12,7 +11,7 @@ from pex.compatibility import commonpath
 from pex.layout import Layout
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import Virtualenv
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_2134.py
+++ b/tests/integration/test_issue_2134.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-import subprocess
 import sys
 
 import pytest
@@ -10,7 +9,7 @@ import pytest
 from pex import layout
 from pex.common import open_zip, touch
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, Iterable, Optional

--- a/tests/integration/test_issue_2183.py
+++ b/tests/integration/test_issue_2183.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-import subprocess
 from textwrap import dedent
 
 import pytest
@@ -14,7 +13,7 @@ from pex.pep_503 import ProjectName
 from pex.pex import PEX
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import Virtualenv
-from testing import PY_VER, make_env, run_pex_command
+from testing import PY_VER, make_env, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_2203.py
+++ b/tests/integration/test_issue_2203.py
@@ -3,12 +3,12 @@
 
 import os.path
 import stat
-import subprocess
 from collections import OrderedDict
 
 from pex.common import safe_rmtree
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import InstallationChoice, Virtualenv
+from testing import subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_2235.py
+++ b/tests/integration/test_issue_2235.py
@@ -1,11 +1,10 @@
 import os
-import subprocess
 import sys
 
 import pytest
 
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_2249.py
+++ b/tests/integration/test_issue_2249.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import
 
 import os.path
-import subprocess
 from contextlib import closing
 from textwrap import dedent
 from typing import Iterator
@@ -15,7 +14,7 @@ import pytest
 
 from pex.common import safe_rmtree
 from pex.typing import TYPE_CHECKING
-from testing import IS_PYPY, make_env, run_pex_command, scie
+from testing import IS_PYPY, make_env, run_pex_command, scie, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, List

--- a/tests/integration/test_issue_2355.py
+++ b/tests/integration/test_issue_2355.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import json
 import os
-import subprocess
 from textwrap import dedent
 
 from pex.interpreter import PythonInterpreter
@@ -13,7 +12,7 @@ from pex.pip.version import PipVersion
 from pex.result import try_
 from pex.targets import CompletePlatform, Targets
 from pex.typing import TYPE_CHECKING
-from testing import IS_X86_64, run_pex_command
+from testing import IS_X86_64, run_pex_command, subprocess
 from testing.docker import skip_unless_docker
 
 if TYPE_CHECKING:

--- a/tests/integration/test_issue_2389.py
+++ b/tests/integration/test_issue_2389.py
@@ -2,12 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-import subprocess
 import sys
 
 from pex.interpreter import PythonInterpreter
 from pex.typing import TYPE_CHECKING
-from testing import PY310, ensure_python_interpreter, run_pex_command
+from testing import PY310, ensure_python_interpreter, run_pex_command, subprocess
 from testing.cli import run_pex3
 
 if TYPE_CHECKING:

--- a/tests/integration/test_issue_2391.py
+++ b/tests/integration/test_issue_2391.py
@@ -3,14 +3,13 @@
 
 import os.path
 import re
-import subprocess
 import sys
 
 import pytest
 
 from pex.layout import Layout
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_2410.py
+++ b/tests/integration/test_issue_2410.py
@@ -4,14 +4,13 @@
 from __future__ import absolute_import
 
 import os.path
-import subprocess
 from textwrap import dedent
 
 from colors import colors  # vendor:skip
 
 from pex.common import safe_open
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_2412.py
+++ b/tests/integration/test_issue_2412.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import, print_function
 
 import os.path
-import subprocess
 from textwrap import dedent
 
 import pytest
@@ -17,6 +16,7 @@ from pex.requirements import PyPIRequirement, parse_requirement_file
 from pex.resolve.lockfile import json_codec
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import InstallationChoice, Virtualenv
+from testing import subprocess
 from testing.cli import run_pex3
 from testing.lock import index_lock_artifacts
 

--- a/tests/integration/test_issue_2413.py
+++ b/tests/integration/test_issue_2413.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 import glob
 import os.path
-import subprocess
 from textwrap import dedent
 
 import pytest
@@ -15,6 +14,7 @@ from pex.os import is_exe
 from pex.pep_503 import ProjectName
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import InstallationChoice, Virtualenv
+from testing import subprocess
 
 if TYPE_CHECKING:
     from typing import Any, List

--- a/tests/integration/test_issue_2415.py
+++ b/tests/integration/test_issue_2415.py
@@ -3,7 +3,6 @@
 
 import atexit
 import os.path
-import subprocess
 import time
 from textwrap import dedent
 
@@ -12,7 +11,7 @@ import pytest
 from pex.common import safe_mkdir, safe_open
 from pex.fetcher import URLFetcher
 from pex.typing import TYPE_CHECKING
-from testing import IS_MAC, IS_PYPY, PY_VER, data, run_pex_command
+from testing import IS_MAC, IS_PYPY, PY_VER, data, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_2572.py
+++ b/tests/integration/test_issue_2572.py
@@ -5,10 +5,9 @@ from __future__ import absolute_import
 
 import os
 import shutil
-import subprocess
 
 from pex.fs import safe_symlink
-from testing import make_env, run_pex_command
+from testing import make_env, run_pex_command, subprocess
 from testing.pytest.tmp import Tempdir
 
 

--- a/tests/integration/test_issue_2739.py
+++ b/tests/integration/test_issue_2739.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-import subprocess
 
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
@@ -10,7 +9,7 @@ from pex.resolve.locked_resolve import FileArtifact
 from pex.resolve.lockfile import json_codec
 from pex.resolve.resolved_requirement import Pin
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 from testing.cli import run_pex3
 
 if TYPE_CHECKING:

--- a/tests/integration/test_issue_298.py
+++ b/tests/integration/test_issue_298.py
@@ -6,13 +6,13 @@ from __future__ import absolute_import
 
 import os.path
 import shutil
-import subprocess
 from textwrap import dedent
 
 from pex.common import safe_open
 from pex.fetcher import URLFetcher
 from pex.os import WINDOWS
 from pex.typing import TYPE_CHECKING
+from testing import subprocess
 from testing.docker import skip_unless_docker
 
 if TYPE_CHECKING:

--- a/tests/integration/test_issue_455.py
+++ b/tests/integration/test_issue_455.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 import sys
 
 import pytest
@@ -10,7 +9,7 @@ import pytest
 from pex.compatibility import commonpath
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import Virtualenv
-from testing import IS_MAC, PY310, ensure_python_venv, run_pex_command
+from testing import IS_MAC, PY310, ensure_python_venv, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_issue_539.py
+++ b/tests/integration/test_issue_539.py
@@ -3,14 +3,13 @@
 
 import glob
 import os
-import subprocess
 
 import pytest
 
 from pex.common import temporary_dir
 from pex.pip.installation import get_pip
 from pex.resolve.configured_resolver import ConfiguredResolver
-from testing import IS_LINUX_ARM64, IS_PYPY, PY_VER, run_pex_command
+from testing import IS_LINUX_ARM64, IS_PYPY, PY_VER, run_pex_command, subprocess
 
 
 @pytest.mark.skipif(

--- a/tests/integration/test_issue_598.py
+++ b/tests/integration/test_issue_598.py
@@ -2,10 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 
 from pex.common import temporary_dir
-from testing import make_env, run_pex_command
+from testing import make_env, run_pex_command, subprocess
 
 
 def test_force_local_implicit_ns_packages():

--- a/tests/integration/test_issue_661.py
+++ b/tests/integration/test_issue_661.py
@@ -2,12 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 
 import pytest
 
 from pex.common import temporary_dir
-from testing import IS_ARM_64, IS_PYPY, run_pex_command
+from testing import IS_ARM_64, IS_PYPY, run_pex_command, subprocess
 
 
 @pytest.mark.skipif(

--- a/tests/integration/test_issue_736.py
+++ b/tests/integration/test_issue_736.py
@@ -2,10 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 
 from pex.common import safe_copy, temporary_dir
-from testing import built_wheel, make_env, make_source_dir, run_pex_command
+from testing import built_wheel, make_env, make_source_dir, run_pex_command, subprocess
 
 
 def test_requirement_setup_py_with_extras():

--- a/tests/integration/test_issue_745.py
+++ b/tests/integration/test_issue_745.py
@@ -2,13 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 from textwrap import dedent
 
 import pytest
 
 from pex.common import safe_open, temporary_dir
-from testing import PY27, ensure_python_venv, make_env, run_pex_command
+from testing import PY27, ensure_python_venv, make_env, run_pex_command, subprocess
 
 
 def test_extras_isolation():

--- a/tests/integration/test_issue_898.py
+++ b/tests/integration/test_issue_898.py
@@ -2,11 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 from textwrap import dedent
 
 from pex.common import safe_open, temporary_dir
-from testing import PY27, PY310, ensure_python_interpreter, make_env, run_pex_command
+from testing import PY27, PY310, ensure_python_interpreter, make_env, run_pex_command, subprocess
 
 
 def test_top_level_requirements_requires_python_env_markers():

--- a/tests/integration/test_issue_996.py
+++ b/tests/integration/test_issue_996.py
@@ -4,13 +4,20 @@
 import multiprocessing
 import os
 import re
-import subprocess
 from textwrap import dedent
 
 from pex.interpreter import PythonInterpreter
 from pex.targets import AbbreviatedPlatform
 from pex.typing import TYPE_CHECKING
-from testing import PY39, PY310, IntegResults, ensure_python_interpreter, make_env, run_pex_command
+from testing import (
+    PY39,
+    PY310,
+    IntegResults,
+    ensure_python_interpreter,
+    make_env,
+    run_pex_command,
+    subprocess,
+)
 from testing.pytest.tmp import Tempdir
 
 if TYPE_CHECKING:

--- a/tests/integration/test_layout.py
+++ b/tests/integration/test_layout.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 import sys
 
 import pytest
@@ -11,7 +10,7 @@ from pex.common import safe_open, safe_rmtree
 from pex.layout import Layout
 from pex.pep_427 import InstallableType
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 from testing.pep_427 import get_installable_type_flag
 
 if TYPE_CHECKING:

--- a/tests/integration/test_lock_resolver.py
+++ b/tests/integration/test_lock_resolver.py
@@ -6,7 +6,6 @@ import hashlib
 import os
 import re
 import shutil
-import subprocess
 import sys
 from textwrap import dedent
 
@@ -23,7 +22,7 @@ from pex.pep_503 import ProjectName
 from pex.pex_info import PexInfo
 from pex.typing import TYPE_CHECKING
 from pex.util import CacheHelper
-from testing import IS_PYPY, PY_VER, built_wheel, make_env, run_pex_command
+from testing import IS_PYPY, PY_VER, built_wheel, make_env, run_pex_command, subprocess
 from testing.cli import run_pex3
 from testing.lock import index_lock_artifacts
 from testing.pytest.tmp import Tempdir, TempdirFactory

--- a/tests/integration/test_no_pre_install_wheels.py
+++ b/tests/integration/test_no_pre_install_wheels.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import hashlib
 import os
-import subprocess
 import zipfile
 from textwrap import dedent
 
@@ -13,7 +12,7 @@ from pex.dist_metadata import ProjectNameAndVersion
 from pex.pex_info import PexInfo
 from pex.typing import TYPE_CHECKING
 from pex.util import CacheHelper
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_overrides.py
+++ b/tests/integration/test_overrides.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import
 import os.path
 import re
 import shutil
-import subprocess
 import sys
 from collections import defaultdict
 
@@ -18,7 +17,16 @@ from pex.pep_503 import ProjectName
 from pex.pex import PEX
 from pex.pex_info import PexInfo
 from pex.typing import TYPE_CHECKING
-from testing import PY39, PY310, PY_VER, data, ensure_python_interpreter, make_env, run_pex_command
+from testing import (
+    PY39,
+    PY310,
+    PY_VER,
+    data,
+    ensure_python_interpreter,
+    make_env,
+    run_pex_command,
+    subprocess,
+)
 from testing.cli import run_pex3
 from testing.lock import extract_lock_option_args, index_lock_artifacts
 

--- a/tests/integration/test_pep_427.py
+++ b/tests/integration/test_pep_427.py
@@ -3,7 +3,6 @@
 
 import os.path
 import re
-import subprocess
 from glob import glob
 from textwrap import dedent
 
@@ -14,7 +13,7 @@ from pex.pip.installation import get_pip
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import InstallationChoice, Virtualenv
-from testing import WheelBuilder, make_env
+from testing import WheelBuilder, make_env, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_pex_bootstrapper.py
+++ b/tests/integration/test_pex_bootstrapper.py
@@ -3,7 +3,6 @@
 import json
 import os.path
 import re
-import subprocess
 import sys
 from textwrap import dedent
 
@@ -20,7 +19,15 @@ from pex.pex_info import PexInfo
 from pex.typing import TYPE_CHECKING
 from pex.venv.installer import CollisionError
 from pex.venv.virtualenv import Virtualenv
-from testing import PY38, PY39, PY_VER, ensure_python_interpreter, make_env, run_pex_command
+from testing import (
+    PY38,
+    PY39,
+    PY_VER,
+    ensure_python_interpreter,
+    make_env,
+    run_pex_command,
+    subprocess,
+)
 from testing.pytest.tmp import Tempdir
 
 if TYPE_CHECKING:

--- a/tests/integration/test_pex_entry_points.py
+++ b/tests/integration/test_pex_entry_points.py
@@ -2,12 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-import subprocess
 from textwrap import dedent
 
 from pex.common import safe_open
 from pex.typing import TYPE_CHECKING
-from testing import make_project, run_pex_command
+from testing import make_project, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_pex_import.py
+++ b/tests/integration/test_pex_import.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-import subprocess
 from textwrap import dedent
 
 import colors  # vendor:skip
@@ -17,7 +16,7 @@ from pex.targets import Targets
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
 from pex.venv.virtualenv import Virtualenv
-from testing import make_env, run_pex_command
+from testing import make_env, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, List, Text

--- a/tests/integration/test_reexec.py
+++ b/tests/integration/test_reexec.py
@@ -3,7 +3,6 @@
 
 import json
 import os
-import subprocess
 import sys
 from textwrap import dedent
 
@@ -20,6 +19,7 @@ from testing import (
     make_env,
     run_pex_command,
     run_simple_pex,
+    subprocess,
 )
 
 if TYPE_CHECKING:

--- a/tests/integration/test_script_metadata.py
+++ b/tests/integration/test_script_metadata.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 import os.path
 import re
-import subprocess
 import sys
 from textwrap import dedent
 
@@ -14,7 +13,7 @@ import colors  # vendor:skip
 from pex.targets import LocalInterpreter
 from pex.third_party.packaging.specifiers import SpecifierSet
 from pex.typing import TYPE_CHECKING
-from testing import PY310, ensure_python_interpreter, run_pex_command
+from testing import PY310, ensure_python_interpreter, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/test_setproctitle.py
+++ b/tests/integration/test_setproctitle.py
@@ -1,7 +1,6 @@
 # Copyright 2022 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import os.path
-import subprocess
 import sys
 import sysconfig
 from textwrap import dedent
@@ -16,7 +15,7 @@ from pex.layout import Layout
 from pex.pep_427 import InstallableType
 from pex.pex_info import PexInfo
 from pex.typing import TYPE_CHECKING
-from testing import IS_MAC, run_pex_command
+from testing import IS_MAC, run_pex_command, subprocess
 from testing.pep_427 import get_installable_type_flag
 
 if TYPE_CHECKING:

--- a/tests/integration/test_sh_boot.py
+++ b/tests/integration/test_sh_boot.py
@@ -4,7 +4,6 @@
 import json
 import os
 import re
-import subprocess
 import sys
 from textwrap import dedent
 
@@ -14,7 +13,7 @@ from pex.common import safe_open
 from pex.layout import Layout
 from pex.os import WINDOWS
 from pex.typing import TYPE_CHECKING
-from testing import all_pythons, make_env, run_pex_command
+from testing import all_pythons, make_env, run_pex_command, subprocess
 from testing.pytest.tmp import Tempdir
 
 if TYPE_CHECKING:

--- a/tests/integration/test_shebang_length_limit.py
+++ b/tests/integration/test_shebang_length_limit.py
@@ -7,7 +7,6 @@ import errno
 import json
 import os
 import shutil
-import subprocess
 from textwrap import dedent
 
 import colors  # vendor:skip
@@ -20,7 +19,7 @@ from pex.executables import chmod_plus_x
 from pex.fs import safe_symlink
 from pex.os import WINDOWS
 from pex.typing import TYPE_CHECKING
-from testing import IS_PYPY, make_project, run_pex_command
+from testing import IS_PYPY, make_project, run_pex_command, subprocess
 from testing.cli import run_pex3
 
 if TYPE_CHECKING:

--- a/tests/integration/test_variables.py
+++ b/tests/integration/test_variables.py
@@ -2,14 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 import sys
 
 import pytest
 
 from pex.layout import Layout
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/tools/commands/test_issue_2105.py
+++ b/tests/integration/tools/commands/test_issue_2105.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-import subprocess
 from textwrap import dedent
 
 import pytest
@@ -13,7 +12,7 @@ from pex.pep_503 import ProjectName
 from pex.pex import PEX
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import InstallationChoice, Virtualenv
-from testing import make_env, run_pex_command
+from testing import make_env, run_pex_command, subprocess
 from testing.pytest.tmp import Tempdir, TempdirFactory
 
 if TYPE_CHECKING:

--- a/tests/integration/tools/commands/test_venv.py
+++ b/tests/integration/tools/commands/test_venv.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 import sys
 from textwrap import dedent
 
@@ -12,7 +11,7 @@ from pex.common import CopyMode, is_pyc_file, safe_open
 from pex.typing import TYPE_CHECKING
 from pex.util import CacheHelper
 from pex.venv.virtualenv import Virtualenv
-from testing import IntegResults, make_env, run_pex_command
+from testing import IntegResults, make_env, run_pex_command, subprocess
 from testing.venv import assert_venv_site_packages_copy_mode
 
 if TYPE_CHECKING:

--- a/tests/integration/venv_ITs/test_issue_1630.py
+++ b/tests/integration/venv_ITs/test_issue_1630.py
@@ -3,7 +3,6 @@
 
 import json
 import os
-import subprocess
 
 from pex.cache.dirs import CacheDir
 from pex.dist_metadata import Distribution
@@ -12,7 +11,7 @@ from pex.pep_376 import InstalledWheel
 from pex.pex_info import PexInfo
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import Virtualenv
-from testing import PY38, ensure_python_venv, run_pex_command
+from testing import PY38, ensure_python_venv, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, Container, List

--- a/tests/integration/venv_ITs/test_issue_1637.py
+++ b/tests/integration/venv_ITs/test_issue_1637.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 from textwrap import dedent
 
 import pytest
@@ -10,8 +9,8 @@ from colors import yellow  # vendor:skip
 
 from pex.cache.dirs import CacheDir
 from pex.common import safe_open, touch
-from pex.typing import TYPE_CHECKING
-from testing import make_env, run_pex_command
+from pex.typing import TYPE_CHECKING, cast
+from testing import make_env, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, Iterable, List, Text
@@ -83,7 +82,7 @@ def execute_app(
     stripped_stderr = stderr.decode("utf-8").strip()
     assert 0 == process.returncode, stripped_stderr
     assert yellow("*** Flashy UI ***") in stripped_stderr
-    return stdout.decode("utf-8").splitlines()
+    return cast("List[Text]", stdout.decode("utf-8").splitlines())
 
 
 def test_pex_path_dedup(tmpdir):

--- a/tests/integration/venv_ITs/test_issue_1641.py
+++ b/tests/integration/venv_ITs/test_issue_1641.py
@@ -1,13 +1,12 @@
 # Copyright 2022 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import os.path
-import subprocess
 from textwrap import dedent
 
 import pytest
 
 from pex.typing import TYPE_CHECKING
-from testing import PY_VER, run_pex_command
+from testing import PY_VER, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, List

--- a/tests/integration/venv_ITs/test_issue_1668.py
+++ b/tests/integration/venv_ITs/test_issue_1668.py
@@ -2,10 +2,16 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os.path
-import subprocess
 
 from pex.typing import TYPE_CHECKING
-from testing import PY38, ensure_python_interpreter, make_env, pex_project_dir, run_pex_command
+from testing import (
+    PY38,
+    ensure_python_interpreter,
+    make_env,
+    pex_project_dir,
+    run_pex_command,
+    subprocess,
+)
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/integration/venv_ITs/test_issue_1745.py
+++ b/tests/integration/venv_ITs/test_issue_1745.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 from textwrap import dedent
 
 import pytest
@@ -11,7 +10,7 @@ from colors import colors  # vendor:skip
 from pex.common import safe_open
 from pex.enum import Enum
 from pex.typing import TYPE_CHECKING
-from testing import IntegResults, run_pex_command
+from testing import IntegResults, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, List, Optional

--- a/tests/integration/venv_ITs/test_issue_1973.py
+++ b/tests/integration/venv_ITs/test_issue_1973.py
@@ -5,14 +5,13 @@ from __future__ import absolute_import
 
 import os.path
 import shutil
-import subprocess
 
 import colors  # vendor:skip
 import pytest
 
 from pex.interpreter import PythonInterpreter
 from pex.typing import TYPE_CHECKING
-from testing import PY310, ensure_python_distribution, make_env, run_pex_command
+from testing import PY310, ensure_python_distribution, make_env, run_pex_command, subprocess
 from testing.cli import run_pex3
 
 if TYPE_CHECKING:

--- a/tests/integration/venv_ITs/test_issue_2065.py
+++ b/tests/integration/venv_ITs/test_issue_2065.py
@@ -3,14 +3,13 @@
 
 import json
 import os
-import subprocess
 from textwrap import dedent
 
 import pytest
 
 from pex.common import safe_open
 from pex.typing import TYPE_CHECKING
-from testing import make_env, run_pex_command
+from testing import make_env, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, List

--- a/tests/integration/venv_ITs/test_issue_2160.py
+++ b/tests/integration/venv_ITs/test_issue_2160.py
@@ -1,7 +1,6 @@
 # Copyright 2023 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import os.path
-import subprocess
 import sys
 from textwrap import dedent
 
@@ -13,7 +12,7 @@ from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.pex import PEX
 from pex.typing import TYPE_CHECKING
-from testing import WheelBuilder, run_pex_command
+from testing import WheelBuilder, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, List

--- a/tests/integration/venv_ITs/test_issue_2248.py
+++ b/tests/integration/venv_ITs/test_issue_2248.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 import sys
 from textwrap import dedent
 
@@ -11,7 +10,7 @@ from colors import colors  # vendor:skip
 
 from pex.typing import TYPE_CHECKING
 from pex.version import __version__
-from testing import IntegResults, run_pex_command
+from testing import IntegResults, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, List

--- a/tests/integration/venv_ITs/test_virtualenv.py
+++ b/tests/integration/venv_ITs/test_virtualenv.py
@@ -4,7 +4,6 @@
 import json
 import os.path
 import shutil
-import subprocess
 from textwrap import dedent
 
 import pytest
@@ -13,7 +12,7 @@ from pex.dist_metadata import Distribution
 from pex.pep_503 import ProjectName
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import InstallationChoice, InvalidVirtualenvError, Virtualenv
-from testing import VenvFactory, all_python_venvs
+from testing import VenvFactory, all_python_venvs, subprocess
 from testing.docker import DockerVirtualenvRunner
 
 if TYPE_CHECKING:

--- a/tests/pip/test_log_analyzer.py
+++ b/tests/pip/test_log_analyzer.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import
 
 import os.path
-import subprocess
 from textwrap import dedent
 
 import pytest
@@ -13,6 +12,7 @@ from pex.executables import chmod_plus_x
 from pex.jobs import Job
 from pex.pip.log_analyzer import ErrorAnalyzer, ErrorMessage, LogAnalyzer, LogScrapeJob
 from pex.typing import TYPE_CHECKING
+from testing import subprocess
 
 if TYPE_CHECKING:
     from typing import Any, Optional

--- a/tests/resolve/lockfile/test_json_codec.py
+++ b/tests/resolve/lockfile/test_json_codec.py
@@ -4,7 +4,6 @@
 import json
 import os
 import re
-import subprocess
 from textwrap import dedent
 
 import pytest
@@ -24,6 +23,7 @@ from pex.resolve.resolver_configuration import BuildConfiguration, ResolverVersi
 from pex.sorted_tuple import SortedTuple
 from pex.third_party.packaging import tags
 from pex.typing import TYPE_CHECKING
+from testing import subprocess
 
 if TYPE_CHECKING:
     from typing import Any, Container

--- a/tests/test_bdist_pex.py
+++ b/tests/test_bdist_pex.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 import sys
 from contextlib import contextmanager
 from textwrap import dedent
@@ -15,7 +14,7 @@ from pex.pip.version import PipVersion
 from pex.resolver import resolve
 from pex.typing import TYPE_CHECKING
 from pex.venv.virtualenv import InstallationChoice, Virtualenv
-from testing import WheelBuilder, make_project, pex_project_dir, temporary_content
+from testing import WheelBuilder, make_project, pex_project_dir, subprocess, temporary_content
 
 if TYPE_CHECKING:
     from typing import Dict, Iterable, Iterator, List, Optional, Union

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -3,7 +3,6 @@
 
 import os
 import platform
-import subprocess
 import sys
 from contextlib import contextmanager
 from textwrap import dedent
@@ -32,6 +31,7 @@ from testing import (
     ensure_python_interpreter,
     install_wheel,
     make_bdist,
+    subprocess,
     temporary_content,
     temporary_filename,
 )

--- a/tests/test_execution_mode.py
+++ b/tests/test_execution_mode.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import
 
 import os.path
-import subprocess
 import sys
 from subprocess import CalledProcessError
 
@@ -14,7 +13,7 @@ from pex.cache.dirs import CacheDir
 from pex.layout import Layout
 from pex.pep_427 import InstallableType
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import run_pex_command, subprocess
 from testing.pep_427 import get_installable_type_flag
 
 if TYPE_CHECKING:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -2,13 +2,13 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 
 import pytest
 
 from pex.common import safe_mkdir, temporary_dir
 from pex.executor import Executor
 from pex.typing import TYPE_CHECKING
+from testing import subprocess
 
 if TYPE_CHECKING:
     from typing import Callable, List

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -7,7 +7,6 @@ import glob
 import json
 import os
 import re
-import subprocess
 import sys
 from collections import defaultdict
 from contextlib import contextmanager
@@ -35,6 +34,7 @@ from testing import (
     ensure_python_interpreter,
     ensure_python_venv,
     pushd,
+    subprocess,
 )
 from testing.pytest.tmp import TempdirFactory
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 import json
 import os
-import subprocess
 from textwrap import dedent
 
 import pytest
@@ -13,6 +12,7 @@ import pytest
 from pex.interpreter import PythonInterpreter
 from pex.jobs import _ABSOLUTE_MAX_JOBS, DEFAULT_MAX_JOBS, Job, SpawnedJob, _sanitize_max_jobs
 from pex.typing import TYPE_CHECKING, cast
+from testing import subprocess
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Iterable

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -4,14 +4,13 @@
 from __future__ import absolute_import
 
 import os
-import subprocess
 import sys
 
 from pex.interpreter import PythonInterpreter
 from pex.tools.commands import all_commands
 from pex.venv.virtualenv import Virtualenv
 from pex.version import __version__
-from testing import make_env
+from testing import make_env, subprocess
 
 # N.B.: Our test environments include Pex installed from our pyproject.toml in a Tox managed venv.
 # This is how Tox works and its critical background to the assumptions made in the tests below.

--- a/tests/test_pex.py
+++ b/tests/test_pex.py
@@ -4,7 +4,6 @@
 import json
 import os
 import site
-import subprocess
 import sys
 import sysconfig
 import tempfile
@@ -39,6 +38,7 @@ from testing import (
     make_bdist,
     run_simple_pex,
     run_simple_pex_test,
+    subprocess,
     temporary_content,
     write_simple_pex,
 )

--- a/tests/test_pex_bootstrapper.py
+++ b/tests/test_pex_bootstrapper.py
@@ -3,7 +3,6 @@
 
 import os
 import shutil
-import subprocess
 import sys
 from textwrap import dedent
 
@@ -25,7 +24,7 @@ from pex.pex_bootstrapper import (
 from pex.pex_builder import PEXBuilder
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
-from testing import PY38, PY39, PY310, ensure_python_interpreter
+from testing import PY38, PY39, PY310, ensure_python_interpreter, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, Iterable, List, Optional

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -5,7 +5,6 @@ import filecmp
 import os
 import re
 import stat
-import subprocess
 import sys
 import zipfile
 from contextlib import contextmanager
@@ -25,7 +24,15 @@ from pex.pex_builder import Check, InvalidZipAppError, PEXBuilder
 from pex.pex_warnings import PEXWarning
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
-from testing import IS_PYPY, NonDeterministicWalk, WheelBuilder, install_wheel, make_bdist, make_env
+from testing import (
+    IS_PYPY,
+    NonDeterministicWalk,
+    WheelBuilder,
+    install_wheel,
+    make_bdist,
+    make_env,
+    subprocess,
+)
 from testing import write_simple_pex as write_pex
 
 try:

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -3,7 +3,6 @@
 
 import os
 import shutil
-import subprocess
 import sys
 import zipfile
 from collections import defaultdict
@@ -38,6 +37,7 @@ from testing import (
     ensure_python_interpreter,
     make_project,
     make_source_dir,
+    subprocess,
 )
 
 if TYPE_CHECKING:

--- a/tests/test_third_party.py
+++ b/tests/test_third_party.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 import sys
 from contextlib import contextmanager
 
@@ -11,6 +10,7 @@ from pex.common import temporary_dir
 from pex.compatibility import commonpath
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV
+from testing import subprocess
 
 if TYPE_CHECKING:
     from typing import Dict, Iterator, Tuple

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 from hashlib import sha1
 from textwrap import dedent
 
@@ -14,6 +13,7 @@ from pex.pex import PEX
 from pex.pex_builder import PEXBuilder
 from pex.typing import TYPE_CHECKING, cast
 from pex.util import CacheHelper, DistributionHelper, named_temporary_file
+from testing import subprocess
 
 if TYPE_CHECKING:
     from typing import Callable

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -2,12 +2,12 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-import subprocess
 import sys
 
 from pex.common import touch
 from pex.typing import TYPE_CHECKING
 from pex.vendor import VendorSpec
+from testing import subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/test_zip_utils.py
+++ b/tests/test_zip_utils.py
@@ -5,7 +5,6 @@ import filecmp
 import os.path
 import re
 import shutil
-import subprocess
 import sys
 from io import BytesIO
 
@@ -14,7 +13,7 @@ import pytest
 from pex.common import open_zip
 from pex.typing import TYPE_CHECKING
 from pex.ziputils import Zip, ZipError
-from testing import PY_VER
+from testing import PY_VER, subprocess
 
 if TYPE_CHECKING:
     from typing import Any

--- a/tests/tools/commands/test_repository.py
+++ b/tests/tools/commands/test_repository.py
@@ -8,7 +8,6 @@ import itertools
 import json
 import os
 import signal
-import subprocess
 from textwrap import dedent
 
 import pytest
@@ -22,7 +21,14 @@ from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.resolver_configuration import BuildConfiguration
 from pex.third_party.packaging.specifiers import SpecifierSet
 from pex.typing import TYPE_CHECKING
-from testing import PY310, PY_VER, ensure_python_venv, run_command_with_jitter, run_pex_command
+from testing import (
+    PY310,
+    PY_VER,
+    ensure_python_venv,
+    run_command_with_jitter,
+    run_pex_command,
+    subprocess,
+)
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Iterator

--- a/tests/tools/commands/test_venv.py
+++ b/tests/tools/commands/test_venv.py
@@ -7,7 +7,6 @@ import errno
 import multiprocessing
 import os
 import shutil
-import subprocess
 import sys
 import tempfile
 from subprocess import CalledProcessError
@@ -24,7 +23,7 @@ from pex.pex_builder import PEXBuilder
 from pex.typing import TYPE_CHECKING, cast
 from pex.util import named_temporary_file
 from pex.venv.virtualenv import Virtualenv
-from testing import IS_PYPY, PY310, PY_VER, ensure_python_interpreter, run_pex_command
+from testing import IS_PYPY, PY310, PY_VER, ensure_python_interpreter, run_pex_command, subprocess
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Iterable, Iterator, List, Optional, Protocol, Set, Text, Tuple


### PR DESCRIPTION
This works around lack of Windows shebang support since running PEX
files directly is so entrenched in tests.

More work towards #2658.