### PR TITLE
Fix Pex locking for source requirements.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,18 @@
 # Release Notes
 
+## 2.36.1
+
+This release fixes a few issues with creating Pex locks when source requirements were involved.
+
+Previously, locking VCS requirements would fail for projects with non-normalized project names,
+e.g.: PySocks vs its normalized form of pysocks.
+
+Additionally, locking would fail when the requirements were specified at least in part via
+requirements files (`-r` / `--requirements`) and there was either a local project or a VCS
+requirement contained in the requirements files.
+
+* Fix Pex locking for source requirements. (#2750)
+
 ## 2.36.0
 
 This release brings support for creating PEXes that target Android. The Pip 25.1 upgrade in Pex

--- a/pex/pip/vcs.py
+++ b/pex/pip/vcs.py
@@ -34,15 +34,16 @@ def _find_built_source_dist(
     # encoded in: `pip._internal.req.req_install.InstallRequirement.archive`.
 
     listing = os.listdir(build_dir)
-    pattern = re.compile(
-        r"{project_name}-(?P<version>.+)\.zip".format(
-            project_name=project_name.normalized.replace("-", "[-_.]+")
-        )
-    )
+    pattern = re.compile(r"(?P<project_name>[^-]+)-(?P<version>.+)\.zip")
     for name in listing:
         match = pattern.match(name)
-        if match and Version(match.group("version")) == version:
-            return os.path.join(build_dir, name)
+        if not match:
+            continue
+        if ProjectName(match.group("project_name")) != project_name:
+            continue
+        if Version(match.group("version")) != version:
+            continue
+        return os.path.join(build_dir, name)
 
     return Error(
         "Expected to find built sdist for {project_name} {version} in {build_dir} but only found:\n"

--- a/pex/pip/vcs.py
+++ b/pex/pip/vcs.py
@@ -34,7 +34,7 @@ def _find_built_source_dist(
     # encoded in: `pip._internal.req.req_install.InstallRequirement.archive`.
 
     listing = os.listdir(build_dir)
-    pattern = re.compile(r"(?P<project_name>[^-]+)-(?P<version>.+)\.zip")
+    pattern = re.compile(r"(?P<project_name>.+)-(?P<version>.+)\.zip")
     for name in listing:
         match = pattern.match(name)
         if not match:

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.36.0"
+__version__ = "2.36.1"

--- a/tests/integration/cli/commands/test_issue_1665.py
+++ b/tests/integration/cli/commands/test_issue_1665.py
@@ -45,4 +45,4 @@ def test_lock_black(tmpdir):
     cwd = os.path.join(str(tmpdir), "cwd")
     tmpdir = os.path.join(cwd, ".tmp")
     os.makedirs(tmpdir)
-    assert_lock("--tmpdir", ".tmp", cwd=cwd)
+    assert_lock(cwd=cwd)

--- a/tests/integration/cli/commands/test_lock_requirements_file.py
+++ b/tests/integration/cli/commands/test_lock_requirements_file.py
@@ -1,0 +1,112 @@
+# Copyright 2025 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import, print_function
+
+import difflib
+import filecmp
+import os
+
+import pytest
+
+from pex.pip.version import PipVersion
+from testing.cli import run_pex3
+from testing.pytest_utils.tmp import Tempdir
+
+
+def diff(
+    file1,  # type: str
+    file2,  # type: str
+):
+    # type: (...) -> str
+
+    with open(file1) as fp1, open(file2) as fp2:
+        return os.linesep.join(
+            difflib.context_diff(fp1.readlines(), fp2.readlines(), fp1.name, fp2.name)
+        )
+
+
+def assert_locks_match(
+    tmpdir,  # type: Tempdir
+    *requirements  # type: str
+):
+    # type: (...) -> None
+
+    lock1 = tmpdir.join("lock1.json")
+    run_pex3(
+        "lock",
+        "create",
+        "--pip-version",
+        "latest-compatible",
+        "-o",
+        lock1,
+        "--indent",
+        "2",
+        *requirements
+    ).assert_success()
+
+    requirements_file = tmpdir.join("requirements.txt")
+    with open(requirements_file, "w") as fp:
+        for requirement in requirements:
+            print(requirement, file=fp)
+
+    lock2 = tmpdir.join("lock2.json")
+    run_pex3(
+        "lock",
+        "create",
+        "--pip-version",
+        "latest-compatible",
+        "-o",
+        lock2,
+        "--indent",
+        "2",
+        "-r",
+        requirements_file,
+    ).assert_success()
+
+    assert filecmp.cmp(lock1, lock2, shallow=False), diff(lock1, lock2)
+
+
+def test_lock_by_name(tmpdir):
+    # type: (Tempdir) -> None
+
+    assert_locks_match(tmpdir, "cowsay<6")
+
+
+def test_lock_vcs(tmpdir):
+    # type: (Tempdir) -> None
+
+    assert_locks_match(
+        tmpdir, "ansicolors @ git+https://github.com/jonathaneunice/colors.git@c965f5b9"
+    )
+
+
+@pytest.mark.skipif(
+    PipVersion.LATEST_COMPATIBLE is PipVersion.VENDORED,
+    reason="Vendored Pip cannot handle modern pyproject.toml with heterogeneous arrays.",
+)
+def test_lock_local_project(
+    tmpdir,  # type: Tempdir
+    pex_project_dir,  # type: str
+):
+    # type: (...) -> None
+
+    assert_locks_match(tmpdir, pex_project_dir)
+
+
+def test_lock_mixed(
+    tmpdir,  # type: Tempdir
+    pex_project_dir,  # type: str
+):
+    # type: (...) -> None
+
+    requirements = [
+        "cowsay<6",
+        "ansicolors @ git+https://github.com/jonathaneunice/colors.git@c965f5b9",
+    ]
+    # N.B.: Vendored Pip cannot handle modern pyproject.toml with heterogeneous arrays, which ours
+    # uses.
+    if PipVersion.LATEST_COMPATIBLE is not PipVersion.VENDORED:
+        requirements.append(pex_project_dir)
+
+    assert_locks_match(tmpdir, *requirements)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,7 +9,6 @@ import os
 import pytest
 
 from pex.atomic_directory import atomic_directory
-from pex.common import temporary_dir
 from pex.interpreter import PythonInterpreter
 from pex.os import WINDOWS
 from pex.pip.version import PipVersion
@@ -19,7 +18,7 @@ from testing import PY310, data, ensure_python_interpreter, make_env, run_pex_co
 from testing.mitmproxy import Proxy
 
 if TYPE_CHECKING:
-    from typing import Any, Callable, Iterator
+    from typing import Any, Callable
 
 
 @pytest.fixture(scope="session")
@@ -90,18 +89,6 @@ def pex_bdist(
     wheels = glob.glob(os.path.join(wheels_dir, "pex-*.whl"))
     assert 1 == len(wheels)
     return wheels[0]
-
-
-@pytest.fixture
-def tmp_workdir():
-    # type: () -> Iterator[str]
-    cwd = os.getcwd()
-    with temporary_dir() as tmpdir:
-        os.chdir(tmpdir)
-        try:
-            yield os.path.realpath(tmpdir)
-        finally:
-            os.chdir(cwd)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Previously, locking VCS requirements would fail for projects with
non-normalized project names, e.g.: PySocks vs its normalized form of
pysocks.

Additionally, locking would fail when the requirements were specified
at least in part via requirements files (`-r` / `--requirements`) and
there was either a local project or a VCS requirement contained in the
requirements files.