### PR TITLE
Avoid fast-path in `--sh-boot` script for `PEX_PYTHON`, `PEX_PYTHON_PATH` and `PEX_PATH`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 2.33.8
+
+This release fixes running a PEX with any of `PEX_PYTHON=...`,  `PEX_PYTHON_PATH=...` or `PEX_PATH=...` set for PEXes using venv-execution and sh-bootstrapping (that is, built with `--sh-boot --venv=...` ). Previously, those environment variables were ignored if the venv already existed in the `PEX_ROOT` (for instance, if the PEX had already been run).
+
+* Avoid fast-path in `--sh-boot` script for `PEX_PYTHON`, `PEX_PYTHON_PATH` and `PEX_PATH`. (#2729)
+
 ## 2.33.7
 
 This release fixes `PEX_TOOLS=1 ./path/to/pex` for PEXes using venv-execution and sh-bootstrapping (that is, built with `--sh-boot --venv=... --include-tools` ). Previously, the `PEX_TOOLS=1` was ignored if the venv already existed in the `PEX_ROOT` (for instance, if the PEX had already been run).

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -834,7 +834,8 @@ def venv_dir(
 
     # The venv contents are affected by which PEX files are in play as well as which interpreter
     # is selected. The former is influenced via PEX_PATH and the latter is influenced by interpreter
-    # constraints, PEX_PYTHON and PEX_PYTHON_PATH.
+    # constraints, PEX_PYTHON and PEX_PYTHON_PATH. (NB. `create_sh_boot_script` in `pex.sh_boot`
+    # has code to disable its fast-path that must be kept in sync with the logic here.)
 
     pex_path_contents = {}  # type: Dict[str, Dict[str, str]]
     venv_contents = {"pex_path": pex_path_contents}  # type: Dict[str, Any]

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.33.7"
+__version__ = "2.33.8"


### PR DESCRIPTION
Similar to #2726, there's some additional variables that are need to avoid the `--sh-boot` fast-path.