### PR TITLE
Prepare the 2.33.8 release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 2.33.8
+
+This release only upgrades the Pex PEX scies from Python 3.13.1 to 3.13.3.
+
+The main thrust of the release is to kick the tires on Pex's new build system which is powered by
+`uv` + `dev-cmd` and make sure all the action machinery is still working properly.
+
 ## 2.33.7
 
 This release fixes `PEX_TOOLS=1 ./path/to/pex` for PEXes using venv-execution and sh-bootstrapping (that is, built with `--sh-boot --venv=... --include-tools` ). Previously, the `PEX_TOOLS=1` was ignored if the venv already existed in the `PEX_ROOT` (for instance, if the PEX had already been run).

--- a/package/complete-platforms/linux-aarch64.json
+++ b/package/complete-platforms/linux-aarch64.json
@@ -1,8 +1,8 @@
 {
   "__meta_data__": {
-    "comment": "DO NOT EDIT - Generated via: `tox -e gen-scie-platform -- --pbs-release 20241206 --python-version 3.13.1`.",
-    "pbs-release": "20241206",
-    "python-version": "3.13.1"
+    "comment": "DO NOT EDIT - Generated via: `uv run dev-cmd gen-scie-platform -- --pbs-release 20250409 --python-version 3.13.3`.",
+    "pbs-release": "20250409",
+    "python-version": "3.13.3"
   },
   "compatible_tags": [
     "cp313-cp313-manylinux_2_36_aarch64",
@@ -662,14 +662,14 @@
   ],
   "marker_environment": {
     "implementation_name": "cpython",
-    "implementation_version": "3.13.1",
+    "implementation_version": "3.13.3",
     "os_name": "posix",
     "platform_machine": "aarch64",
     "platform_python_implementation": "CPython",
-    "platform_release": "6.8.0-1017-azure",
+    "platform_release": "6.8.0-1021-azure",
     "platform_system": "Linux",
-    "platform_version": "#20-Ubuntu SMP Tue Oct 22 03:43:13 UTC 2024",
-    "python_full_version": "3.13.1",
+    "platform_version": "#25-Ubuntu SMP Wed Jan 15 20:45:09 UTC 2025",
+    "python_full_version": "3.13.3",
     "python_version": "3.13",
     "sys_platform": "linux"
   }

--- a/package/complete-platforms/linux-armv7l.json
+++ b/package/complete-platforms/linux-armv7l.json
@@ -1,8 +1,8 @@
 {
   "__meta_data__": {
-    "comment": "DO NOT EDIT - Generated via: `tox -e gen-scie-platform -- --pbs-release 20241206 --python-version 3.13.1`.",
-    "pbs-release": "20241206",
-    "python-version": "3.13.1"
+    "comment": "DO NOT EDIT - Generated via: `uv run dev-cmd gen-scie-platform -- --pbs-release 20250409 --python-version 3.13.3`.",
+    "pbs-release": "20250409",
+    "python-version": "3.13.3"
   },
   "compatible_tags": [
     "cp313-cp313-manylinux_2_36_armv7l",
@@ -662,14 +662,14 @@
   ],
   "marker_environment": {
     "implementation_name": "cpython",
-    "implementation_version": "3.13.1",
+    "implementation_version": "3.13.3",
     "os_name": "posix",
     "platform_machine": "armv7l",
     "platform_python_implementation": "CPython",
-    "platform_release": "6.8.0-1017-azure",
+    "platform_release": "6.8.0-1021-azure",
     "platform_system": "Linux",
-    "platform_version": "#20-Ubuntu SMP Tue Oct 22 03:43:13 UTC 2024",
-    "python_full_version": "3.13.1",
+    "platform_version": "#25-Ubuntu SMP Wed Jan 15 20:45:09 UTC 2025",
+    "python_full_version": "3.13.3",
     "python_version": "3.13",
     "sys_platform": "linux"
   }

--- a/package/complete-platforms/linux-x86_64.json
+++ b/package/complete-platforms/linux-x86_64.json
@@ -1,8 +1,8 @@
 {
   "__meta_data__": {
-    "comment": "DO NOT EDIT - Generated via: `tox -e gen-scie-platform -- --pbs-release 20241206 --python-version 3.13.1`.",
-    "pbs-release": "20241206",
-    "python-version": "3.13.1"
+    "comment": "DO NOT EDIT - Generated via: `uv run dev-cmd gen-scie-platform -- --pbs-release 20250409 --python-version 3.13.3`.",
+    "pbs-release": "20250409",
+    "python-version": "3.13.3"
   },
   "compatible_tags": [
     "cp313-cp313-manylinux_2_36_x86_64",
@@ -1068,14 +1068,14 @@
   ],
   "marker_environment": {
     "implementation_name": "cpython",
-    "implementation_version": "3.13.1",
+    "implementation_version": "3.13.3",
     "os_name": "posix",
     "platform_machine": "x86_64",
     "platform_python_implementation": "CPython",
-    "platform_release": "6.8.0-1017-azure",
+    "platform_release": "6.8.0-1021-azure",
     "platform_system": "Linux",
-    "platform_version": "#20-Ubuntu SMP Tue Oct 22 03:43:13 UTC 2024",
-    "python_full_version": "3.13.1",
+    "platform_version": "#25-Ubuntu SMP Wed Jan 15 20:45:09 UTC 2025",
+    "python_full_version": "3.13.3",
     "python_version": "3.13",
     "sys_platform": "linux"
   }

--- a/package/complete-platforms/macos-aarch64.json
+++ b/package/complete-platforms/macos-aarch64.json
@@ -1,8 +1,8 @@
 {
   "__meta_data__": {
-    "comment": "DO NOT EDIT - Generated via: `tox -e gen-scie-platform -- --pbs-release 20241206 --python-version 3.13.1`.",
-    "pbs-release": "20241206",
-    "python-version": "3.13.1"
+    "comment": "DO NOT EDIT - Generated via: `uv run dev-cmd gen-scie-platform -- --pbs-release 20250409 --python-version 3.13.3`.",
+    "pbs-release": "20250409",
+    "python-version": "3.13.3"
   },
   "compatible_tags": [
     "cp313-cp313-macosx_14_0_arm64",
@@ -633,14 +633,14 @@
   ],
   "marker_environment": {
     "implementation_name": "cpython",
-    "implementation_version": "3.13.1",
+    "implementation_version": "3.13.3",
     "os_name": "posix",
     "platform_machine": "arm64",
     "platform_python_implementation": "CPython",
     "platform_release": "23.6.0",
     "platform_system": "Darwin",
-    "platform_version": "Darwin Kernel Version 23.6.0: Thu Sep 12 23:34:00 PDT 2024; root:xnu-10063.141.1.701.1~1/RELEASE_ARM64_VMAPPLE",
-    "python_full_version": "3.13.1",
+    "platform_version": "Darwin Kernel Version 23.6.0: Thu Dec 19 20:45:54 PST 2024; root:xnu-10063.141.1.703.2~1/RELEASE_ARM64_VMAPPLE",
+    "python_full_version": "3.13.3",
     "python_version": "3.13",
     "sys_platform": "darwin"
   }

--- a/package/complete-platforms/macos-x86_64.json
+++ b/package/complete-platforms/macos-x86_64.json
@@ -1,8 +1,8 @@
 {
   "__meta_data__": {
-    "comment": "DO NOT EDIT - Generated via: `tox -e gen-scie-platform -- --pbs-release 20241206 --python-version 3.13.1`.",
-    "pbs-release": "20241206",
-    "python-version": "3.13.1"
+    "comment": "DO NOT EDIT - Generated via: `uv run dev-cmd gen-scie-platform -- --pbs-release 20250409 --python-version 3.13.3`.",
+    "pbs-release": "20250409",
+    "python-version": "3.13.3"
   },
   "compatible_tags": [
     "cp313-cp313-macosx_13_0_x86_64",
@@ -2808,14 +2808,14 @@
   ],
   "marker_environment": {
     "implementation_name": "cpython",
-    "implementation_version": "3.13.1",
+    "implementation_version": "3.13.3",
     "os_name": "posix",
     "platform_machine": "x86_64",
     "platform_python_implementation": "CPython",
     "platform_release": "22.6.0",
     "platform_system": "Darwin",
-    "platform_version": "Darwin Kernel Version 22.6.0: Thu Sep  5 20:48:48 PDT 2024; root:xnu-8796.141.3.708.1~1/RELEASE_X86_64",
-    "python_full_version": "3.13.1",
+    "platform_version": "Darwin Kernel Version 22.6.0: Thu Mar  6 21:52:09 PST 2025; root:xnu-8796.141.3.711.5~1/RELEASE_X86_64",
+    "python_full_version": "3.13.3",
     "python_version": "3.13",
     "sys_platform": "darwin"
   }

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.33.7"
+__version__ = "2.33.8"

--- a/scripts/gen-scie-platform.py
+++ b/scripts/gen-scie-platform.py
@@ -14,6 +14,7 @@ import time
 import zipfile
 from argparse import ArgumentError, ArgumentTypeError
 from contextlib import contextmanager
+from datetime import timedelta
 from pathlib import Path
 from textwrap import dedent
 from typing import IO, Collection, Iterable, Iterator
@@ -85,9 +86,9 @@ def create_all_complete_platforms(
 
     print(f"Monitoring workflow run at {run.html_url}.", file=out)
 
-    # The long pole job currently takes ~4 minutes; so 10 minutes should cover things.
-    max_time = time.time() + (60 * 10)
-    print(f"Waiting up to 10 minutes for run to complete.", file=out)
+    # The long pole job currently takes ~9 minutes; so 15 minutes should cover things.
+    max_time = time.time() + timedelta(minutes=15).total_seconds()
+    print(f"Waiting up to 15 minutes for run to complete.", file=out)
     while time.time() < max_time:
         run = repo.get_workflow_run(run.id)
         if not run.conclusion:
@@ -115,7 +116,7 @@ def create_all_complete_platforms(
     for artifact in artifacts:
         print(f"Downloading {artifact.archive_download_url} to {dest_dir}...", file=out)
         with httpx.stream(
-            "GET", artifact.archive_download_url, follow_redirects=True
+            "GET", artifact.archive_download_url, follow_redirects=True, auth=httpx.NetRCAuth()
         ) as response, tempfile.SpooledTemporaryFile(max_size=1_000_000) as tmp_fp:
             response.raise_for_status()
             for chunk in response.iter_bytes():


### PR DESCRIPTION
Add the final fixes for the gen-scie-platform script / workflow and
update the Pex PEX scies to use CPython 3.13.3.