### PR TITLE
Fix dup requirement extra merging during PEX boot.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 2.33.2
+
+This release fixes PEXes build with root requirements like `foo[bar] foo[baz]` (vs. `foo[bar,baz]`,
+which worked already).
+
+* Fix dup requirement extra merging during PEX boot. (#2707)
+
 ## 2.33.1
 
 This release fixes a bug in both `pex3 lock subset` and

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.33.1"
+__version__ = "2.33.2"

--- a/tests/integration/test_issue_2706.py
+++ b/tests/integration/test_issue_2706.py
@@ -1,0 +1,72 @@
+# Copyright 2025 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import shutil
+import subprocess
+
+from pex.cache.dirs import CacheDir
+from pex.common import safe_mkdir
+from pex.compatibility import commonpath
+from pex.pip.version import PipVersion
+from pex.venv.virtualenv import InstallationChoice, Virtualenv
+from testing import built_wheel, run_pex_command
+from testing.pytest_utils.tmp import Tempdir
+
+
+def test_extras_from_dup_root_reqs(tmpdir):
+    # type: (Tempdir) -> None
+
+    find_links = tmpdir.join("find-links")
+    safe_mkdir(find_links)
+
+    if PipVersion.DEFAULT is not PipVersion.VENDORED:
+        Virtualenv.create(
+            tmpdir.join("pip-resolver-venv"), install_pip=InstallationChoice.YES
+        ).interpreter.execute(
+            args=["-m", "pip", "wheel", "--wheel-dir", find_links]
+            + list(map(str, PipVersion.DEFAULT.requirements))
+        )
+
+    with built_wheel(
+        name="foo", extras_require={"bar": ["bar"], "baz": ["baz"]}
+    ) as foo, built_wheel(name="bar") as bar, built_wheel(name="baz") as baz:
+        shutil.copy(foo, find_links)
+        shutil.copy(bar, find_links)
+        shutil.copy(baz, find_links)
+
+        pex_root = tmpdir.join("pex_root")
+        pex = tmpdir.join("pex")
+        run_pex_command(
+            args=[
+                "--pex-root",
+                pex_root,
+                "--runtime-pex-root",
+                pex_root,
+                "--no-pypi",
+                "--find-links",
+                find_links,
+                "--resolver-version",
+                "pip-2020-resolver",
+                "foo[bar]",
+                "foo[baz]",
+                "-o",
+                pex,
+            ]
+        ).assert_success()
+
+        installed_wheel_dir = CacheDir.INSTALLED_WHEELS.path(pex_root=pex_root)
+        for module in "foo", "bar", "baz":
+            assert installed_wheel_dir == commonpath(
+                (
+                    installed_wheel_dir,
+                    subprocess.check_output(
+                        args=[
+                            pex,
+                            "-c",
+                            "import {module}; print({module}.__file__)".format(module=module),
+                        ]
+                    ).decode("utf-8"),
+                )
+            )


### PR DESCRIPTION
Previously, using root requirements of `foo[bar] foo[baz]` would produce
the same PEX as `foo[bar,baz]`, (save for the root requirements list)
but the former PEX would not properly activate both the `bar` and `baz`
extras during boot. This is now fixed.

Fixes #2706.