### PR TITLE
Upgrade to `science` 0.12.2 to fix PBS rate limits.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 2.33.5
+
+This release fixes rate limit issues building CPython Pex scies by bumping to science 0.12.2 which
+is fixed to properly support bearer authentication via the `SCIENCE_AUTH_<normalized_host>_BEARER`
+environment variable.
+
+* Upgrade to `science` 0.12.2 to fix PBS rate limits. (#2720)
+
 ## 2.33.4
 
 This release fixes PEX scies to exclude a ptex binary for `--scie eager` scies saving ~5MB on scies

--- a/pex/scie/science.py
+++ b/pex/scie/science.py
@@ -67,7 +67,7 @@ class Manifest(object):
 
 
 SCIENCE_RELEASES_URL = "https://github.com/a-scie/lift/releases"
-MIN_SCIENCE_VERSION = Version("0.12.1")
+MIN_SCIENCE_VERSION = Version("0.12.2")
 SCIENCE_REQUIREMENT = SpecifierSet("~={min_version}".format(min_version=MIN_SCIENCE_VERSION))
 
 

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.33.4"
+__version__ = "2.33.5"

--- a/tests/integration/scie/test_pex_scie.py
+++ b/tests/integration/scie/test_pex_scie.py
@@ -313,7 +313,7 @@ def test_specified_science_binary(tmpdir):
 
     local_science_binary = os.path.join(str(tmpdir), "science")
     with open(local_science_binary, "wb") as write_fp, URLFetcher().get_body_stream(
-        "https://github.com/a-scie/lift/releases/download/v0.12.1/{binary}".format(
+        "https://github.com/a-scie/lift/releases/download/v0.12.2/{binary}".format(
             binary=SysPlatform.CURRENT.qualified_binary_name("science")
         )
     ) as read_fp:
@@ -357,7 +357,7 @@ def test_specified_science_binary(tmpdir):
         cached_science_binaries
     ), "Expected the local science binary to be used but not cached."
     assert (
-        "0.12.1"
+        "0.12.2"
         == subprocess.check_output(args=[local_science_binary, "--version"]).decode("utf-8").strip()
     )
 


### PR DESCRIPTION
C.F.: https://github.com/a-scie/lift/issues/127