### PR TITLE
Do not include `ptex` in `--scie eager` scies.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 2.33.4
+
+This release fixes PEX scies to exclude a ptex binary for `--scie eager` scies saving ~5MB on scies
+targeting 64 bit systems.
+
+* Do not include `ptex` in `--scie eager` scies. (#2717)
+
 ## 2.33.3
 
 This release fixes Pex Zip64 support such that PEX zips do not use Zip64 extensions unless needed.

--- a/pex/scie/science.py
+++ b/pex/scie/science.py
@@ -212,17 +212,19 @@ def create_manifests(
 
     lift = {
         "name": name,
-        "ptex": {
-            "id": Filenames.PTEX.name,
-            "version": PTEX_VERSION,
-            "argv1": "{scie.env.PEX_BOOTSTRAP_URLS={scie.lift}}",
-        },
         "scie_jump": {"version": SCIE_JUMP_VERSION},
         "files": [
             {"name": Filenames.CONFIGURE_BINDING.name},
             dict(name=pex_name, is_executable=True, **({"key": pex_key} if pex_key else {})),
         ],
     }  # type: Dict[str, Any]
+
+    if configuration.options.style is ScieStyle.LAZY:
+        lift["ptex"] = {
+            "id": Filenames.PTEX.name,
+            "version": PTEX_VERSION,
+            "argv1": "{scie.env.PEX_BOOTSTRAP_URLS={scie.lift}}",
+        }
 
     configure_binding = {
         "env": {

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.33.3"
+__version__ = "2.33.4"

--- a/tests/integration/scie/test_pex_scie.py
+++ b/tests/integration/scie/test_pex_scie.py
@@ -1230,7 +1230,7 @@ def test_scie_eager_no_ptex(tmpdir):
         assert "pex" in output, output
         assert "lift.json" in output, output
 
-        assert ("pypy" if IS_PYPY else "cpython" in output) != lazy, output
+        assert (("pypy" if IS_PYPY else "cpython") in output) != lazy, output
         assert ("ptex" in output) == expect_included, output
 
     assert_ptex(expect_included=False, lazy=False)

--- a/tests/integration/scie/test_pex_scie.py
+++ b/tests/integration/scie/test_pex_scie.py
@@ -1192,15 +1192,46 @@ def test_scie_split_contents(tmpdir):
     split_dir = tmpdir.join("split")
     subprocess.check_call(args=[scie, split_dir], env=make_env(SCIE="split"))
 
-    # TODO(John Sirois): When the 1.6.0 scie-jump is released, replace this check with:
-    #  + Add is_exe(...) check.
-    #  + Change is_script(...) check below to check_executable=True.
-    #  + Execute the split PEX directly instead of via sys.executable below.
-    with open(os.path.join(split_dir, "lift.json")) as fp:
-        assert {file["name"]: file for file in json.load(fp)["scie"]["lift"]["files"]}[
-            "cowsay.pex"
-        ]["executable"]
-
     split_pex = os.path.join(split_dir, "cowsay.pex")
-    assert is_script(split_pex, check_executable=False)
-    assert b"| Moo! |" in subprocess.check_output(args=[sys.executable, split_pex, "Moo!"])
+    assert is_exe(split_pex)
+    assert is_script(split_pex)
+    assert b"| Moo! |" in subprocess.check_output(args=[split_pex, "Moo!"])
+
+
+@skip_if_no_provider
+def test_scie_eager_no_ptex(tmpdir):
+    # type: (Tempdir) -> None
+
+    def assert_ptex(
+        expect_included,  # type: bool
+        lazy,  # type: bool
+    ):
+        # type: (...) -> None
+
+        run_pex_command(
+            args=[
+                "cowsay<6",
+                "-c",
+                "cowsay",
+                "-o",
+                tmpdir.join("cowsay.pex"),
+                "--scie",
+                "lazy" if lazy else "eager",
+            ]
+        ).assert_success()
+
+        scie = tmpdir.join("cowsay")
+        assert b"| Moo! |" in subprocess.check_output(args=[scie, "Moo!"])
+
+        output = subprocess.check_output(args=[scie, "-n"], env=make_env(SCIE="split")).decode(
+            "utf-8"
+        )
+        assert "scie-jump" in output, output
+        assert "pex" in output, output
+        assert "lift.json" in output, output
+
+        assert ("cpython" in output) != lazy, output
+        assert ("ptex" in output) == expect_included, output
+
+    assert_ptex(expect_included=False, lazy=False)
+    assert_ptex(expect_included=True, lazy=True)

--- a/tests/integration/scie/test_pex_scie.py
+++ b/tests/integration/scie/test_pex_scie.py
@@ -1230,7 +1230,7 @@ def test_scie_eager_no_ptex(tmpdir):
         assert "pex" in output, output
         assert "lift.json" in output, output
 
-        assert ("cpython" in output) != lazy, output
+        assert ("pypy" if IS_PYPY else "cpython" in output) != lazy, output
         assert ("ptex" in output) == expect_included, output
 
     assert_ptex(expect_included=False, lazy=False)


### PR DESCRIPTION
This saves ~5MB for eager scies targeting 64 bit systems.