### PR TITLE
Fix PEP-723 script metadata parsing.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 2.33.6
+
+Fix PEP-723 script metadata parsing to skip metadata blocks found in multiline strings.
+
+* Fix PEP-723 script metadata parsing. (#2722)
+
 ## 2.33.5
 
 This release fixes rate limit issues building CPython Pex scies by bumping to science 0.12.2 which

--- a/pex/pep_723.py
+++ b/pex/pep_723.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import
 import ast
 import re
 from collections import OrderedDict, defaultdict
-from typing import DefaultDict
 
 from pex import toml
 from pex.common import pluralize
@@ -17,7 +16,7 @@ from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from typing import Any, List, Mapping, Optional, Tuple
+    from typing import Any, DefaultDict, List, Mapping, Optional, Tuple
 
     import attr  # vendor:skip
 else:

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.33.5"
+__version__ = "2.33.6"

--- a/tests/test_pep_723.py
+++ b/tests/test_pep_723.py
@@ -382,3 +382,39 @@ def test_parse_invalid_requires_python_value():
                 """
             )
         )
+
+
+def test_parse_confounding_string_literals():
+    # type: () -> None
+
+    assert not ScriptMetadata.parse(
+        dedent(
+            '''\
+            print("""
+            # /// script
+            # dependencies = ["ansicolors"]
+            # ///
+            """)
+            '''
+        )
+    )
+
+    assert ScriptMetadata(dependencies=(Requirement.parse("cowsay"),)) == ScriptMetadata.parse(
+        dedent(
+            '''\
+            print("""
+            # /// script
+            # dependencies = ["ansicolors"]
+            # ///
+            """)
+            # /// script
+            # dependencies = ["cowsay"]
+            # ///
+            print("""
+            # /// script
+            # dependencies = ["dev-cmd"]
+            # ///
+            """)
+            '''
+        )
+    )


### PR DESCRIPTION
This pre-emptively fixes the issue reported here:
  https://github.com/astral-sh/uv/issues/12303