### PR TITLE
Fix `--scie-only` for `-o` not ending in `.pex`.

### DIFF
--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -1385,7 +1385,9 @@ def do_main(
                         ),
                         V=options.verbosity,
                     )
-                if scie_configuration.options.scie_only:
+                if scie_configuration.options.scie_only and os.path.realpath(
+                    pex_file
+                ) != os.path.realpath(scie_info.file):
                     os.unlink(pex_file)
     else:
         if not _compatible_with_current_platform(interpreter, targets.platforms):


### PR DESCRIPTION
Previously, this combination of arguments would lead to no output at all
since the PEX would be unlinked but the PEX had the same name as the
final scie; so the scie itself was unlinked.