### PR TITLE
Avoid fast-path in --sh-boot script when PEX_TOOLS=1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 2.33.7
+
+This release fixes `PEX_TOOLS=1 ./path/to/pex` for PEXes using venv-execution and sh-bootstrapping (that is, built with `--sh-boot --venv=... --include-tools` ). Previously, the `PEX_TOOLS=1` was ignored if the venv already existed in the `PEX_ROOT` (for instance, if the PEX had already been run).
+
+* Avoid fast-path in `--sh-boot` script when `PEX_TOOLS=1`. (#2726)
+
 ## 2.33.6
 
 Fix PEP-723 script metadata parsing to skip metadata blocks found in multiline strings.

--- a/pex/sh_boot.py
+++ b/pex/sh_boot.py
@@ -199,10 +199,11 @@ def create_sh_boot_script(
         PEX_ROOT="${{PEX_ROOT:-${{DEFAULT_PEX_ROOT}}}}"
         INSTALLED_PEX="${{PEX_ROOT}}/{pex_installed_relpath}"
 
-        if [ -n "${{VENV}}" -a -x "${{INSTALLED_PEX}}" ]; then
+        if [ -n "${{VENV}}" -a -x "${{INSTALLED_PEX}}" -a "${{PEX_TOOLS:-}}" != "" ]; then
             # We're a --venv execution mode PEX installed under the PEX_ROOT and the venv
             # interpreter to use is embedded in the shebang of our venv pex script; so just
-            # execute that script directly.
+            # execute that script directly... except if we're needing to execute PEX code, in
+            # the form of the tools.
             export PEX="{pex}"
             exec "${{INSTALLED_PEX}}/bin/python" ${{VENV_PYTHON_ARGS}} "${{INSTALLED_PEX}}" \\
                 "$@"

--- a/pex/sh_boot.py
+++ b/pex/sh_boot.py
@@ -199,7 +199,7 @@ def create_sh_boot_script(
         PEX_ROOT="${{PEX_ROOT:-${{DEFAULT_PEX_ROOT}}}}"
         INSTALLED_PEX="${{PEX_ROOT}}/{pex_installed_relpath}"
 
-        if [ -n "${{VENV}}" -a -x "${{INSTALLED_PEX}}" -a "${{PEX_TOOLS:-}}" != "" ]; then
+        if [ -n "${{VENV}}" -a -x "${{INSTALLED_PEX}}" -a -z "${{PEX_TOOLS:-}}" ]; then
             # We're a --venv execution mode PEX installed under the PEX_ROOT and the venv
             # interpreter to use is embedded in the shebang of our venv pex script; so just
             # execute that script directly... except if we're needing to execute PEX code, in

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.33.6"
+__version__ = "2.33.7"


### PR DESCRIPTION
This patch stops the "execute venv entrypoint directly" fast-path from happening when the user has set `PEX_TOOLS=1` with a `--sh-boot` PEX, mimicking the similar check performed for Python bootstrapping:

https://github.com/pex-tool/pex/blob/17bd416647eaca978e538408f1ec21813ab26335/pex/pex_boot.py#L204-L205

This change ensures that `PEX_TOOLS=1 ./some.pex` always works, no matter the state of the `PEX_ROOT` cache.

Fixes #2725 