### PR TITLE
Fix entrypoint-less PEX scies used as `--python`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,13 @@
 # Release Notes
 
-## 2.33.10-WIP
+## 2.33.10
 
 This release follows up on the PEX scie argv0 fix in #2738 to further ensure the argv0 of a PEX scie
-is the absolute path of the scie.
+is the absolute path of the scie. In addition, a regression for PEX scies with no entry point is
+fixed, allowing such PEX scies to be used as `--python` targets in Pex invocations.
 
 * Fix PEX scie argv0 to be the scie absolute path. (#2741)
+* Fix entrypoint-less PEX scies used as `--python`. (#2742)
 
 ## 2.33.9
 

--- a/pex/pex_boot.py
+++ b/pex/pex_boot.py
@@ -191,8 +191,16 @@ def boot(
             if os.path.isfile(pex_exe):
                 sys.argv[0] = pex_exe
 
+    overridden_entry_point = os.environ.get("__PEX_ENTRY_POINT__", None)
     sys.path[0] = os.path.abspath(sys.path[0])
-    sys.path.insert(0, os.path.abspath(os.path.join(entry_point, bootstrap_dir)))
+    sys.path.insert(
+        0, os.path.abspath(os.path.join(overridden_entry_point or entry_point, bootstrap_dir))
+    )
+
+    if overridden_entry_point and overridden_entry_point != entry_point:
+        # This PEX has already been installed out of band; so we short-circuit to execute the
+        # pre-installed PEX.
+        __re_exec__(sys.executable, python_args, overridden_entry_point)
 
     venv_dir = None  # type: Optional[str]
     if not installed_from:

--- a/pex/scie/science.py
+++ b/pex/scie/science.py
@@ -153,7 +153,10 @@ def create_manifests(
                     env = {
                         "default": default_env(named_entry_point),
                         "remove_exact": ["PEX_VENV"],
-                        "replace": {"__PEX_EXE__": "{scie}"},
+                        "replace": {
+                            "__PEX_EXE__": "{scie}",
+                            "__PEX_ENTRY_POINT__": "{scie.bindings.configure:PEX}",
+                        },
                     }
                 else:
                     env = {
@@ -161,6 +164,7 @@ def create_manifests(
                         "remove_exact": ["PEX_INTERPRETER", "PEX_SCRIPT", "PEX_VENV"],
                         "replace": {
                             "__PEX_EXE__": "{scie}",
+                            "__PEX_ENTRY_POINT__": "{scie.bindings.configure:PEX}",
                             "PEX_MODULE": str(named_entry_point.entry_point),
                         },
                     }
@@ -186,7 +190,6 @@ def create_manifests(
                                 "PEX_SCRIPT",
                                 "PEX_VENV",
                             ],
-                            "replace": {"__PEX_EXE__": "{scie}"},
                         },
                         "exe": "{scie.bindings.configure:PYTHON}",
                         "args": args(
@@ -204,7 +207,10 @@ def create_manifests(
             yield {
                 "env": {
                     "remove_exact": ["PEX_VENV"],
-                    "replace": {"__PEX_EXE__": "{scie}"},
+                    "replace": {
+                        "__PEX_EXE__": "{scie}",
+                        "__PEX_ENTRY_POINT__": "{scie.bindings.configure:PEX}",
+                    },
                 },
                 "exe": "{scie.bindings.configure:PYTHON}",
                 "args": ["{scie.bindings.configure:PEX}"],

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.33.9"
+__version__ = "2.33.10"

--- a/tests/integration/scie/test_issue_2740.py
+++ b/tests/integration/scie/test_issue_2740.py
@@ -1,0 +1,103 @@
+# Copyright 2025 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import json
+import subprocess
+from textwrap import dedent
+
+import pytest
+
+from pex.compatibility import commonpath
+from pex.typing import TYPE_CHECKING
+from testing import run_pex_command
+from testing.pytest_utils.tmp import Tempdir
+from testing.scie import skip_if_no_provider
+
+if TYPE_CHECKING:
+    from typing import List
+
+
+@pytest.mark.parametrize(
+    "execution_mode_args",
+    [
+        pytest.param([], id="ZIPAPP"),
+        pytest.param(["--sh-boot"], id="SH_BOOT"),
+        pytest.param(["--venv"], id="VENV"),
+        pytest.param(["--venv", "--sh-boot"], id="VENV-SH_BOOT"),
+    ],
+)
+@skip_if_no_provider
+def test_use_pex_scie_as_interpreter(
+    pex_wheel,  # type: str
+    tmpdir,  # type: Tempdir
+    execution_mode_args,  # type: List[str]
+):
+    # type: (...) -> None
+
+    pex = tmpdir.join("pex")
+    run_pex_command(args=[pex_wheel, "--scie", "eager", "--scie-only", "-o", pex]).assert_success()
+
+    app = tmpdir.join("test")
+    pex_root = tmpdir.join("pex_root")
+
+    set_pex_root = tmpdir.join("set_pex_root.py")
+    with open(set_pex_root, "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                import os
+
+
+                os.environ["PEX_ROOT"] = {pex_root!r}
+                """
+            ).format(pex_root=pex_root)
+        )
+
+    subprocess.check_call(
+        args=[
+            pex,
+            "-m",
+            "pex",
+            "--preamble-file",
+            set_pex_root,
+            "--scie",
+            "eager",
+            "--python",
+            pex,
+            "--venv",
+            "--prefer-wheel",
+            "setproctitle",
+            "pip",
+            "-o",
+            app,
+        ]
+    )
+
+    data = json.loads(
+        subprocess.check_output(
+            args=[
+                app,
+                "-c",
+                dedent(
+                    """\
+                    import json
+                    import sys
+
+                    import pip
+                    import setproctitle
+
+
+                    json.dump(
+                        {"setproctitle": setproctitle.__file__, "pip": pip.__file__},
+                        sys.stdout
+                    )
+                    """
+                ),
+            ]
+        )
+    )
+    assert pex_root == commonpath((pex_root, data.pop("pip")))
+    assert pex_root == commonpath((pex_root, data.pop("setproctitle")))
+    assert not data


### PR DESCRIPTION
The PEX scie argv0 fix in #2738 regressed the ability to treat a PEX
scie with no entrypoint as a Python interpreter in `pex --python ...`
invocations. This is now fixed.

Fixes #2740