### PR TITLE
Add support for `pex --pylock`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## 2.39.0
+
+This release adds support for `pex --pylock` and `pex3 venv create --pylock` for building PEXes and
+venvs from [pylock.toml][PEP-751] locks. In both cases PEX supports subsetting the lock if it
+provides `dependencies` metadata for its locked packages, bit this metadata is optional in the spec;
+so your mileage may vary. If the metadata is not available and was required, Pex will let you know
+with an appropriate error post resolve and pre building the final PEX or venv.
+
+* Add support for `pex --pylock`. (#2766)
+
 ## 2.38.1
 
 This release fixes a long-standing bug parsing requirements files that included other requirements

--- a/pex/artifact_url.py
+++ b/pex/artifact_url.py
@@ -1,0 +1,265 @@
+# Copyright 2025 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import codecs
+import hashlib
+import re
+from collections import defaultdict
+
+from pex import hashing
+from pex.compatibility import PY3, url_unquote, url_unquote_plus, urlparse
+from pex.dist_metadata import is_wheel
+from pex.enum import Enum
+from pex.hashing import HashlibHasher
+from pex.tracer import TRACER
+from pex.typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from typing import (
+        BinaryIO,
+        Container,
+        DefaultDict,
+        Dict,
+        Iterable,
+        List,
+        Mapping,
+        Optional,
+        Sequence,
+        Text,
+        Tuple,
+        Union,
+    )
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
+
+
+class VCS(Enum["VCS.Value"]):
+    class Value(Enum.Value):
+        pass
+
+    Bazaar = Value("bzr")
+    Git = Value("git")
+    Mercurial = Value("hg")
+    Subversion = Value("svn")
+
+
+VCS.seal()
+
+
+@attr.s(frozen=True)
+class VCSScheme(object):
+    vcs = attr.ib()  # type: VCS.Value
+    scheme = attr.ib()  # type: str
+
+
+class ArchiveScheme(Enum["ArchiveScheme.Value"]):
+    class Value(Enum.Value):
+        pass
+
+    FTP = Value("ftp")
+    HTTP = Value("http")
+    HTTPS = Value("https")
+
+
+ArchiveScheme.seal()
+
+
+def parse_scheme(scheme):
+    # type: (str) -> Union[str, ArchiveScheme.Value, VCSScheme]
+    match = re.match(
+        r"""
+        ^
+        (?:
+            (?P<archive_scheme>
+                # Archives
+                  ftp
+                | https?
+            )
+            |
+            (?P<vcs_type>
+                # VCSs: https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support
+                  bzr
+                | git
+                | hg
+                | svn
+            )\+(?P<vcs_scheme>.+)
+        )
+        $
+        """,
+        scheme,
+        re.VERBOSE,
+    )
+    if not match:
+        return scheme
+
+    archive_scheme = match.group("archive_scheme")
+    if archive_scheme:
+        return cast(ArchiveScheme.Value, ArchiveScheme.for_value(archive_scheme))
+
+    return VCSScheme(vcs=VCS.for_value(match.group("vcs_type")), scheme=match.group("vcs_scheme"))
+
+
+@attr.s(frozen=True)
+class Fingerprint(object):
+    @classmethod
+    def from_stream(
+        cls,
+        stream,  # type: BinaryIO
+        algorithm="sha256",  # type: str
+    ):
+        # type: (...) -> Fingerprint
+        digest = hashlib.new(algorithm)
+        hashing.update_hash(filelike=stream, digest=digest)
+        return cls(algorithm=algorithm, hash=digest.hexdigest())
+
+    @classmethod
+    def from_digest(cls, digest):
+        # type: (HashlibHasher) -> Fingerprint
+        return cls.from_hashing_fingerprint(digest.hexdigest())
+
+    @classmethod
+    def from_hashing_fingerprint(cls, fingerprint):
+        # type: (hashing.Fingerprint) -> Fingerprint
+        return cls(algorithm=fingerprint.algorithm, hash=fingerprint)
+
+    algorithm = attr.ib()  # type: str
+    hash = attr.ib()  # type: str
+
+
+# These ranks prefer the highest digest size and then use alphabetic order for a tie-break.
+RANKED_ALGORITHMS = tuple(
+    sorted(
+        hashlib.algorithms_guaranteed,
+        key=lambda alg: (-hashlib.new(alg).digest_size, alg),
+    )
+)
+
+
+def split_requested_revision(artifact_url):
+    # type: (ArtifactURL) -> Tuple[str, Optional[str]]
+    vcs_url, _, requested_revision = artifact_url.normalized_url.partition("@")
+    return vcs_url, requested_revision or None
+
+
+def parse_qs(query_string):
+    # type: (str) -> Dict[str, List[str]]
+    if PY3:
+        return urlparse.parse_qs(query_string)
+    else:
+        # N.B.: Python2.7 splits parameters on `&` _and_ `;`. We only want splits on `&`.
+        parameters = defaultdict(list)  # type: DefaultDict[str, List[str]]
+        for parameter in query_string.split("&"):
+            raw_name, sep, raw_value = parameter.partition("=")
+            if not sep:
+                continue
+            name = url_unquote_plus(raw_name)
+            value = url_unquote_plus(raw_value)
+            parameters[name].append(value)
+        return parameters
+
+
+@attr.s(frozen=True)
+class ArtifactURL(object):
+    @staticmethod
+    def create_fragment(
+        fragment_parameters,  # type: Mapping[str, Iterable[str]]
+        excludes=(),  # type: Container[str]
+    ):
+        # type: (...) -> str
+        return "&".join(
+            sorted(
+                "{name}={value}".format(name=name, value=value)
+                for name, values in fragment_parameters.items()
+                for value in values
+                if name not in excludes
+            )
+        )
+
+    @classmethod
+    def parse(cls, url):
+        # type: (Text) -> ArtifactURL
+
+        try:
+            codecs.encode(url, "ascii")
+        except ValueError as e:
+            raise ValueError(
+                "Invalid URL:{url}\n"
+                "URLs can only contain ASCII octets: {err}".format(url=url, err=e)
+            )
+        else:
+            raw_url = str(url)
+
+        url_info = urlparse.urlparse(raw_url)
+        scheme = parse_scheme(url_info.scheme) if url_info.scheme else "file"
+        path = url_unquote(url_info.path)
+
+        parameters = url_unquote(url_info.params)
+
+        fingerprints = []
+        fragment_parameters = parse_qs(url_info.fragment)
+        if fragment_parameters:
+            # Artifact URLs from indexes may contain pre-computed hashes. We isolate those here,
+            # centrally, if present.
+            # See: https://peps.python.org/pep-0503/#specification
+            for alg in RANKED_ALGORITHMS:
+                hashes = fragment_parameters.pop(alg, None)
+                if not hashes:
+                    continue
+                if len(hashes) > 1 and len(set(hashes)) > 1:
+                    TRACER.log(
+                        "The artifact url contains multiple distinct hash values for the {alg} "
+                        "algorithm, not trusting any of these: {url}".format(alg=alg, url=url)
+                    )
+                    continue
+                fingerprints.append(Fingerprint(algorithm=alg, hash=hashes[0]))
+
+        subdirectories = fragment_parameters.get("subdirectory")
+        subdirectory = subdirectories[-1] if subdirectories else None
+
+        download_url = urlparse.urlunparse(
+            url_info._replace(fragment=cls.create_fragment(fragment_parameters))
+        )
+        normalized_url = urlparse.urlunparse(
+            url_info._replace(path=path, params="", query="", fragment="")
+        )
+        return cls(
+            raw_url=raw_url,
+            url_info=url_info,
+            download_url=download_url,
+            normalized_url=normalized_url,
+            scheme=scheme,
+            path=path,
+            subdirectory=subdirectory,
+            parameters=parameters,
+            fragment_parameters=fragment_parameters,
+            fingerprints=tuple(fingerprints),
+        )
+
+    raw_url = attr.ib(eq=False)  # type: str
+    url_info = attr.ib(eq=False)  # type: urlparse.ParseResult
+    download_url = attr.ib(eq=False)  # type: str
+    normalized_url = attr.ib()  # type: str
+    scheme = attr.ib(eq=False)  # type: Union[str, ArchiveScheme.Value, VCSScheme]
+    path = attr.ib(eq=False)  # type: str
+    subdirectory = attr.ib(eq=False)  # type: Optional[str]
+    parameters = attr.ib(eq=False)  # type: str
+    fragment_parameters = attr.ib(eq=False)  # type: Mapping[str, Sequence[str]]
+    fingerprints = attr.ib(eq=False)  # type: Tuple[Fingerprint, ...]
+
+    def fragment(self, excludes=()):
+        # type: (Container[str]) -> str
+        return self.create_fragment(self.fragment_parameters, excludes=excludes)
+
+    @property
+    def is_wheel(self):
+        # type: () -> bool
+        return is_wheel(self.path)
+
+    @property
+    def fingerprint(self):
+        # type: () -> Optional[Fingerprint]
+        return self.fingerprints[0] if self.fingerprints else None

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -139,7 +139,11 @@ def configure_clp_pex_resolution(parser):
     )
 
     resolver_options.register(
-        group, include_pex_repository=True, include_lock=True, include_pre_resolved=True
+        group,
+        include_pex_repository=True,
+        include_pex_lock=True,
+        include_pylock=True,
+        include_pre_resolved=True,
     )
 
     group.add_argument(

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -1360,7 +1360,7 @@ def do_main(
         pex_builder.build(
             pex_file,
             bytecode_compile=options.compile,
-            deterministic_timestamp=not options.use_system_time,
+            deterministic=not options.use_system_time,
             layout=options.layout,
             compress=options.compress,
             check=options.check,

--- a/pex/cli/commands/venv.py
+++ b/pex/cli/commands/venv.py
@@ -116,7 +116,11 @@ class Venv(OutputMixin, JsonMixin, BuildTimeCommand):
         installer_options.register(parser)
         target_options.register(parser, include_platforms=True)
         resolver_options.register(
-            parser, include_pex_repository=True, include_lock=True, include_pre_resolved=True
+            parser,
+            include_pex_repository=True,
+            include_pex_lock=True,
+            include_pylock=True,
+            include_pre_resolved=True,
         )
         requirement_options.register(parser)
 

--- a/pex/compatibility.py
+++ b/pex/compatibility.py
@@ -126,7 +126,9 @@ if PY3:
     from urllib import parse as _url_parse
     from urllib.error import HTTPError as HTTPError
     from urllib.parse import quote as _url_quote
+    from urllib.parse import quote_plus as _url_quote_plus
     from urllib.parse import unquote as _url_unquote
+    from urllib.parse import unquote_plus as _url_unquote_plus
     from urllib.request import AbstractHTTPHandler as AbstractHTTPHandler
     from urllib.request import FileHandler as FileHandler
     from urllib.request import HTTPBasicAuthHandler as HTTPBasicAuthHandler
@@ -138,7 +140,9 @@ if PY3:
     from urllib.request import build_opener as build_opener
 else:
     from urllib import quote as _url_quote
+    from urllib import quote_plus as _url_quote_plus
     from urllib import unquote as _url_unquote
+    from urllib import unquote_plus as _url_unquote_plus
 
     import urlparse as _url_parse
     from httplib import HTTPConnection as HTTPConnection
@@ -156,8 +160,10 @@ else:
 
 urlparse = _url_parse
 url_unquote = _url_unquote
+url_unquote_plus = _url_unquote_plus
 url_quote = _url_quote
-del _url_parse, _url_unquote, _url_quote
+url_quote_plus = _url_quote_plus
+del _url_parse, _url_unquote, _url_unquote_plus, _url_quote, _url_quote_plus
 
 if PY3:
     from queue import Queue as Queue

--- a/pex/enum.py
+++ b/pex/enum.py
@@ -152,7 +152,6 @@ class Enum(Generic["_V"]):
             "Expected Enum subclass {cls} to have a type parameter that is a subclass of "
             "`Enum.Value`. Instead found {type_var} was of type: {enum_value_type}",
             cls=cls,
-            name=cls.__name__,
             type_var=cls.type_var,
             enum_value_type=enum_value_type,
         )

--- a/pex/pex_builder.py
+++ b/pex/pex_builder.py
@@ -606,7 +606,7 @@ class PEXBuilder(object):
         self,
         path,  # type: str
         bytecode_compile=True,  # type: bool
-        deterministic_timestamp=False,  # type: bool
+        deterministic=False,  # type: bool
         layout=Layout.ZIPAPP,  # type: Layout.Value
         compress=True,  # type: bool
         check=Check.NONE,  # type: Check.Value
@@ -620,7 +620,7 @@ class PEXBuilder(object):
 
         :param path: The path where the PEX should be stored.
         :param bytecode_compile: If True, precompile .py files into .pyc files.
-        :param deterministic_timestamp: If True, will use our hardcoded time for zipfile timestamps.
+        :param deterministic: If True, will use our hardcoded time for zipfile timestamps.
         :param layout: The layout to use for the PEX.
         :param compress: Whether to compress zip entries when building to a layout that uses zip
                          files.
@@ -650,14 +650,14 @@ class PEXBuilder(object):
         elif layout == Layout.PACKED:
             self._build_packedapp(
                 dirname=tmp_pex,
-                deterministic_timestamp=deterministic_timestamp,
+                deterministic=deterministic,
                 compress=compress,
                 bytecode_compile=bytecode_compile,
             )
         else:
             self._build_zipapp(
                 filename=tmp_pex,
-                deterministic_timestamp=deterministic_timestamp,
+                deterministic=deterministic,
                 compress=compress,
                 bytecode_compile=bytecode_compile,
             )
@@ -711,7 +711,7 @@ class PEXBuilder(object):
     def _build_packedapp(
         self,
         dirname,  # type: str
-        deterministic_timestamp=False,  # type: bool
+        deterministic=False,  # type: bool
         compress=True,  # type: bool
         bytecode_compile=False,  # type: bool
     ):
@@ -751,7 +751,7 @@ class PEXBuilder(object):
                 if not atomic_bootstrap_zip_dir.is_finalized():
                     self._chroot.zip(
                         os.path.join(atomic_bootstrap_zip_dir.work_dir, pex_info.bootstrap),
-                        deterministic_timestamp=deterministic_timestamp,
+                        deterministic=deterministic,
                         exclude_file=is_pyc_temporary_file if bytecode_compile else is_pyc_file,
                         strip_prefix=pex_info.bootstrap,
                         labels=("bootstrap",),
@@ -786,7 +786,7 @@ class PEXBuilder(object):
                             if not atomic_zip_dir.is_finalized():
                                 self._chroot.zip(
                                     os.path.join(atomic_zip_dir.work_dir, location),
-                                    deterministic_timestamp=deterministic_timestamp,
+                                    deterministic=deterministic,
                                     exclude_file=is_pyc_temporary_file
                                     if bytecode_compile
                                     else is_pyc_file,
@@ -799,7 +799,7 @@ class PEXBuilder(object):
     def _build_zipapp(
         self,
         filename,  # type: str
-        deterministic_timestamp=False,  # type: bool
+        deterministic=False,  # type: bool
         compress=True,  # type: bool
         bytecode_compile=False,  # type: bool
     ):
@@ -813,7 +813,7 @@ class PEXBuilder(object):
             self._chroot.zip(
                 filename,
                 mode="a",
-                deterministic_timestamp=deterministic_timestamp,
+                deterministic=deterministic,
                 # When configured with a `copy_mode` of `CopyMode.SYMLINK`, we symlink distributions
                 # as pointers to installed wheel directories in <PEX_ROOT>/installed_wheels/...
                 # Since those installed wheels reside in a shared cache, they can be in-use by other

--- a/pex/pip/vcs.py
+++ b/pex/pip/vcs.py
@@ -7,18 +7,17 @@ import os
 import re
 
 from pex import hashing
+from pex.artifact_url import VCS, Fingerprint
 from pex.common import is_pyc_dir, is_pyc_file, open_zip, temporary_dir
 from pex.hashing import Sha256
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
-from pex.requirements import VCS
-from pex.resolve.resolved_requirement import Fingerprint
 from pex.result import Error, try_
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Tuple, Union
+    from typing import Optional, Tuple, Union
 
     from pex.hashing import HintedDigest
 
@@ -61,6 +60,7 @@ def fingerprint_downloaded_vcs_archive(
     project_name,  # type: str
     version,  # type: str
     vcs,  # type: VCS.Value
+    subdirectory=None,  # type: Optional[str]
 ):
     # type: (...) -> Tuple[Fingerprint, str]
 
@@ -70,7 +70,7 @@ def fingerprint_downloaded_vcs_archive(
         )
     )
     digest = Sha256()
-    digest_vcs_archive(archive_path=archive_path, vcs=vcs, digest=digest)
+    digest_vcs_archive(archive_path=archive_path, vcs=vcs, digest=digest, subdirectory=subdirectory)
     return Fingerprint.from_digest(digest), archive_path
 
 
@@ -78,6 +78,7 @@ def digest_vcs_archive(
     archive_path,  # type: str
     vcs,  # type: VCS.Value
     digest,  # type: HintedDigest
+    subdirectory=None,  # type: Optional[str]
 ):
     # type: (...) -> None
 
@@ -101,7 +102,7 @@ def digest_vcs_archive(
 
         # TODO(John Sirois): Consider implementing zip_hash to avoid the extractall.
         hashing.dir_hash(
-            directory=chroot,
+            directory=os.path.join(chroot, subdirectory) if subdirectory else chroot,
             digest=digest,
             dir_filter=(
                 lambda dir_path: (

--- a/pex/requirements.py
+++ b/pex/requirements.py
@@ -24,7 +24,7 @@ from pex.third_party.packaging.version import InvalidVersion, Version
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Iterable, Iterator, Match, Optional, Text, Tuple, Union
+    from typing import FrozenSet, Iterable, Iterator, Match, Optional, Text, Tuple, Union
 
     import attr  # vendor:skip
 else:
@@ -153,6 +153,11 @@ class PyPIRequirement(_ParsedRequirement):
 
     requirement = attr.ib()  # type: Requirement
 
+    @property
+    def extras(self):
+        # type: () -> FrozenSet[str]
+        return self.requirement.extras
+
 
 @attr.s(frozen=True)
 class URLRequirement(_ParsedRequirement):
@@ -160,6 +165,11 @@ class URLRequirement(_ParsedRequirement):
 
     url = attr.ib()  # type: ArtifactURL
     requirement = attr.ib()  # type: Requirement
+
+    @property
+    def extras(self):
+        # type: () -> FrozenSet[str]
+        return self.requirement.extras
 
     @property
     def filename(self):
@@ -184,6 +194,11 @@ class VCSRequirement(_ParsedRequirement):
     vcs = attr.ib()  # type: VCS.Value
     url = attr.ib()  # type: Text
     requirement = attr.ib()  # type: Requirement
+
+    @property
+    def extras(self):
+        # type: () -> FrozenSet[str]
+        return self.requirement.extras
 
 
 def parse_requirement_from_project_name_and_specifier(

--- a/pex/requirements.py
+++ b/pex/requirements.py
@@ -8,6 +8,7 @@ import re
 from contextlib import contextmanager
 
 from pex import attrs, dist_metadata, pex_warnings
+from pex.artifact_url import VCS, ArchiveScheme, ArtifactURL, VCSScheme
 from pex.compatibility import url_unquote, urlparse
 from pex.dist_metadata import (
     MetadataError,
@@ -15,12 +16,12 @@ from pex.dist_metadata import (
     Requirement,
     RequirementParseError,
 )
-from pex.enum import Enum
 from pex.fetcher import URLFetcher
+from pex.pep_503 import ProjectName
 from pex.third_party.packaging.markers import Marker
 from pex.third_party.packaging.specifiers import SpecifierSet
 from pex.third_party.packaging.version import InvalidVersion, Version
-from pex.typing import TYPE_CHECKING, cast
+from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Iterable, Iterator, Match, Optional, Text, Tuple, Union
@@ -157,21 +158,23 @@ class PyPIRequirement(_ParsedRequirement):
 class URLRequirement(_ParsedRequirement):
     """A requirement realized through a distribution archive at a fixed URL."""
 
-    url = attr.ib()  # type: Text
+    url = attr.ib()  # type: ArtifactURL
     requirement = attr.ib()  # type: Requirement
 
+    @property
+    def filename(self):
+        # type: () -> str
+        return os.path.basename(self.url.path)
 
-class VCS(Enum["VCS.Value"]):
-    class Value(Enum.Value):
-        pass
+    @property
+    def project_name(self):
+        return self.requirement.project_name
 
-    Bazaar = Value("bzr")
-    Git = Value("git")
-    Mercurial = Value("hg")
-    Subversion = Value("svn")
-
-
-VCS.seal()
+    @property
+    def subdirectory(self):
+        # type: () -> Optional[str]
+        subdirectories = self.url.fragment_parameters.get("subdirectory")
+        return subdirectories[-1] if subdirectories else None
 
 
 @attr.s(frozen=True)
@@ -235,11 +238,27 @@ class LocalProjectRequirement(_ParsedRequirement):
     extras = attr.ib(default=(), converter=attrs.str_tuple_from_iterable)  # type: Tuple[str, ...]
     marker = attr.ib(default=None)  # type: Optional[Marker]
     editable = attr.ib(default=False)  # type: bool
+    project_name = attr.ib(default=None)  # type: Optional[ProjectName]
 
-    def as_requirement(self, dist):
-        # type: (str) -> Requirement
+    def as_requirement(self, dist=None):
+        # type: (Optional[str]) -> Requirement
         """Create a requirement given a distribution that was built from this local project."""
-        return parse_requirement_from_dist(dist, self.extras, self.marker, self.editable)
+        if dist is None and self.project_name is None:
+            raise ValueError(
+                "No distribution was supplied and the local project at {path} has an unknown "
+                "project name; so no requirement can be calculated.".format(path=self.path)
+            )
+
+        if dist is not None:
+            return parse_requirement_from_dist(dist, self.extras, self.marker, self.editable)
+
+        return parse_requirement_from_project_name_and_specifier(
+            project_name=str(self.project_name),
+            extras=self.extras,
+            marker=self.marker,
+            editable=self.editable,
+            url="file://{path}".format(path=self.path),
+        )
 
 
 if TYPE_CHECKING:
@@ -279,59 +298,6 @@ def _strip_requirement_options(line):
     return editable, re.sub(r"\s--(global-option|install-option|hash).*$", "", processed_text)
 
 
-class ArchiveScheme(Enum["ArchiveScheme.Value"]):
-    class Value(Enum.Value):
-        pass
-
-    FTP = Value("ftp")
-    HTTP = Value("http")
-    HTTPS = Value("https")
-
-
-ArchiveScheme.seal()
-
-
-@attr.s(frozen=True)
-class VCSScheme(object):
-    vcs = attr.ib()  # type: VCS.Value
-    scheme = attr.ib()  # type: str
-
-
-def parse_scheme(scheme):
-    # type: (str) -> Union[str, ArchiveScheme.Value, VCSScheme]
-    match = re.match(
-        r"""
-        ^
-        (?:
-            (?P<archive_scheme>
-                # Archives
-                  ftp
-                | https?
-            )
-            |
-            (?P<vcs_type>
-                # VCSs: https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support
-                  bzr
-                | git
-                | hg
-                | svn
-            )\+(?P<vcs_scheme>.+)
-        )
-        $
-        """,
-        scheme,
-        re.VERBOSE,
-    )
-    if not match:
-        return scheme
-
-    archive_scheme = match.group("archive_scheme")
-    if archive_scheme:
-        return cast(ArchiveScheme.Value, ArchiveScheme.for_value(archive_scheme))
-
-    return VCSScheme(vcs=VCS.for_value(match.group("vcs_type")), scheme=match.group("vcs_scheme"))
-
-
 @attr.s(frozen=True)
 class ProjectNameExtrasAndMarker(object):
     project_name = attr.ib()  # type: Text
@@ -343,20 +309,18 @@ class ProjectNameExtrasAndMarker(object):
         return self.project_name, self.extras, self.marker
 
 
-def _try_parse_fragment_project_name_and_marker(fragment):
-    # type: (Text) -> Optional[ProjectNameExtrasAndMarker]
-    project_requirement = None
-    for part in fragment.split("&"):
-        if part.startswith("egg="):
-            _, project_requirement = part.split("=", 1)
-            break
-    if project_requirement is None:
+def _try_parse_fragment_project_name_and_marker(url):
+    # type: (ArtifactURL) -> Optional[ProjectNameExtrasAndMarker]
+    project_names = url.fragment_parameters.get("egg")
+    if not project_names:
         return None
+
+    project_name = project_names[-1]
     try:
-        req = Requirement.parse(project_requirement)
+        req = Requirement.parse(project_name)
         return ProjectNameExtrasAndMarker(req.name, extras=req.extras, marker=req.marker)
     except (RequirementParseError, ValueError):
-        return ProjectNameExtrasAndMarker(project_requirement)
+        return ProjectNameExtrasAndMarker(project_name)
 
 
 @attr.s(frozen=True)
@@ -482,14 +446,11 @@ def _parse_requirement_line(
 
     editable, processed_text = _strip_requirement_options(line)
     project_name, direct_reference_url = _split_direct_references(processed_text)
-    parsed_url = urlparse.urlparse(direct_reference_url or processed_text)
+    parsed_url = ArtifactURL.parse(direct_reference_url or processed_text)
 
-    parsed_scheme = parse_scheme(parsed_url.scheme)
-    # Handle non local URLs.
-    if isinstance(parsed_scheme, (ArchiveScheme.Value, VCSScheme)):
-        project_name_extras_and_marker = _try_parse_fragment_project_name_and_marker(
-            parsed_url.fragment
-        )
+    # Handle non-local URLs.
+    if isinstance(parsed_url.scheme, (ArchiveScheme.Value, VCSScheme)):
+        project_name_extras_and_marker = _try_parse_fragment_project_name_and_marker(parsed_url)
         project_name, extras, marker = (
             project_name_extras_and_marker.astuple()
             if project_name_extras_and_marker
@@ -508,19 +469,26 @@ def _parse_requirement_line(
         # Pip allows an environment marker after the url which matches the urlparse structure:
         #   scheme://netloc/path;parameters?query#fragment
         # See: https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlparse
-        if not marker and parsed_url.params:
-            marker = Marker(parsed_url.params)
+        if not marker and parsed_url.parameters:
+            marker = Marker(parsed_url.parameters)
         if project_name is None:
             raise ParseError(
                 line,
                 (
-                    "Could not determine a project name for URL requirement {}, consider using "
-                    "#egg=<project name>."
+                    "Could not determine a project name for URL requirement {url}, consider using "
+                    "#egg=<project name>.".format(url=parsed_url.raw_url)
                 ),
             )
+        parsed_url_info = parsed_url.url_info._replace(
+            params="",
+            # Omit `egg=project_name` since that gets moved to a `project_name @` suffix in
+            # `parse_requirement_from_project_name_and_specifier`, but retain all other fragment
+            # parameters; notably, subdirectory when present.
+            fragment=parsed_url.fragment(excludes={"egg"}),
+        )
         # There may be whitespace separated markers; so we strip the trailing whitespace
         # used to support those.
-        url = parsed_url._replace(params="", fragment="").geturl().rstrip()
+        url = parsed_url_info.geturl().rstrip()
         requirement = parse_requirement_from_project_name_and_specifier(
             project_name,
             extras=extras,
@@ -528,13 +496,14 @@ def _parse_requirement_line(
             marker=marker,
             url=url,
         )
+        parsed_scheme = parsed_url.scheme
         if isinstance(parsed_scheme, VCSScheme):
-            url = urlparse.urlparse(url)._replace(scheme=parsed_scheme.scheme).geturl()
+            url = parsed_url_info._replace(scheme=parsed_scheme.scheme).geturl()
             return VCSRequirement(line, parsed_scheme.vcs, url, requirement)
-        return URLRequirement(line, url, requirement)
+        return URLRequirement(line, url=ArtifactURL.parse(url), requirement=requirement)
 
     # Handle local archives and project directories via path or file URL (Pip proprietary).
-    local_requirement = parsed_url._replace(scheme="").geturl()
+    local_requirement = parsed_url.url_info._replace(scheme="").geturl()
     project_name_extras_and_marker = _try_parse_pip_local_formats(
         local_requirement, basepath=basepath
     )
@@ -560,7 +529,11 @@ def _parse_requirement_line(
             requirement = parse_requirement_from_dist(
                 archive_or_project_path, extras=extras, marker=marker
             )
-            return URLRequirement(line, archive_or_project_path, requirement)
+            return URLRequirement(
+                line,
+                url=ArtifactURL.parse(archive_or_project_path),
+                requirement=requirement,
+            )
         except dist_metadata.UnrecognizedDistributionFormat:
             # This is not a recognized local archive distribution. Fall through and try parsing as a
             # PEP-440 requirement.

--- a/pex/resolve/config.py
+++ b/pex/resolve/config.py
@@ -10,6 +10,7 @@ from pex.resolve.resolver_configuration import (
     PexRepositoryConfiguration,
     PipConfiguration,
     PreResolvedConfiguration,
+    PylockRepositoryConfiguration,
 )
 from pex.result import Error, catch, try_
 from pex.targets import Targets
@@ -23,8 +24,9 @@ if TYPE_CHECKING:
     Configuration = Union[
         LockRepositoryConfiguration,
         PexRepositoryConfiguration,
-        PreResolvedConfiguration,
         PipConfiguration,
+        PreResolvedConfiguration,
+        PylockRepositoryConfiguration,
     ]
     _C = TypeVar("_C", bound=Configuration)
 

--- a/pex/resolve/configured_resolve.py
+++ b/pex/resolve/configured_resolve.py
@@ -7,7 +7,8 @@ from pex.common import pluralize
 from pex.dependency_configuration import DependencyConfiguration
 from pex.pep_427 import InstallableType
 from pex.resolve.configured_resolver import ConfiguredResolver
-from pex.resolve.lock_resolver import resolve_from_lock
+from pex.resolve.lock_resolver import resolve_from_pex_lock, resolve_from_pylock
+from pex.resolve.lockfile.pep_751 import Pylock
 from pex.resolve.pex_repository_resolver import resolve_from_pex
 from pex.resolve.pre_resolved_resolver import resolve_from_dists
 from pex.resolve.requirement_configuration import RequirementConfiguration
@@ -15,6 +16,7 @@ from pex.resolve.resolver_configuration import (
     LockRepositoryConfiguration,
     PexRepositoryConfiguration,
     PreResolvedConfiguration,
+    PylockRepositoryConfiguration,
 )
 from pex.resolve.resolvers import ResolveResult
 from pex.resolver import resolve as resolve_via_pip
@@ -45,7 +47,7 @@ def resolve(
         ):
             pip_configuration = resolver_configuration.pip_configuration
             return try_(
-                resolve_from_lock(
+                resolve_from_pex_lock(
                     targets=targets,
                     lock=lock,
                     resolver=ConfiguredResolver(pip_configuration=pip_configuration),
@@ -62,6 +64,37 @@ def resolve(
                     compile=compile_pyc,
                     max_parallel_jobs=pip_configuration.max_jobs,
                     pip_version=lock.pip_version,
+                    use_pip_config=pip_configuration.use_pip_config,
+                    extra_pip_requirements=pip_configuration.extra_requirements,
+                    keyring_provider=pip_configuration.keyring_provider,
+                    result_type=result_type,
+                    dependency_configuration=dependency_configuration,
+                )
+            )
+    elif isinstance(resolver_configuration, PylockRepositoryConfiguration):
+        pylock = try_(Pylock.parse(resolver_configuration.lock_file_path))
+        with TRACER.timed(
+            "Resolving requirements from lock file {lock_file}".format(lock_file=pylock.source)
+        ):
+            pip_configuration = resolver_configuration.pip_configuration
+            return try_(
+                resolve_from_pylock(
+                    targets=targets,
+                    pylock=pylock,
+                    resolver=ConfiguredResolver(pip_configuration=pip_configuration),
+                    requirements=requirement_configuration.requirements,
+                    requirement_files=requirement_configuration.requirement_files,
+                    constraint_files=requirement_configuration.constraint_files,
+                    transitive=pip_configuration.transitive,
+                    indexes=pip_configuration.repos_configuration.indexes,
+                    find_links=pip_configuration.repos_configuration.find_links,
+                    resolver_version=pip_configuration.resolver_version,
+                    network_configuration=pip_configuration.network_configuration,
+                    password_entries=pip_configuration.repos_configuration.password_entries,
+                    build_configuration=pip_configuration.build_configuration,
+                    compile=compile_pyc,
+                    max_parallel_jobs=pip_configuration.max_jobs,
+                    pip_version=pip_configuration.version,
                     use_pip_config=pip_configuration.use_pip_config,
                     extra_pip_requirements=pip_configuration.extra_requirements,
                     keyring_provider=pip_configuration.keyring_provider,

--- a/pex/resolve/configured_resolver.py
+++ b/pex/resolve/configured_resolver.py
@@ -61,7 +61,7 @@ class ConfiguredResolver(Resolver):
     ):
         # type: (...) -> ResolveResult
         return try_(
-            lock_resolver.resolve_from_lock(
+            lock_resolver.resolve_from_pex_lock(
                 targets=targets,
                 lock=lock,
                 resolver=self,

--- a/pex/resolve/downloads.py
+++ b/pex/resolve/downloads.py
@@ -7,6 +7,7 @@ import os.path
 import shutil
 
 from pex import hashing
+from pex.artifact_url import ArtifactURL, Fingerprint
 from pex.atomic_directory import atomic_directory
 from pex.cache.dirs import CacheDir, DownloadDir
 from pex.common import safe_mkdir, safe_mkdtemp
@@ -18,7 +19,7 @@ from pex.pip.installation import get_pip
 from pex.pip.tool import PackageIndexConfiguration, Pip
 from pex.resolve import locker
 from pex.resolve.locked_resolve import Artifact, FileArtifact, LockConfiguration
-from pex.resolve.resolved_requirement import ArtifactURL, Fingerprint, PartialArtifact
+from pex.resolve.resolved_requirement import PartialArtifact
 from pex.resolve.resolvers import Resolver
 from pex.result import Error
 from pex.targets import LocalInterpreter, Target

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -3,31 +3,175 @@
 
 from __future__ import absolute_import
 
+from collections import defaultdict
+
 from pex.auth import PasswordDatabase, PasswordEntry
 from pex.dependency_configuration import DependencyConfiguration
-from pex.dist_metadata import Requirement, is_wheel
+from pex.dist_metadata import Distribution, Requirement, is_wheel
 from pex.network_configuration import NetworkConfiguration
 from pex.pep_427 import InstallableType
+from pex.pep_503 import ProjectName
 from pex.pip.tool import PackageIndexConfiguration
 from pex.pip.version import PipVersionValue
 from pex.resolve.lock_downloader import LockDownloader
-from pex.resolve.locked_resolve import LocalProjectArtifact
+from pex.resolve.locked_resolve import (
+    FileArtifact,
+    LocalProjectArtifact,
+    LockConfiguration,
+    LockStyle,
+)
 from pex.resolve.lockfile.model import Lockfile
-from pex.resolve.lockfile.subset import subset
+from pex.resolve.lockfile.pep_751 import Package, Pylock
+from pex.resolve.lockfile.pep_751 import subset as subset_pylock
+from pex.resolve.lockfile.subset import SubsetResult
+from pex.resolve.lockfile.subset import subset as subset_pex_lock
 from pex.resolve.requirement_configuration import RequirementConfiguration
 from pex.resolve.resolver_configuration import BuildConfiguration, ResolverVersion
 from pex.resolve.resolvers import Resolver, ResolveResult
 from pex.resolver import BuildAndInstallRequest, BuildRequest, InstallRequest
 from pex.result import Error, try_
-from pex.targets import Targets
+from pex.targets import Target, Targets
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import DefaultDict, List, Set
     from typing import Iterable, Optional, Sequence, Tuple, Union
 
 
-def resolve_from_lock(
+def _check_subset(
+    pylock,  # type: Pylock
+    transitive,  # type: bool
+    target,  # type: Target
+    packages,  # type: Sequence[Package]
+    resolved_distributions,  # type: Sequence[Distribution]
+):
+    # type: (...) -> Optional[Error]
+
+    expected_resolve = {package.project_name for package in packages}
+
+    actual_resolve = set()  # type: Set[ProjectName]
+    for resolved_distribution in resolved_distributions:
+        actual_resolve.add(resolved_distribution.metadata.project_name)
+        if transitive:
+            for req in resolved_distribution.metadata.requires_dists:
+                if target.requirement_applies(req):
+                    actual_resolve.add(req.project_name)
+
+    if expected_resolve == actual_resolve:
+        return None
+
+    mismatch_msg = (
+        "Expected the following projects to be resolved:\n"
+        "+ {expected}\n"
+        "\n"
+        "Actually resolved:\n"
+        "+ {actual}".format(
+            expected="\n+ ".join(sorted(map(str, expected_resolve))),
+            actual="\n+ ".join(sorted(map(str, actual_resolve))),
+        )
+    )
+    if pylock.created_by == "pex":
+        return Error(mismatch_msg)
+
+    return Error(
+        "{mismatch_msg}\n"
+        "\n"
+        "The lock {lock_desc} likely does not include optional `dependencies` metadata for its "
+        "packages.\n"
+        "This metadata is required for Pex to subset a PEP-751 lock.".format(
+            mismatch_msg=mismatch_msg, lock_desc=pylock.render_description()
+        )
+    )
+
+
+def resolve_from_pylock(
+    targets,  # type: Targets
+    pylock,  # type: Pylock
+    resolver,  # type: Resolver
+    requirements=None,  # type: Optional[Iterable[str]]
+    requirement_files=None,  # type: Optional[Iterable[str]]
+    constraint_files=None,  # type: Optional[Iterable[str]]
+    indexes=None,  # type: Optional[Sequence[str]]
+    find_links=None,  # type: Optional[Sequence[str]]
+    resolver_version=None,  # type: Optional[ResolverVersion.Value]
+    network_configuration=None,  # type: Optional[NetworkConfiguration]
+    password_entries=(),  # type: Iterable[PasswordEntry]
+    build_configuration=BuildConfiguration(),  # type: BuildConfiguration
+    compile=False,  # type: bool
+    transitive=True,  # type: bool
+    verify_wheels=True,  # type: bool
+    max_parallel_jobs=None,  # type: Optional[int]
+    pip_version=None,  # type: Optional[PipVersionValue]
+    use_pip_config=False,  # type: bool
+    extra_pip_requirements=(),  # type: Tuple[Requirement, ...]
+    keyring_provider=None,  # type: Optional[str]
+    result_type=InstallableType.INSTALLED_WHEEL_CHROOT,  # type: InstallableType.Value
+    dependency_configuration=DependencyConfiguration(),  # type: DependencyConfiguration
+):
+    # type: (...) -> Union[ResolveResult, Error]
+
+    requirement_configuration = RequirementConfiguration(
+        requirements=requirements,
+        requirement_files=requirement_files,
+        constraint_files=constraint_files,
+    )
+    pylock_subset_result = try_(
+        subset_pylock(
+            targets=targets,
+            pylock=pylock,
+            requirement_configuration=requirement_configuration,
+            network_configuration=network_configuration,
+            build_configuration=build_configuration,
+            transitive=transitive,
+            dependency_configuration=dependency_configuration,
+        )
+    )
+    resolve_result = _resolve_from_subset_result(
+        pylock_subset_result.subset_result,
+        # This ensures artifact downloads via Pip will not be rejected by Pip for mismatched
+        # target interpreters, etc.
+        lock_configuration=LockConfiguration(
+            style=LockStyle.UNIVERSAL,
+            requires_python=tuple([pylock.requires_python]) if pylock.requires_python else (),
+        ),
+        resolver=resolver,
+        indexes=indexes,
+        find_links=find_links,
+        resolver_version=resolver_version,
+        network_configuration=network_configuration,
+        password_entries=password_entries,
+        build_configuration=build_configuration,
+        compile=compile,
+        verify_wheels=verify_wheels,
+        max_parallel_jobs=max_parallel_jobs,
+        pip_version=pip_version,
+        use_pip_config=use_pip_config,
+        extra_pip_requirements=extra_pip_requirements,
+        keyring_provider=keyring_provider,
+        result_type=result_type,
+        dependency_configuration=dependency_configuration,
+    )
+    if not requirement_configuration.has_requirements or isinstance(resolve_result, Error):
+        return resolve_result
+
+    resolved_distributions_by_target = defaultdict(
+        list
+    )  # type: DefaultDict[Target, List[Distribution]]
+    for resolved_distribution in resolve_result.distributions:
+        resolved_distributions_by_target[resolved_distribution.target].append(
+            resolved_distribution.distribution
+        )
+    for target, packages in pylock_subset_result.packages_by_target.items():
+        resolved_distributions = resolved_distributions_by_target[target]
+        error = _check_subset(pylock, transitive, target, packages, resolved_distributions)
+        if error:
+            return error
+
+    return resolve_result
+
+
+def resolve_from_pex_lock(
     targets,  # type: Targets
     lock,  # type: Lockfile
     resolver,  # type: Resolver
@@ -55,7 +199,7 @@ def resolve_from_lock(
 
     dependency_configuration = lock.dependency_configuration().merge(dependency_configuration)
     subset_result = try_(
-        subset(
+        subset_pex_lock(
             targets=targets,
             lock=lock,
             requirement_configuration=RequirementConfiguration(
@@ -69,15 +213,58 @@ def resolve_from_lock(
             dependency_configuration=dependency_configuration,
         )
     )
+    return _resolve_from_subset_result(
+        subset_result,
+        lock_configuration=lock.lock_configuration(),
+        resolver=resolver,
+        indexes=indexes,
+        find_links=find_links,
+        resolver_version=resolver_version,
+        network_configuration=network_configuration,
+        password_entries=password_entries,
+        build_configuration=build_configuration,
+        compile=compile,
+        verify_wheels=verify_wheels,
+        max_parallel_jobs=max_parallel_jobs,
+        pip_version=pip_version,
+        use_pip_config=use_pip_config,
+        extra_pip_requirements=extra_pip_requirements,
+        keyring_provider=keyring_provider,
+        result_type=result_type,
+        dependency_configuration=dependency_configuration,
+    )
+
+
+def _resolve_from_subset_result(
+    subset_result,  # type: SubsetResult
+    lock_configuration,  # type: LockConfiguration
+    resolver,  # type: Resolver
+    indexes=None,  # type: Optional[Sequence[str]]
+    find_links=None,  # type: Optional[Sequence[str]]
+    resolver_version=None,  # type: Optional[ResolverVersion.Value]
+    network_configuration=None,  # type: Optional[NetworkConfiguration]
+    password_entries=(),  # type: Iterable[PasswordEntry]
+    build_configuration=BuildConfiguration(),  # type: BuildConfiguration
+    compile=False,  # type: bool
+    verify_wheels=True,  # type: bool
+    max_parallel_jobs=None,  # type: Optional[int]
+    pip_version=None,  # type: Optional[PipVersionValue]
+    use_pip_config=False,  # type: bool
+    extra_pip_requirements=(),  # type: Tuple[Requirement, ...]
+    keyring_provider=None,  # type: Optional[str]
+    result_type=InstallableType.INSTALLED_WHEEL_CHROOT,  # type: InstallableType.Value
+    dependency_configuration=DependencyConfiguration(),  # type: DependencyConfiguration
+):
+    # type: (...) -> Union[ResolveResult, Error]
+
     downloadable_artifacts_and_targets = tuple(
         (downloadable_artifact, resolved_subset.target)
         for resolved_subset in subset_result.subsets
         for downloadable_artifact in resolved_subset.resolved.downloadable_artifacts
     )
-
     lock_downloader = LockDownloader.create(
         targets=tuple(resolved_subset.target for resolved_subset in subset_result.subsets),
-        lock=lock,
+        lock_configuration=lock_configuration,
         resolver=resolver,
         indexes=indexes,
         find_links=find_links,
@@ -102,7 +289,6 @@ def resolve_from_lock(
         )
         if isinstance(downloaded_artifacts, Error):
             return downloaded_artifacts
-
     with TRACER.timed("Categorizing {} downloaded artifacts".format(len(downloaded_artifacts))):
         build_requests = []
         install_requests = []
@@ -123,9 +309,13 @@ def resolve_from_lock(
                             target=resolved_subset.target,
                             source_path=downloaded_artifact.path,
                             fingerprint=downloaded_artifact.fingerprint,
+                            subdirectory=(
+                                downloadable_artifact.artifact.subdirectory
+                                if isinstance(downloadable_artifact.artifact, FileArtifact)
+                                else None
+                            ),
                         )
                     )
-
     with TRACER.timed(
         "Building {} artifacts and installing {}".format(
             len(build_requests), len(build_requests) + len(install_requests)

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -35,8 +35,7 @@ from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import DefaultDict, List, Set
-    from typing import Iterable, Optional, Sequence, Tuple, Union
+    from typing import DefaultDict, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
 
 def _check_subset(

--- a/pex/resolve/locked_resolve.py
+++ b/pex/resolve/locked_resolve.py
@@ -3,11 +3,13 @@
 
 from __future__ import absolute_import, division
 
+import functools
 import itertools
 import os
 from collections import OrderedDict, defaultdict, deque
 from functools import total_ordering
 
+from pex.artifact_url import VCS, ArtifactURL, Fingerprint, VCSScheme
 from pex.common import pluralize
 from pex.dependency_configuration import DependencyConfiguration
 from pex.dist_metadata import DistMetadata, Requirement, is_sdist, is_wheel
@@ -17,20 +19,13 @@ from pex.orderedset import OrderedSet
 from pex.pep_425 import CompatibilityTags, TagRank
 from pex.pep_503 import ProjectName
 from pex.rank import Rank
-from pex.requirements import VCS, VCSScheme
-from pex.resolve.resolved_requirement import (
-    ArtifactURL,
-    Fingerprint,
-    PartialArtifact,
-    Pin,
-    ResolvedRequirement,
-)
+from pex.resolve.resolved_requirement import PartialArtifact, Pin, ResolvedRequirement
 from pex.resolve.resolver_configuration import BuildConfiguration
 from pex.result import Error
 from pex.sorted_tuple import SortedTuple
 from pex.targets import Target
 from pex.tracer import TRACER
-from pex.typing import TYPE_CHECKING
+from pex.typing import TYPE_CHECKING, Generic
 
 if TYPE_CHECKING:
     from typing import (
@@ -45,6 +40,7 @@ if TYPE_CHECKING:
         Protocol,
         Set,
         Tuple,
+        TypeVar,
         Union,
     )
 
@@ -111,7 +107,24 @@ class LockConfiguration(object):
 
 @total_ordering
 @attr.s(frozen=True, order=False)
-class Artifact(object):
+class UnFingerprintedArtifact(object):
+    url = attr.ib()  # type: ArtifactURL
+    verified = attr.ib()  # type: bool
+
+    @property
+    def subdirectory(self):
+        # type: () -> Optional[str]
+        return self.url.subdirectory
+
+    def __lt__(self, other):
+        # type: (Any) -> bool
+        if not isinstance(other, UnFingerprintedArtifact):
+            return NotImplemented
+        return self.url < other.url
+
+
+@attr.s(frozen=True, order=False)
+class Artifact(UnFingerprintedArtifact):
     @classmethod
     def from_artifact_url(
         cls,
@@ -173,15 +186,7 @@ class Artifact(object):
             editable=editable,
         )
 
-    url = attr.ib()  # type: ArtifactURL
     fingerprint = attr.ib()  # type: Fingerprint
-    verified = attr.ib()  # type: bool
-
-    def __lt__(self, other):
-        # type: (Any) -> bool
-        if not isinstance(other, Artifact):
-            return NotImplemented
-        return self.url < other.url
 
 
 @attr.s(frozen=True, order=False)
@@ -217,7 +222,25 @@ class LocalProjectArtifact(Artifact):
 
 
 @attr.s(frozen=True, order=False)
+class UnFingerprintedLocalProjectArtifact(UnFingerprintedArtifact):
+    directory = attr.ib()  # type: str
+    editable = attr.ib(default=False)  # type: bool
+
+    @property
+    def is_source(self):
+        # type: () -> bool
+        return True
+
+
+@attr.s(frozen=True, order=False)
 class VCSArtifact(Artifact):
+    @staticmethod
+    def split_requested_revision(artifact_url):
+        # type: (ArtifactURL) -> Tuple[str, Optional[str]]
+
+        vcs_url, _, requested_revision = artifact_url.normalized_url.partition("@")
+        return vcs_url, requested_revision or None
+
     @classmethod
     def from_artifact_url(
         cls,
@@ -235,24 +258,19 @@ class VCSArtifact(Artifact):
                 )
             )
 
-        vcs_url, _, requested_revision = artifact_url.normalized_url.partition("@")
-        subdirectories = artifact_url.fragment_parameters.get("subdirectory")
+        _, requested_revision = cls.split_requested_revision(artifact_url)
         return cls(
             url=artifact_url,
             fingerprint=fingerprint,
             verified=verified,
             vcs=artifact_url.scheme.vcs,
-            vcs_url=vcs_url,
-            requested_revision=requested_revision or None,
+            requested_revision=requested_revision,
             commit_id=commit_id,
-            subdirectory=subdirectories[-1] if subdirectories else None,
         )
 
     vcs = attr.ib()  # type: VCS.Value
-    vcs_url = attr.ib()  # type: str
     requested_revision = attr.ib(default=None)  # type: Optional[str]
     commit_id = attr.ib(default=None)  # type: Optional[str]
-    subdirectory = attr.ib(default=None)  # type: Optional[str]
 
     @property
     def is_source(self):
@@ -260,13 +278,47 @@ class VCSArtifact(Artifact):
 
     def as_unparsed_requirement(self, project_name):
         # type: (ProjectName) -> str
+
         names = self.url.fragment_parameters.get("egg")
         if names and ProjectName(names[-1]) == project_name:
             # A Pip proprietary VCS requirement.
             return self.url.raw_url
+
         # A PEP-440 direct reference VCS requirement with the project name stripped from earlier
         # processing. See: https://peps.python.org/pep-0440/#direct-references
         return "{project_name} @ {url}".format(project_name=project_name, url=self.url.raw_url)
+
+
+@attr.s(frozen=True, order=False)
+class UnFingerprintedVCSArtifact(UnFingerprintedArtifact):
+    vcs = attr.ib()  # type: VCS.Value
+    requested_revision = attr.ib(default=None)  # type: Optional[str]
+    commit_id = attr.ib(default=None)  # type: Optional[str]
+
+    @property
+    def is_source(self):
+        return True
+
+    def as_unparsed_requirement(self, project_name):
+        # type: (ProjectName) -> str
+
+        # A PEP-440 direct reference VCS requirement with the project name and vcs stripped from
+        # earlier processing. See: https://peps.python.org/pep-0440/#direct-references
+        return "{project_name} @ {vcs}+{url}{ref}{subdirectory}".format(
+            project_name=project_name,
+            vcs=self.vcs,
+            url=self.url.normalized_url,
+            ref=(
+                "@{ref}".format(ref=self.commit_id or self.requested_revision)
+                if self.commit_id or self.requested_revision
+                else ""
+            ),
+            subdirectory=(
+                "#subdirectory={subdirectory}".format(subdirectory=self.subdirectory)
+                if self.subdirectory
+                else ""
+            ),
+        )
 
 
 @attr.s(frozen=True)
@@ -473,85 +525,78 @@ class DownloadableArtifact(object):
     def create(
         cls,
         pin,  # type: Pin
-        artifact,  # type: Union[FileArtifact, LocalProjectArtifact, VCSArtifact]
+        artifact,  # type: Union[FileArtifact, LocalProjectArtifact, UnFingerprintedLocalProjectArtifact, UnFingerprintedVCSArtifact, VCSArtifact]
         satisfied_direct_requirements=(),  # type: Iterable[Requirement]
     ):
         # type: (...) -> DownloadableArtifact
         return cls(
-            pin=pin,
+            project_name=pin.project_name,
+            version=pin.version,
             artifact=artifact,
             satisfied_direct_requirements=SortedTuple(satisfied_direct_requirements, key=str),
         )
 
-    pin = attr.ib()  # type: Pin
-    artifact = attr.ib()  # type: Union[FileArtifact, LocalProjectArtifact, VCSArtifact]
+    project_name = attr.ib()  # type: ProjectName
+    artifact = (
+        attr.ib()
+    )  # type: Union[FileArtifact, LocalProjectArtifact, UnFingerprintedLocalProjectArtifact, UnFingerprintedVCSArtifact, VCSArtifact]
     satisfied_direct_requirements = attr.ib(default=SortedTuple())  # type: SortedTuple[Requirement]
+    version = attr.ib(default=None)
 
-
-@attr.s(frozen=True)
-class Resolved(object):
-    @classmethod
-    def create(
-        cls,
-        target,  # type: Target
-        direct_requirements,  # type: Iterable[Requirement]
-        resolved_artifacts,  # type: Iterable[_ResolvedArtifact]
-        source,  # type: LockedResolve
-    ):
-        # type: (...) -> Resolved
-
-        direct_requirements_by_project_name = defaultdict(
-            list
-        )  # type: DefaultDict[ProjectName, List[Requirement]]
-        for requirement in direct_requirements:
-            direct_requirements_by_project_name[requirement.project_name].append(requirement)
-
-        # N.B.: Lowest rank means highest rank value. I.E.: The 1st tag is the most specific and
-        # the 765th tag is the least specific.
-        largest_rank_value = target.supported_tags.lowest_rank.value
-        smallest_rank_value = TagRank.highest_natural().value
-        rank_span = largest_rank_value - smallest_rank_value
-
-        downloadable_artifacts = []
-        target_specificities = []
-        for resolved_artifact in resolved_artifacts:
-            pin = resolved_artifact.locked_requirement.pin
-            downloadable_artifacts.append(
-                DownloadableArtifact.create(
-                    pin=pin,
-                    artifact=resolved_artifact.artifact,
-                    satisfied_direct_requirements=direct_requirements_by_project_name[
-                        pin.project_name
-                    ],
-                )
+    def specifier(self):
+        # type: () -> str
+        if self.version:
+            return "{project_name} {version}".format(
+                project_name=self.project_name, version=self.version
             )
-            target_specificities.append(
-                (rank_span - (resolved_artifact.ranked_artifact.rank.value - smallest_rank_value))
-                / rank_span
-            )
+        return str(self.project_name)
 
-        return cls(
-            target_specificity=(
-                smallest_rank_value
-                if not target_specificities
-                else sum(target_specificities) / len(target_specificities)
-            ),
-            downloadable_artifacts=tuple(downloadable_artifacts),
-            source=source,
-        )
 
+if TYPE_CHECKING:
+    Source = TypeVar("Source")
+
+
+@functools.total_ordering
+class Resolved(Generic["Source"]):
     @classmethod
     def most_specific(cls, resolves):
-        # type: (Iterable[Resolved]) -> Resolved
+        # type: (Iterable[Resolved[Source]]) -> Resolved[Source]
         sorted_resolves = sorted(resolves)
         if len(sorted_resolves) == 0:
             raise ValueError("Given no resolves to pick from.")
         # The most specific has the highest specificity which sorts last.
         return sorted_resolves[-1]
 
-    target_specificity = attr.ib()  # type: float
-    downloadable_artifacts = attr.ib()  # type: Tuple[DownloadableArtifact, ...]
-    source = attr.ib(eq=False)  # type: LockedResolve
+    def __init__(
+        self,
+        target_specificity,  # type: float
+        downloadable_artifacts,  # type: Iterable[DownloadableArtifact]
+        source,  # type: Source
+    ):
+        # type: (...) -> None
+        self.target_specificity = target_specificity
+        self.downloadable_artifacts = tuple(downloadable_artifacts)
+        self.source = source
+
+    def _tup(self):
+        # type: () -> Tuple[float, Tuple[DownloadableArtifact, ...]]
+        return self.target_specificity, self.downloadable_artifacts
+
+    def __eq__(self, other):
+        # type: (Any) -> bool
+        if isinstance(other, Resolved):
+            return self._tup() == other._tup()
+        return NotImplemented
+
+    def __hash__(self):
+        # type: () -> int
+        return hash(self._tup())
+
+    def __lt__(self, other):
+        # type: (Any) -> bool
+        if isinstance(other, Resolved):
+            return self.target_specificity < other.target_specificity
+        return NotImplemented
 
 
 if TYPE_CHECKING:
@@ -650,6 +695,54 @@ class LockedResolve(object):
         # type: () -> str
         return str(self.platform_tag) if self.platform_tag else "universal"
 
+    def create_resolved_artifacts(
+        self,
+        target,  # type: Target
+        direct_requirements,  # type: Iterable[Requirement]
+        resolved_artifacts,  # type: Iterable[_ResolvedArtifact]
+    ):
+        # type: (...) -> Resolved[LockedResolve]
+
+        direct_requirements_by_project_name = defaultdict(
+            list
+        )  # type: DefaultDict[ProjectName, List[Requirement]]
+        for requirement in direct_requirements:
+            direct_requirements_by_project_name[requirement.project_name].append(requirement)
+
+        # N.B.: Lowest rank means highest rank value. I.E.: The 1st tag is the most specific and
+        # the 765th tag is the least specific.
+        largest_rank_value = target.supported_tags.lowest_rank.value
+        smallest_rank_value = TagRank.highest_natural().value
+        rank_span = largest_rank_value - smallest_rank_value
+
+        downloadable_artifacts = []
+        target_specificities = []
+        for resolved_artifact in resolved_artifacts:
+            pin = resolved_artifact.locked_requirement.pin
+            downloadable_artifacts.append(
+                DownloadableArtifact.create(
+                    pin=pin,
+                    artifact=resolved_artifact.artifact,
+                    satisfied_direct_requirements=direct_requirements_by_project_name[
+                        pin.project_name
+                    ],
+                )
+            )
+            target_specificities.append(
+                (rank_span - (resolved_artifact.ranked_artifact.rank.value - smallest_rank_value))
+                / rank_span
+            )
+
+        return Resolved[LockedResolve](
+            target_specificity=(
+                smallest_rank_value
+                if not target_specificities
+                else sum(target_specificities) / len(target_specificities)
+            ),
+            downloadable_artifacts=tuple(downloadable_artifacts),
+            source=self,
+        )
+
     def resolve(
         self,
         target,  # type: Target
@@ -661,7 +754,7 @@ class LockedResolve(object):
         include_all_matches=False,  # type: bool
         dependency_configuration=DependencyConfiguration(),  # type: DependencyConfiguration
     ):
-        # type: (...) -> Union[Resolved, Error]
+        # type: (...) -> Union[Resolved[LockedResolve], Error]
 
         repository = defaultdict(list)  # type: DefaultDict[ProjectName, List[LockedRequirement]]
         for locked_requirement in self.locked_requirements:
@@ -891,9 +984,8 @@ class LockedResolve(object):
                 uniqued_resolved_artifacts.append(resolved_artifact)
                 seen.add(resolved_artifact.ranked_artifact.artifact)
 
-        return Resolved.create(
+        return self.create_resolved_artifacts(
             target=target,
             direct_requirements=requirements,
             resolved_artifacts=uniqued_resolved_artifacts,
-            source=self,
         )

--- a/pex/resolve/locked_resolve.py
+++ b/pex/resolve/locked_resolve.py
@@ -236,10 +236,10 @@ class UnFingerprintedLocalProjectArtifact(UnFingerprintedArtifact):
 class VCSArtifact(Artifact):
     @staticmethod
     def split_requested_revision(artifact_url):
-        # type: (ArtifactURL) -> Tuple[str, Optional[str]]
+        # type: (ArtifactURL) -> Tuple[ArtifactURL, Optional[str]]
 
         vcs_url, _, requested_revision = artifact_url.normalized_url.partition("@")
-        return vcs_url, requested_revision or None
+        return ArtifactURL.parse(vcs_url), requested_revision or None
 
     @classmethod
     def from_artifact_url(

--- a/pex/resolve/locker.py
+++ b/pex/resolve/locker.py
@@ -10,6 +10,7 @@ import re
 from collections import OrderedDict, defaultdict
 
 from pex import hashing
+from pex.artifact_url import ArchiveScheme, ArtifactURL, Fingerprint, VCSScheme
 from pex.common import safe_mkdtemp
 from pex.compatibility import urlparse
 from pex.dist_metadata import ProjectNameAndVersion, Requirement
@@ -22,17 +23,11 @@ from pex.pip.local_project import digest_local_project
 from pex.pip.log_analyzer import LogAnalyzer
 from pex.pip.vcs import fingerprint_downloaded_vcs_archive
 from pex.pip.version import PipVersionValue
-from pex.requirements import ArchiveScheme, LocalProjectRequirement, VCSRequirement, VCSScheme
+from pex.requirements import LocalProjectRequirement, VCSRequirement
 from pex.resolve.locked_resolve import LockConfiguration, LockStyle, TargetSystem
 from pex.resolve.pep_691.fingerprint_service import FingerprintService
 from pex.resolve.pep_691.model import Endpoint
-from pex.resolve.resolved_requirement import (
-    ArtifactURL,
-    Fingerprint,
-    PartialArtifact,
-    Pin,
-    ResolvedRequirement,
-)
+from pex.resolve.resolved_requirement import PartialArtifact, Pin, ResolvedRequirement
 from pex.resolve.resolvers import Resolver
 from pex.targets import Target
 from pex.typing import TYPE_CHECKING
@@ -384,6 +379,7 @@ class Locker(LogAnalyzer):
                         project_name=str(build_result.pin.project_name),
                         version=str(build_result.pin.version),
                         vcs=artifact_url.scheme.vcs,
+                        subdirectory=artifact_url.subdirectory,
                     )
                     verified = True
                     selected_path = os.path.basename(archive_path)

--- a/pex/resolve/lockfile/download_manager.py
+++ b/pex/resolve/lockfile/download_manager.py
@@ -10,21 +10,25 @@ import os
 from pex import hashing
 from pex.atomic_directory import atomic_directory
 from pex.cache.dirs import DownloadDir
-from pex.common import safe_rmtree
+from pex.common import safe_mkdtemp, safe_rmtree
 from pex.fs.lock import FileLockStyle
 from pex.pep_503 import ProjectName
-from pex.resolve.locked_resolve import Artifact
+from pex.resolve.locked_resolve import (
+    Artifact,
+    UnFingerprintedLocalProjectArtifact,
+    UnFingerprintedVCSArtifact,
+)
 from pex.result import Error, ResultError, try_
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING, Generic
 from pex.variables import ENV, Variables
 
 if TYPE_CHECKING:
-    from typing import List, TypeVar, Union
+    from typing import List, Optional, TypeVar, Union
 
     import attr  # vendor:skip
 
-    from pex.hashing import HintedDigest
+    from pex.hashing import Hasher, HintedDigest
 
     _A = TypeVar("_A", bound=Artifact)
 else:
@@ -127,62 +131,19 @@ class DownloadManager(Generic["_A"]):
     ):
         # type: (...) -> DownloadedArtifact
 
-        download_dir = DownloadDir.create(
-            file_hash=artifact.fingerprint.hash, pex_root=self._pex_root
-        )
-        with atomic_directory(download_dir, lock_style=self._file_lock_style) as atomic_dir:
-            if atomic_dir.is_finalized():
-                TRACER.log("Using cached artifact at {} for {}".format(download_dir, artifact))
-            else:
-                legacy_internal_fingerprint = hashing.Sha1()  # Legacy internal
-                internal_fingerprint = hashing.Sha256()  # Internal
-                digests = [
-                    legacy_internal_fingerprint,
-                    internal_fingerprint,
-                ]  # type: List[HintedDigest]
+        if hasattr(artifact, "fingerprint"):
+            download_dir = DownloadDir.create(
+                file_hash=artifact.fingerprint.hash, pex_root=self._pex_root
+            )  # type: str
+            with atomic_directory(download_dir, lock_style=self._file_lock_style) as atomic_dir:
+                if atomic_dir.is_finalized():
+                    TRACER.log("Using cached artifact at {} for {}".format(download_dir, artifact))
+                else:
+                    self._download(artifact, project_name, atomic_dir.work_dir)
+        else:
+            download_dir = safe_mkdtemp()
+            self._download(artifact, project_name, download_dir)
 
-                # The locking process will have pre-calculated some artifact fingerprints ahead of
-                # time; these will be marked as verified and can be trusted.
-                if not artifact.verified:
-                    # For the rest (E.G.: PyPI URLs with embedded fingerprints), we distrust and
-                    # establish our own fingerprint. This will mostly be wasted effort since we
-                    # share the same hash algorithm as PyPI currently, but it will serve to upgrade
-                    # the fingerprint on other cheeseshops that use a lower-grade hash algorithm (
-                    # See: https://peps.python.org/pep-0503/#specification).
-                    check = hashlib.new(artifact.fingerprint.algorithm)  # External
-                    digests.append(check)
-
-                with TRACER.timed("Downloading {artifact}".format(artifact=artifact)):
-                    filename = try_(
-                        self.save(
-                            artifact=artifact,
-                            project_name=project_name,
-                            dest_dir=atomic_dir.work_dir,
-                            digest=hashing.MultiDigest(digests),
-                        )
-                    )
-
-                if not artifact.verified:
-                    actual_hash = check.hexdigest()
-                    if artifact.fingerprint.hash != actual_hash:
-                        raise ResultError(
-                            Error(
-                                "Expected {algorithm} hash of {expected_hash} when downloading "
-                                "{project_name} but hashed to {actual_hash}.".format(
-                                    algorithm=artifact.fingerprint.algorithm,
-                                    expected_hash=artifact.fingerprint.hash,
-                                    project_name=project_name,
-                                    actual_hash=actual_hash,
-                                )
-                            )
-                        )
-
-                DownloadedArtifact.store(
-                    artifact_dir=atomic_dir.work_dir,
-                    filename=filename,
-                    legacy_fingerprint=legacy_internal_fingerprint.hexdigest(),
-                    fingerprint=internal_fingerprint.hexdigest(),
-                )
         try:
             return DownloadedArtifact.load(download_dir)
         except DownloadedArtifact.LoadError as e:
@@ -194,6 +155,69 @@ class DownloadManager(Generic["_A"]):
             )
             safe_rmtree(download_dir)
             return self.store(artifact, project_name, retry=False)
+
+    def _download(
+        self,
+        artifact,  # type: _A
+        project_name,  # type: ProjectName
+        dest_dir,  # type: str
+    ):
+        # type: (...) -> None
+
+        # The locking process will have pre-calculated some artifact fingerprints ahead of
+        # time; these will be marked as verified and can be trusted.
+        perform_hash_check = not artifact.verified and not isinstance(
+            artifact, (UnFingerprintedLocalProjectArtifact, UnFingerprintedVCSArtifact)
+        )
+
+        legacy_internal_fingerprint = hashing.Sha1()  # Legacy internal
+        internal_fingerprint = hashing.Sha256()  # Internal
+        digests = [
+            legacy_internal_fingerprint,
+            internal_fingerprint,
+        ]  # type: List[HintedDigest]
+
+        check = None  # type: Optional[Hasher]
+        if perform_hash_check:
+            # For the rest (E.G.: PyPI URLs with embedded fingerprints), we distrust and
+            # establish our own fingerprint. This will mostly be wasted effort since we
+            # share the same hash algorithm as PyPI currently, but it will serve to upgrade
+            # the fingerprint on other cheeseshops that use a lower-grade hash algorithm (
+            # See: https://peps.python.org/pep-0503/#specification).
+            check = hashlib.new(artifact.fingerprint.algorithm)  # External
+            digests.append(check)
+
+        with TRACER.timed("Downloading {artifact}".format(artifact=artifact)):
+            filename = try_(
+                self.save(
+                    artifact=artifact,
+                    project_name=project_name,
+                    dest_dir=dest_dir,
+                    digest=hashing.MultiDigest(digests),
+                )
+            )
+
+        if check:
+            actual_hash = check.hexdigest()
+            if artifact.fingerprint.hash != actual_hash:
+                raise ResultError(
+                    Error(
+                        "Expected {algorithm} hash of {expected_hash} when downloading "
+                        "{project_name} but hashed to {actual_hash}.".format(
+                            algorithm=artifact.fingerprint.algorithm,
+                            expected_hash=artifact.fingerprint.hash,
+                            project_name=project_name,
+                            actual_hash=actual_hash,
+                        )
+                    )
+                )
+
+        DownloadedArtifact.store(
+            artifact_dir=dest_dir,
+            filename=filename,
+            legacy_fingerprint=legacy_internal_fingerprint.hexdigest(),
+            fingerprint=internal_fingerprint.hexdigest(),
+        )
 
     def save(
         self,

--- a/pex/resolve/lockfile/json_codec.py
+++ b/pex/resolve/lockfile/json_codec.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 import json
 
 from pex import compatibility
+from pex.artifact_url import Fingerprint
 from pex.dist_metadata import Requirement, RequirementParseError
 from pex.enum import Enum
 from pex.pep_440 import Version
@@ -23,7 +24,7 @@ from pex.resolve.locked_resolve import (
 )
 from pex.resolve.lockfile.model import Lockfile
 from pex.resolve.path_mappings import PathMappings
-from pex.resolve.resolved_requirement import Fingerprint, Pin
+from pex.resolve.resolved_requirement import Pin
 from pex.resolve.resolver_configuration import BuildConfiguration, PipConfiguration, ResolverVersion
 from pex.sorted_tuple import SortedTuple
 from pex.third_party.packaging import tags

--- a/pex/resolve/lockfile/pep_751.py
+++ b/pex/resolve/lockfile/pep_751.py
@@ -994,7 +994,7 @@ class PackageParser(object):
 
             path = directory_parse_context.get_string("path")
             if not os.path.isabs(path):
-                path = os.path.join(os.path.dirname(self.source), path)
+                path = os.path.normpath(os.path.join(os.path.dirname(self.source), path))
             subdirectory = directory_parse_context.get_string("subdirectory", default="") or None
             if subdirectory:
                 path = os.path.normpath(os.path.join(path, subdirectory))
@@ -1249,11 +1249,13 @@ class Pylock(object):
         packages = []  # type: List[Package]
         for indexed_package in package_index.iter_packages():
             package = try_(package_parser.parse(indexed_package))
-            if isinstance(package.artifact, LocalProjectArtifact):
+            if isinstance(package.artifact, UnFingerprintedLocalProjectArtifact):
                 directory = package.artifact.directory
                 if not os.path.isabs(directory):
-                    directory = os.path.join(os.path.dirname(pylock_toml_path), directory)
-                local_project_requirement_mapping[package.artifact.directory] = Requirement.parse(
+                    directory = os.path.normpath(
+                        os.path.join(os.path.dirname(pylock_toml_path), directory)
+                    )
+                local_project_requirement_mapping[directory] = Requirement.parse(
                     "{project_name} @ file://{directory}".format(
                         project_name=package.project_name, directory=directory
                     )

--- a/pex/resolve/lockfile/pep_751.py
+++ b/pex/resolve/lockfile/pep_751.py
@@ -1221,12 +1221,10 @@ class Pylock(object):
         package_index = PackageIndex.create(packages_data)
         package_parser = PackageParser(package_index=package_index, source=pylock_toml_path)
 
-        has_dependency_info = False
         local_project_requirement_mapping = {}  # type: Dict[str, Requirement]
         packages = []  # type: List[Package]
         for indexed_package in package_index.iter_packages():
             package = try_(package_parser.parse(indexed_package))
-            has_dependency_info |= package.dependencies is not None
             if isinstance(package.artifact, LocalProjectArtifact):
                 directory = package.artifact.directory
                 if not os.path.isabs(directory):
@@ -1242,7 +1240,6 @@ class Pylock(object):
             lock_version=lock_version,
             created_by=created_by,
             packages=tuple(packages),
-            has_dependency_info=has_dependency_info,
             local_project_requirement_mapping=local_project_requirement_mapping,
             source=pylock_toml_path,
             environments=environments,
@@ -1255,7 +1252,6 @@ class Pylock(object):
     lock_version = attr.ib()  # type: Version
     created_by = attr.ib()  # type: str
     packages = attr.ib()  # type: Tuple[Package, ...]
-    has_dependency_info = attr.ib()  # type: bool
 
     local_project_requirement_mapping = attr.ib()  # type: Mapping[str, Requirement]
     source = attr.ib()  # type: str

--- a/pex/resolve/lockfile/pep_751.py
+++ b/pex/resolve/lockfile/pep_751.py
@@ -3,31 +3,73 @@
 
 from __future__ import absolute_import
 
-from collections import OrderedDict, defaultdict
+import os
+from collections import OrderedDict, defaultdict, deque
 
 from pex import toml
-from pex.dist_metadata import Requirement
-from pex.exceptions import production_assert
+from pex.artifact_url import RANKED_ALGORITHMS, VCS, ArtifactURL, Fingerprint, VCSScheme
+from pex.common import pluralize
+from pex.compatibility import urlparse
+from pex.dependency_configuration import DependencyConfiguration
+from pex.dist_metadata import Constraint, Requirement
+from pex.exceptions import production_assert, reportable_unexpected_error_msg
+from pex.network_configuration import NetworkConfiguration
 from pex.orderedset import OrderedSet
+from pex.pep_425 import CompatibilityTags, RankedTag
+from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
-from pex.requirements import URLRequirement, parse_requirement_string
+from pex.requirements import LocalProjectRequirement, URLRequirement, parse_requirement_string
 from pex.resolve.locked_resolve import (
     DownloadableArtifact,
     FileArtifact,
     LocalProjectArtifact,
     LockedRequirement,
     LockedResolve,
+    Resolved,
     TargetSystem,
+    UnFingerprintedLocalProjectArtifact,
+    UnFingerprintedVCSArtifact,
     VCSArtifact,
 )
 from pex.resolve.lockfile.requires_dist import remove_unused_requires_dist
+from pex.resolve.lockfile.subset import Subset, SubsetResult
+from pex.resolve.requirement_configuration import RequirementConfiguration
 from pex.resolve.resolved_requirement import Pin
+from pex.resolve.resolver_configuration import BuildConfiguration
+from pex.result import Error, ResultError, try_
+from pex.sorted_tuple import SortedTuple
+from pex.targets import Target, Targets
 from pex.third_party.packaging.markers import Marker
-from pex.toml import InlineTable
+from pex.third_party.packaging.specifiers import SpecifierSet
+from pex.toml import InlineTable, TomlDecodeError
+from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from typing import IO, Any, DefaultDict, Dict, Iterable, List, Mapping, Optional, Tuple, Union
+    from typing import (
+        IO,
+        Any,
+        DefaultDict,
+        Dict,
+        Iterable,
+        Iterator,
+        List,
+        Mapping,
+        Optional,
+        Sequence,
+        Set,
+        Text,
+        Tuple,
+        Type,
+        TypeVar,
+        Union,
+    )
+
+    import attr  # vendor:skip
+
+    from pex.requirements import ParsedRequirement
+else:
+    from pex.third_party import attr
 
 
 def _calculate_marker(
@@ -125,12 +167,12 @@ def _elide_extras(marker):
 def _to_environment(system):
     # type: (TargetSystem.Value) -> str
     if system is TargetSystem.LINUX:
-        return "platform_system = 'Linux'"
+        return "platform_system == 'Linux'"
     elif system is TargetSystem.MAC:
-        return "platform_system = 'Darwin'"
+        return "platform_system == 'Darwin'"
     else:
         production_assert(system is TargetSystem.WINDOWS)
-        return "platform_system = 'Windows'"
+        return "platform_system == 'Windows'"
 
 
 def convert(
@@ -180,9 +222,17 @@ def convert(
 
     artifact_subset_by_pin = defaultdict(
         list
-    )  # type: DefaultDict[Pin, List[Union[FileArtifact, LocalProjectArtifact, VCSArtifact]]]
+    )  # type: DefaultDict[Pin, List[Union[FileArtifact, LocalProjectArtifact, UnFingerprintedLocalProjectArtifact, UnFingerprintedVCSArtifact, VCSArtifact]]]
     for downloadable_artifact in subset:
-        artifact_subset_by_pin[downloadable_artifact.pin].append(downloadable_artifact.artifact)
+        production_assert(
+            downloadable_artifact.version is not None,
+            "Pex locks should always have pins for all downloaded artifacts.",
+        )
+        pin = Pin(
+            project_name=downloadable_artifact.project_name,
+            version=cast(Version, downloadable_artifact.version),
+        )
+        artifact_subset_by_pin[pin].append(downloadable_artifact.artifact)
 
     archive_requirements = {
         req.project_name: req
@@ -213,7 +263,9 @@ def convert(
         package["name"] = locked_requirement.pin.project_name.normalized
 
         artifacts = artifact_subset or list(locked_requirement.iter_artifacts())
-        if len(artifacts) != 1 or not isinstance(artifacts[0], LocalProjectArtifact):
+        if len(artifacts) != 1 or not isinstance(
+            artifacts[0], (LocalProjectArtifact, UnFingerprintedLocalProjectArtifact)
+        ):
             # https://peps.python.org/pep-0751/#packages-version
             # The version MUST NOT be included when it cannot be guaranteed to be consistent with
             # the code used (i.e. when a source tree is used).
@@ -254,19 +306,26 @@ def convert(
             production_assert(
                 artifact_count == 1,
                 "Expected a direct URL requirement to have exactly one artifact but "
-                "{requirement} has {count}.".format(
-                    requirement=archive_requirement, count=artifact_count
-                ),
+                "{requirement} has {count}.",
+                requirement=archive_requirement,
+                count=artifact_count,
             )
-            artifact = artifacts[0]
+            production_assert(
+                isinstance(artifacts[0], FileArtifact),
+                "Packages with an archive should resolve to FileArtifacts but resolved a "
+                "{type} instead.",
+                type=type(artifacts[0]),
+            )
+            archive_artifact = cast(FileArtifact, artifacts[0])
+
             archive = InlineTable()  # type: OrderedDict[str, Any]
 
             # https://peps.python.org/pep-0751/#packages-archive-url
-            archive["url"] = artifact.url.download_url
+            archive["url"] = archive_artifact.url.download_url
 
             # https://peps.python.org/pep-0751/#packages-archive-hashes
             archive["hashes"] = InlineTable.create(
-                (artifact.fingerprint.algorithm, artifact.fingerprint.hash)
+                (archive_artifact.fingerprint.algorithm, archive_artifact.fingerprint.hash)
             )
 
             package["archive"] = archive
@@ -305,7 +364,7 @@ def convert(
                                 url=artifact.url.download_url,
                             ),
                         )
-                elif isinstance(artifact, VCSArtifact):
+                elif isinstance(artifact, (UnFingerprintedVCSArtifact, VCSArtifact)):
                     if not artifact.commit_id:
                         raise ValueError(
                             "Cannot export {url} in a PEP-751 lock.\n"
@@ -313,7 +372,8 @@ def convert(
                             "A commit id is required to be resolved for VCS artifacts and none "
                             "was.\n"
                             "This most likely means the lock file was created by Pex older than "
-                            "2.37.0 or that the lock was created using Python 2.7.\n"
+                            "2.37.0, using an old `--pip-version` or that the lock was created "
+                            "using Python 2.7.\n"
                             "You'll need to re-create the lock with a newer Pex or newer Python or "
                             "both to be able to export it in PEP-751 format.".format(
                                 url=artifact.url.raw_url
@@ -325,7 +385,14 @@ def convert(
                     vcs_artifact["type"] = artifact.vcs.value
 
                     # https://peps.python.org/pep-0751/#packages-vcs-url
-                    vcs_artifact["url"] = artifact.vcs_url
+                    vcs_url, _ = VCSArtifact.split_requested_revision(artifact.url)
+                    if isinstance(artifact.url.scheme, VCSScheme):
+                        vcs_scheme = artifact.url.scheme
+                        # Strip the vcs part; e.g.: git+https -> https
+                        vcs_url = urlparse.urlunparse(
+                            urlparse.urlparse(vcs_url)._replace(scheme=vcs_scheme.scheme)
+                        )
+                    vcs_artifact["url"] = vcs_url
 
                     # https://peps.python.org/pep-0751/#packages-vcs-requested-revision
                     if artifact.requested_revision:
@@ -340,7 +407,11 @@ def convert(
 
                     package["vcs"] = vcs_artifact
                 else:
-                    production_assert(isinstance(artifact, LocalProjectArtifact))
+                    production_assert(
+                        isinstance(
+                            artifact, (LocalProjectArtifact, UnFingerprintedLocalProjectArtifact)
+                        )
+                    )
                     directory = InlineTable()  # type: OrderedDict[str, Any]
 
                     # https://peps.python.org/pep-0751/#packages-directory-path
@@ -368,3 +439,1071 @@ def convert(
     pylock["packages"] = list(packages.values())
 
     toml.dump(pylock, output)
+
+
+if TYPE_CHECKING:
+    _T = TypeVar("_T")
+
+
+@attr.s(frozen=True)
+class ParseContext(object):
+    source = attr.ib()  # type: str
+    _prefix = attr.ib(init=False)  # type: str
+    table = attr.ib(factory=dict)  # type: Mapping[str, Any]
+    path = attr.ib(default="")  # type: str
+
+    def __attrs_post_init__(self):
+        prefix = "Failed to parse the PEP-751 lock at {pylock}.".format(pylock=self.source)
+        if self.path:
+            prefix = "{prefix} Error parsing content at {path}.".format(
+                prefix=prefix, path=self.path
+            )
+        object.__setattr__(self, "_prefix", prefix)
+
+    def __bool__(self):
+        # type: () -> bool
+        return len(self.table) > 0
+
+    # N.B.: For Python 2.7.
+    __nonzero__ = __bool__
+
+    def subpath(self, key):
+        # type: (str) -> str
+        return "{path}.{subpath}".format(path=self.path, subpath=key) if self.path else key
+
+    def with_table(
+        self,
+        table,  # type: Mapping[str, Any]
+        path=None,  # type: Optional[str]
+    ):
+        # type: (...) -> ParseContext
+        production_assert(not self.path or path is not None)
+        return ParseContext(
+            source=self.source, table=table, path=self.subpath(path) if path else ""
+        )
+
+    def get_string(
+        self,
+        key,  # type: str
+        default=None,  # type: Optional[str]
+    ):
+        # type: (...) -> str
+        return self.get(key, str, default=default)
+
+    def get_array_of_strings(
+        self,
+        key,  # type: str
+        default=None,  # type: Optional[List[str]]
+    ):
+        # type: (...) -> List[str]
+        value = self.get(key, list, default=default)
+        if not all(isinstance(item, str) for item in value):
+            raise ResultError(
+                self.error(
+                    "Expected {key} to be an arrays of strings.".format(key=self.subpath(key))
+                )
+            )
+        return cast("List[str]", value)
+
+    def get_array_of_tables(
+        self,
+        key,  # type: str
+        default=None,  # type: Optional[List[Dict[str, Any]]]
+        diagnostic_key=None,  # type: Optional[str]
+    ):
+        # type: (...) -> List[ParseContext]
+        value = self.get(key, list, default=default)
+        if not all(
+            isinstance(item, dict) and all(isinstance(key, str) for key in item) for item in value
+        ):
+            raise ResultError(
+                self.error("Expected {key} to be an array of tables.".format(key=self.subpath(key)))
+            )
+        return [
+            self.with_table(
+                item,
+                path="{key}[{index}]{diagnostic}".format(
+                    key=key,
+                    index=index,
+                    diagnostic=(
+                        "{{{key} = {value}}}".format(key=diagnostic_key, value=item[diagnostic_key])
+                        if diagnostic_key
+                        else ""
+                    ),
+                ),
+            )
+            for index, item in enumerate(value)
+        ]
+
+    def get_table(
+        self,
+        key,  # type: str
+        default=None,  # type: Optional[Mapping[str, Any]]
+    ):
+        # type: (...) -> ParseContext
+        value = self.get(key, dict, default=default)
+        if not all(isinstance(name, str) for name in value):
+            raise ResultError(
+                self.error(
+                    "Expected {key} to be a table but not all dict keys are strings.".format(
+                        key=self.subpath(key)
+                    )
+                )
+            )
+        return self.with_table(value, path=key)
+
+    def get(
+        self,
+        key,  # type: str
+        item_type,  # type: Type[_T]
+        default=None,  # type: Optional[_T]
+    ):
+        # type: (...) -> _T
+        value = self.table.get(key, None)
+        if value is None:
+            if default is None:
+                raise ResultError(
+                    self.error("A value for {key} is required.".format(key=self.subpath(key)))
+                )
+            return default
+        if not isinstance(value, item_type):
+            raise ResultError(
+                self.error(
+                    "Expected {key} to be a {expected_type} but got a {value_type}.".format(
+                        key=self.subpath(key), expected_type=item_type, value_type=type(value)
+                    )
+                )
+            )
+        return cast("_T", value)
+
+    def error(
+        self,
+        msg,  # type: str
+        err=None,  # type: Optional[Exception]
+    ):
+        # type: (...) -> Error
+        return Error(
+            os.linesep.join(
+                (self._prefix, "{msg}: {err}".format(msg=msg, err=err) if err else msg)
+            ),
+        )
+
+
+@attr.s(frozen=True)
+class Package(object):
+    project_name = attr.ib()  # type: ProjectName
+    artifact = (
+        attr.ib()
+    )  # type: Union[FileArtifact, UnFingerprintedLocalProjectArtifact, UnFingerprintedVCSArtifact]
+    artifact_is_archive = attr.ib(default=False)  # type: bool
+    version = attr.ib(default=None)  # type: Optional[Version]
+    requires_python = attr.ib(default=None)  # type: Optional[SpecifierSet]
+    marker = attr.ib(default=None)  # type: Optional[Marker]
+    dependencies = attr.ib(default=None)  # type: Optional[Tuple[Package, ...]]
+    additional_wheels = attr.ib(default=())  # type: Tuple[FileArtifact, ...]
+
+    @property
+    def artifact_is_wheel(self):
+        # type: () -> bool
+        return isinstance(self.artifact, FileArtifact) and self.artifact.is_wheel
+
+    @property
+    def has_wheel(self):
+        # type: () -> bool
+        return self.artifact_is_wheel or len(self.additional_wheels) > 0
+
+    def iter_wheels(self):
+        # type: () -> Iterator[FileArtifact]
+        if self.artifact_is_wheel:
+            yield cast(FileArtifact, self.artifact)
+        for wheel in self.additional_wheels:
+            yield wheel
+
+    def as_unparsed_requirement(self):
+        # type: () -> str
+
+        if isinstance(self.artifact, UnFingerprintedVCSArtifact):
+            return self.artifact.as_unparsed_requirement(self.project_name)
+
+        if self.artifact_is_archive or isinstance(
+            self.artifact, UnFingerprintedLocalProjectArtifact
+        ):
+            return "{project_name} @ {url}".format(
+                project_name=self.project_name, url=self.artifact.url.raw_url
+            )
+
+        if self.version:
+            return "{project_name}{operator}{version}".format(
+                project_name=self.project_name,
+                operator="===" if self.version.is_legacy else "==",
+                version=self.version,
+            )
+
+        return str(self.project_name)
+
+    def as_requirement(self):
+        # type: () -> Requirement
+        return Requirement.parse(self.as_unparsed_requirement())
+
+    def as_parsed_requirement(self):
+        # type: () -> ParsedRequirement
+        if isinstance(self.artifact, UnFingerprintedLocalProjectArtifact):
+            path = (
+                self.artifact.directory
+                if os.path.isabs(self.artifact.directory)
+                else "./{path}".format(path=self.artifact.directory)
+            )
+            return attr.evolve(
+                (
+                    parse_requirement_string("-e {path}".format(path=path))
+                    if self.artifact.editable
+                    else parse_requirement_string(path)
+                ),
+                project_name=self.project_name,
+            )
+        return parse_requirement_string(self.as_unparsed_requirement())
+
+    def identify(self):
+        # type: () -> str
+
+        spec = (
+            "{project_name} {version}".format(project_name=self.project_name, version=self.version)
+            if self.version
+            else str(self.project_name)
+        )
+
+        artifacts = ""  # type: str
+        if isinstance(self.artifact, FileArtifact) and self.artifact.is_source:
+            artifacts = "sdist"
+        elif isinstance(self.artifact, UnFingerprintedLocalProjectArtifact):
+            artifacts = "directory"
+        elif isinstance(self.artifact, UnFingerprintedVCSArtifact):
+            artifacts = "vcs checkout"
+        elif self.artifact_is_wheel and not self.additional_wheels:
+            artifacts = "wheel"
+
+        if self.additional_wheels:
+            if not artifacts:
+                artifacts = "in {count} wheels".format(count=len(self.additional_wheels) + 1)
+            else:
+                artifacts = "{artifact} and {count}".format(
+                    artifact=artifacts, count=len(self.additional_wheels)
+                )
+
+        return "{spec} {artifacts}".format(spec=spec, artifacts=artifacts)
+
+
+@attr.s(frozen=True)
+class IndexedPackage(object):
+    index = attr.ib()  # type: int
+    parse_context = attr.ib()  # type: ParseContext
+
+    @property
+    def package_data(self):
+        # type: () -> Mapping[str, Any]
+        return self.parse_context.table
+
+
+@attr.s(frozen=True)
+class PackageIndex(object):
+    @classmethod
+    def create(
+        cls,
+        packages_data,  # type: List[ParseContext]
+    ):
+        # type: (...) -> PackageIndex
+
+        project_name_by_index = {}
+        indexed_packages_by_name = defaultdict(
+            list
+        )  # type: DefaultDict[ProjectName, List[IndexedPackage]]
+        for index, package_parse_context in enumerate(packages_data):
+            project_name = ProjectName(package_parse_context.get_string("name"))
+            project_name_by_index[index] = project_name
+            indexed_packages_by_name[project_name].append(
+                IndexedPackage(index, package_parse_context)
+            )
+
+        return cls(
+            project_name_by_index=project_name_by_index,
+            indexed_packages_by_name={
+                project_name: tuple(packages)
+                for project_name, packages in indexed_packages_by_name.items()
+            },
+        )
+
+    _project_name_by_index = attr.ib()  # type: Mapping[int, ProjectName]
+    _indexed_packages_by_name = attr.ib()  # type: Mapping[ProjectName, Tuple[IndexedPackage, ...]]
+
+    def iter_packages(self):
+        # type: () -> Iterator[IndexedPackage]
+        for packages in self._indexed_packages_by_name.values():
+            for package in packages:
+                yield package
+
+    def package_name(self, index):
+        # type: (int) -> ProjectName
+        return self._project_name_by_index[index]
+
+    def packages(self, project_name):
+        # type: (ProjectName) -> Optional[Tuple[IndexedPackage, ...]]
+        return self._indexed_packages_by_name.get(project_name)
+
+
+def spec_matches(
+    spec,  # type: Any
+    package_data,  # type: Any
+):
+    # type: (...) -> bool
+
+    if isinstance(spec, dict) and isinstance(package_data, dict):
+        for key, value in spec.items():
+            if not spec_matches(value, package_data.get(key)):
+                return False
+        return True
+
+    if isinstance(spec, list) and isinstance(package_data, list):
+        # All instances of lists in packages are currently array of tables:
+        # + dependencies
+        # + wheels
+        # + attestation-identities
+        #
+        # As such, we consider the list matches if any of its contained tables matches each of the
+        # spec tables. This allows a dependency spec like so to match the torch cpu wheel in a lock
+        # that also includes torch-2.7.0-cp311-none-macosx_11_0_arm64.whl (cuda 12.8):
+        # {name = "torch", wheels = [{ name = "torch-2.7.0+xpu-cp39-cp39-win_amd64.whl" }]}
+        for spec_item in spec:
+            if not any(
+                spec_matches(spec_item, package_data_item) for package_data_item in package_data
+            ):
+                return False
+        return True
+
+    # I have no clue why MyPy can't track this as bool.
+    return cast(bool, spec == package_data)
+
+
+@attr.s
+class PackageParser(object):
+    package_index = attr.ib()  # type: PackageIndex
+    source = attr.ib()  # type: str
+
+    parsed_packages_by_index = attr.ib(factory=dict)  # type: Dict[int, Package]
+
+    @staticmethod
+    def get_fingerprint(parse_context):
+        # type: (ParseContext) -> Fingerprint
+
+        hashes = parse_context.get_table("hashes")
+        for algorithm in RANKED_ALGORITHMS:
+            hash_value = hashes.get_string(algorithm, default="")
+            if hash_value:
+                return Fingerprint(algorithm=algorithm, hash=hash_value)
+
+        raise ResultError(
+            hashes.error("No hashes from `hashlib.algorithms_guaranteed` are present.")
+        )
+
+    def parse_url_or_path(self, parse_context):
+        # type: (ParseContext) -> ArtifactURL
+
+        url = parse_context.get_string("url")
+        if not url:
+            path = parse_context.get_string("path")
+            if not os.path.isabs(path):
+                path = os.path.join(os.path.dirname(self.source), path)
+            url = "file://{path}".format(path=path)
+        return ArtifactURL.parse(url)
+
+    def parse(self, indexed_package):
+        # type: (IndexedPackage) -> Union[Package, Error]
+
+        index = indexed_package.index
+        package = self.parsed_packages_by_index.get(index)
+        if package:
+            return package
+
+        project_name = self.package_index.package_name(index)
+
+        parse_context = indexed_package.parse_context
+        raw_version = parse_context.get_string("version", default="")
+        version = Version(raw_version) if raw_version else None
+
+        raw_marker = parse_context.get_string("marker", default="")
+        marker = Marker(raw_marker) if raw_marker else None
+
+        raw_requires_python = parse_context.get_string("requires-python", default="")
+        requires_python = SpecifierSet(raw_requires_python) if raw_requires_python else None
+
+        dependencies = []  # type: List[Package]
+
+        dep_parse_contexts = parse_context.get_array_of_tables(
+            "dependencies", default=[], diagnostic_key="name"
+        )
+        for dep_idx, dep_parse_context in enumerate(dep_parse_contexts):
+            dep_name = ProjectName(dep_parse_context.get_string("name"))
+
+            package_deps = self.package_index.packages(dep_name)
+            if not package_deps:
+                return dep_parse_context.error(
+                    "The {project_name} package depends on {dep_name}, but there is no {dep_name} "
+                    "package in the packages array.".format(
+                        project_name=project_name, dep_name=dep_name
+                    )
+                )
+
+            deps = [
+                indexed_package
+                for indexed_package in package_deps
+                if spec_matches(dep_parse_context.table, indexed_package.package_data)
+            ]  # type: List[IndexedPackage]
+            if not deps:
+                return dep_parse_context.error(
+                    "No matching {dep_name} package could be found for {project_name} "
+                    "dependencies[{dep_idx}].".format(
+                        dep_name=dep_name, project_name=project_name, dep_idx=dep_idx
+                    )
+                )
+            elif len(deps) > 1:
+                return dep_parse_context.error(
+                    "More than one package matches {project_name} dependencies[{dep_idx}]:\n"
+                    "{matches}".format(
+                        project_name=project_name,
+                        dep_idx=dep_idx,
+                        matches="\n".join(
+                            "+ packages[{index}]".format(index=dep.index) for dep in deps
+                        ),
+                    )
+                )
+            dependencies.append(try_(self.parse(deps[0])))
+
+        vcs_parse_context = parse_context.get_table("vcs", default={})
+        directory_parse_context = parse_context.get_table("directory", default={})
+        archive_parse_context = parse_context.get_table("archive", default={})
+        sdist_parse_context = parse_context.get_table("sdist", default={})
+        wheels = parse_context.get_array_of_tables("wheels", default=[])
+
+        def check_mutually_exclusive(
+            key,  # type: str
+            others,  # type: Iterable[Union[ParseContext, List[ParseContext]]]
+        ):
+            # type: (...) -> None
+            other_artifacts = [other for other in others if other]
+            if not other_artifacts:
+                return
+            raise ResultError(
+                parse_context.error(
+                    "{lead} mutually exclusive with {key}:\n"
+                    "{other_artifacts}".format(
+                        lead="This artifact is"
+                        if len(other_artifacts) == 1
+                        else "These artifacts are",
+                        key=key,
+                        other_artifacts="\n".join(
+                            "+ {path}".format(
+                                path=(
+                                    other_artifact.path
+                                    if isinstance(other_artifact, ParseContext)
+                                    else parse_context.subpath("wheels")
+                                )
+                            )
+                            for other_artifact in other_artifacts
+                        ),
+                    )
+                )
+            )
+
+        artifact = (
+            None
+        )  # type: Optional[Union[FileArtifact, UnFingerprintedLocalProjectArtifact, UnFingerprintedVCSArtifact]]
+        additional_wheels = []  # type: List[FileArtifact]
+        if vcs_parse_context:
+            check_mutually_exclusive(
+                key=vcs_parse_context.path,
+                others=(
+                    directory_parse_context,
+                    archive_parse_context,
+                    sdist_parse_context,
+                    wheels,
+                ),
+            )
+
+            url = self.parse_url_or_path(vcs_parse_context)
+
+            try:
+                vcs_type = VCS.for_value(vcs_parse_context.get_string("type"))
+            except ValueError as e:
+                return vcs_parse_context.error("Invalid vcs `type`.", err=e)
+
+            commit_id = vcs_parse_context.get_string("commit-id")
+
+            requested_revision = (
+                vcs_parse_context.get_string("requested-revision", default="") or None
+            )
+
+            subdirectory = vcs_parse_context.get_string("subdirectory", default="") or None
+            if subdirectory:
+                vcs_fragment_parameters = defaultdict(list)  # type: DefaultDict[str, List[str]]
+                vcs_fragment_parameters.update(
+                    (name, list(values)) for name, values in url.fragment_parameters.items()
+                )
+                vcs_fragment_parameters["subdirectory"].append(subdirectory)
+                url = ArtifactURL.parse(
+                    url.url_info._replace(
+                        fragment=ArtifactURL.create_fragment(vcs_fragment_parameters)
+                    ).geturl()
+                )
+
+            artifact = UnFingerprintedVCSArtifact(
+                url,
+                verified=True,
+                vcs=vcs_type,
+                requested_revision=requested_revision,
+                commit_id=commit_id,
+            )
+        elif directory_parse_context:
+            check_mutually_exclusive(
+                key=directory_parse_context.path,
+                others=(vcs_parse_context, archive_parse_context, sdist_parse_context, wheels),
+            )
+
+            path = directory_parse_context.get_string("path")
+            if not os.path.isabs(path):
+                path = os.path.join(os.path.dirname(self.source), path)
+            subdirectory = directory_parse_context.get_string("subdirectory", default="") or None
+            if subdirectory:
+                path = os.path.join(path, subdirectory)
+            url = ArtifactURL.parse("file://{path}".format(path=path))
+
+            editable = directory_parse_context.get("editable", bool, default=False)
+
+            artifact = UnFingerprintedLocalProjectArtifact(
+                url, verified=True, directory=path, editable=editable
+            )
+        elif archive_parse_context:
+            url = self.parse_url_or_path(archive_parse_context)
+            subdirectory = vcs_parse_context.get_string("subdirectory", default="") or None
+            if subdirectory:
+                archive_fragment_parameters = defaultdict(list)  # type: DefaultDict[str, List[str]]
+                archive_fragment_parameters.update(
+                    (name, list(values)) for name, values in url.fragment_parameters.items()
+                )
+                archive_fragment_parameters["subdirectory"].append(subdirectory)
+                url = ArtifactURL.parse(
+                    url.url_info._replace(
+                        fragment=ArtifactURL.create_fragment(archive_fragment_parameters)
+                    ).geturl()
+                )
+
+            fingerprint = self.get_fingerprint(archive_parse_context)
+            filename = os.path.basename(url.path)
+
+            artifact = FileArtifact(url, verified=False, fingerprint=fingerprint, filename=filename)
+        else:
+            check_mutually_exclusive(
+                key="{sdist} and {wheels}".format(
+                    sdist=parse_context.subpath("sdist"), wheels=parse_context.subpath("wheels")
+                ),
+                others=(vcs_parse_context, directory_parse_context, archive_parse_context),
+            )
+
+            if sdist_parse_context:
+                url = self.parse_url_or_path(sdist_parse_context)
+                fingerprint = self.get_fingerprint(sdist_parse_context)
+                filename = os.path.basename(url.path)
+
+                artifact = FileArtifact(
+                    url, verified=False, fingerprint=fingerprint, filename=filename
+                )
+            if wheels:
+                for whl_idx, whl_parse_context in enumerate(wheels):
+                    url = self.parse_url_or_path(whl_parse_context)
+                    fingerprint = self.get_fingerprint(whl_parse_context)
+                    filename = os.path.basename(url.path)
+
+                    wheel_artifact = FileArtifact(
+                        url, verified=False, fingerprint=fingerprint, filename=filename
+                    )
+                    if artifact:
+                        additional_wheels.append(wheel_artifact)
+                    else:
+                        artifact = wheel_artifact
+
+        assert artifact is not None, reportable_unexpected_error_msg(
+            "An artifact should have been established via all code paths above."
+        )
+
+        package = Package(
+            project_name=project_name,
+            artifact=artifact,
+            artifact_is_archive=bool(archive_parse_context),
+            version=version,
+            requires_python=requires_python,
+            marker=marker,
+            dependencies=tuple(dependencies) if dependencies is not None else None,
+            additional_wheels=tuple(additional_wheels),
+        )
+        self.parsed_packages_by_index[index] = package
+        return package
+
+
+@attr.s(frozen=True)
+class PackageEvaluator(object):
+    @classmethod
+    def create(
+        cls,
+        target,  # type: Target
+        constraints=(),  # type: Iterable[Requirement]
+        build_configuration=BuildConfiguration(),  # type: BuildConfiguration
+        dependency_configuration=DependencyConfiguration(),  # type: DependencyConfiguration
+    ):
+        # type: (...) -> PackageEvaluator
+
+        constraints_by_project_name = {
+            constraint.project_name: constraint.as_constraint() for constraint in constraints
+        }
+        return cls(
+            target=target,
+            marker_environment=target.marker_environment.as_dict(),
+            constraints_by_project_name=constraints_by_project_name,
+            build_configuration=build_configuration,
+            dependency_configuration=dependency_configuration,
+        )
+
+    target = attr.ib()  # type: Target
+    marker_environment = attr.ib()  # type: Mapping[str, str]
+    constraints_by_project_name = attr.ib(factory=dict)  # type: Mapping[ProjectName, Constraint]
+    build_configuration = attr.ib(default=BuildConfiguration())  # type: BuildConfiguration
+    dependency_configuration = attr.ib(
+        default=DependencyConfiguration()
+    )  # type: DependencyConfiguration
+
+    def _excluded(self, package):
+        # type: (Package) -> bool
+        return len(self.dependency_configuration.excluded_by(package.as_requirement())) > 0
+
+    def _satisfies_build_configuration(self, package):
+        # type: (Package) -> bool
+
+        if package.has_wheel and self.build_configuration.allow_wheel(package.project_name):
+            return True
+        return self.build_configuration.allow_build(package.project_name)
+
+    def _satisfies_constraints(
+        self,
+        project_name,  # type: ProjectName
+        version=None,  # type: Optional[Version]
+    ):
+        # type: (...) -> bool
+
+        if not version:
+            return True
+
+        constraint = self.constraints_by_project_name.get(project_name)
+        if not constraint:
+            return True
+
+        return constraint.contains(version)
+
+    def applies(self, package):
+        # type: (Package) -> bool
+
+        if self._excluded(package):
+            return False
+
+        if not self._satisfies_build_configuration(package):
+            return False
+
+        if not self._satisfies_constraints(package.project_name, package.version):
+            return False
+
+        if package.requires_python and not self.target.requires_python_applies(
+            package.requires_python, source=package.identify()
+        ):
+            return False
+
+        if package.marker and not package.marker.evaluate(self.marker_environment):
+            return False
+
+        return True
+
+    def select_best_fit_wheel(self, wheels):
+        # type: (Sequence[FileArtifact]) -> FileArtifact
+
+        production_assert(len(wheels) > 0)
+
+        best_match = None  # type: Optional[RankedTag]
+        selected_wheel = None  # type: Optional[FileArtifact]
+        for wheel in wheels:
+            wheel_tags = CompatibilityTags.from_wheel(wheel.filename)
+            ranked_tag = self.target.supported_tags.best_match(wheel_tags)
+            if ranked_tag and (
+                not best_match or ranked_tag == ranked_tag.select_higher_rank(best_match)
+            ):
+                best_match = ranked_tag
+                selected_wheel = wheel
+
+        assert selected_wheel is not None, reportable_unexpected_error_msg(
+            "Should have selected a best-fit wheel via all code paths above."
+        )
+        return selected_wheel
+
+    def select_best_fit_artifact(self, package):
+        # type: (Package) -> Union[FileArtifact, UnFingerprintedLocalProjectArtifact, UnFingerprintedVCSArtifact]
+
+        if not package.has_wheel or not self.build_configuration.allow_wheel(package.project_name):
+            # A source distribution (sdist, directory, archive or vcs).
+            return package.artifact
+
+        if not package.additional_wheels:
+            # A sole wheel.
+            return package.artifact
+
+        return self.select_best_fit_wheel(list(package.iter_wheels()))
+
+
+@attr.s(frozen=True)
+class ResolvedPackages(object):
+    packages = attr.ib()  # type: Tuple[Package, ...]
+    resolved = attr.ib()  # type: Resolved[Pylock]
+
+    def resolve_roots(self):
+        # type: () -> Iterable[Package]
+
+        dependants_by_package = defaultdict(list)  # type: DefaultDict[Package, List[Package]]
+        for package in self.packages:
+            if package.dependencies:
+                for dependency in package.dependencies:
+                    dependants_by_package[dependency].append(package)
+
+        return tuple(package for package in self.packages if not dependants_by_package[package])
+
+
+@attr.s(frozen=True)
+class Pylock(object):
+    @classmethod
+    def parse(cls, pylock_toml_path):
+        # type: (str) -> Union[Pylock, Error]
+
+        parse_context = ParseContext(source=pylock_toml_path)
+        try:
+            parse_context = parse_context.with_table(toml.load(pylock_toml_path))
+        except TomlDecodeError as e:
+            return parse_context.error("Failed to parse TOML", e)
+
+        lock_version = Version(
+            parse_context.get_string(
+                "lock-version",
+                "Pex only supports lock version 1.0 and refuses to guess compatibility.",
+            )
+        )
+        if lock_version != Version("1.0"):
+            return parse_context.error(
+                "Found `lock-version` {version}, but Pex only supports version 1.0.".format(
+                    version=lock_version.raw
+                )
+            )
+
+        environments = tuple(
+            map(Marker, parse_context.get_array_of_strings("environments", default=[]))
+        )
+        requires_python = SpecifierSet(parse_context.get_string("requires-python", default=""))
+        extras = tuple(parse_context.get_array_of_strings("extras", default=[]))
+        dependency_groups = tuple(
+            parse_context.get_array_of_strings("dependency-groups", default=[])
+        )
+        default_groups = tuple(parse_context.get_array_of_strings("default-groups", default=[]))
+        created_by = parse_context.get_string("created-by")
+
+        packages_data = parse_context.get_array_of_tables(
+            "packages", default=[], diagnostic_key="name"
+        )
+        package_index = PackageIndex.create(packages_data)
+        package_parser = PackageParser(package_index=package_index, source=pylock_toml_path)
+
+        has_dependency_info = False
+        local_project_requirement_mapping = {}  # type: Dict[str, Requirement]
+        packages = []  # type: List[Package]
+        for indexed_package in package_index.iter_packages():
+            package = try_(package_parser.parse(indexed_package))
+            has_dependency_info |= package.dependencies is not None
+            if isinstance(package.artifact, LocalProjectArtifact):
+                directory = package.artifact.directory
+                if not os.path.isabs(directory):
+                    directory = os.path.join(os.path.dirname(pylock_toml_path), directory)
+                local_project_requirement_mapping[package.artifact.directory] = Requirement.parse(
+                    "{project_name} @ file://{directory}".format(
+                        project_name=package.project_name, directory=directory
+                    )
+                )
+            packages.append(package)
+
+        return cls(
+            lock_version=lock_version,
+            created_by=created_by,
+            packages=tuple(packages),
+            has_dependency_info=has_dependency_info,
+            local_project_requirement_mapping=local_project_requirement_mapping,
+            source=pylock_toml_path,
+            environments=environments,
+            requires_python=requires_python,
+            extras=extras,
+            dependency_groups=dependency_groups,
+            default_groups=default_groups,
+        )
+
+    lock_version = attr.ib()  # type: Version
+    created_by = attr.ib()  # type: str
+    packages = attr.ib()  # type: Tuple[Package, ...]
+    has_dependency_info = attr.ib()  # type: bool
+
+    local_project_requirement_mapping = attr.ib()  # type: Mapping[str, Requirement]
+    source = attr.ib()  # type: str
+
+    environments = attr.ib(default=())  # type: Tuple[Marker, ...]
+    requires_python = attr.ib(default=SpecifierSet())  # type: SpecifierSet
+    extras = attr.ib(default=())  # type: Tuple[str, ...]
+    dependency_groups = attr.ib(default=())  # type: Tuple[str, ...]
+    default_groups = attr.ib(default=())  # type: Tuple[str, ...]
+
+    def resolve(
+        self,
+        target,  # type: Target
+        requirements,  # type: Iterable[Requirement]
+        constraints=(),  # type: Iterable[Requirement]
+        transitive=True,  # type: bool
+        build_configuration=BuildConfiguration(),  # type: BuildConfiguration
+        dependency_configuration=DependencyConfiguration(),  # type: DependencyConfiguration
+    ):
+        # type: (...) -> Union[ResolvedPackages, Error]
+
+        if not target.requires_python_applies(self.requires_python, source=self.source):
+            return Error(
+                "This lock only supports Python {specifier}.".format(specifier=self.requires_python)
+            )
+
+        package_evaluator = PackageEvaluator.create(
+            target, constraints, build_configuration, dependency_configuration
+        )
+        applicable_packages = [
+            package for package in self.packages if package_evaluator.applies(package)
+        ]
+
+        packages_by_project_name = defaultdict(
+            list
+        )  # type: DefaultDict[ProjectName, List[Package]]
+        for package in applicable_packages:
+            packages_by_project_name[package.project_name].append(package)
+
+        if requirements:
+            required_project_names = deque(
+                OrderedSet(requirement.project_name for requirement in requirements)
+            )
+            visited_projects = set()  # type: Set[ProjectName]
+            packages = OrderedSet()  # type: OrderedSet[Package]
+            while required_project_names:
+                project_name = required_project_names.popleft()
+                if project_name in visited_projects:
+                    continue
+                visited_projects.add(project_name)
+                selected_packages = packages_by_project_name[project_name]
+                if transitive:
+                    for selected_package in selected_packages:
+                        if selected_package.dependencies:
+                            for dep in selected_package.dependencies:
+                                required_project_names.append(dep.project_name)
+                packages.update(selected_packages)
+
+            applicable_packages = list(packages)
+            for project_name in list(packages_by_project_name):
+                if project_name not in visited_projects:
+                    packages_by_project_name.pop(project_name)
+
+        ambiguous_packages = {
+            project_name: packages
+            for project_name, packages in packages_by_project_name.items()
+            if len(packages) > 1
+        }
+        if ambiguous_packages:
+            return Error(
+                "Found more than one match for the following projects in {source}.\n"
+                "{ambiguous_packages}\n"
+                "Pex resolves must produce a unique package per project.".format(
+                    ambiguous_packages="\n".join(
+                        "+ {project_name}:\n"
+                        "  {packages}".format(
+                            project_name=project_name,
+                            packages="\n  ".join(package.identify() for package in packages),
+                        )
+                        for project_name, packages in ambiguous_packages.items()
+                    ),
+                    source=self.source,
+                )
+            )
+
+        requirements_by_project_name = defaultdict(
+            list
+        )  # type: DefaultDict[ProjectName, List[Requirement]]
+        if requirements:
+            for requirement in requirements:
+                requirements_by_project_name[requirement.project_name].append(requirement)
+        else:
+            for package in applicable_packages:
+                requirements_by_project_name[package.project_name].append(package.as_requirement())
+
+        downloadable_artifacts = []  # type: List[DownloadableArtifact]
+        for package in applicable_packages:
+            artifact = package_evaluator.select_best_fit_artifact(package)
+            satisfied_direct_requirements = requirements_by_project_name[package.project_name]
+            downloadable_artifacts.append(
+                DownloadableArtifact(
+                    project_name=package.project_name,
+                    version=package.version,
+                    artifact=artifact,
+                    satisfied_direct_requirements=SortedTuple(
+                        satisfied_direct_requirements, key=str
+                    ),
+                )
+            )
+
+        return ResolvedPackages(
+            packages=tuple(applicable_packages),
+            resolved=Resolved[Pylock](
+                target_specificity=1.0, downloadable_artifacts=downloadable_artifacts, source=self
+            ),
+        )
+
+    def render_description(self):
+        # type: () -> str
+        return "{source} created by {created_by}".format(
+            source=self.source, created_by=self.created_by
+        )
+
+
+@attr.s(frozen=True)
+class PylockSubsetResult(object):
+    subset_result = attr.ib()  # type: SubsetResult[Pylock]
+    packages_by_target = attr.ib()  # type: Mapping[Target, Tuple[Package, ...]]
+
+
+def subset(
+    targets,  # type: Targets
+    pylock,  # type: Pylock
+    requirement_configuration=RequirementConfiguration(),  # type: RequirementConfiguration
+    network_configuration=None,  # type: Optional[NetworkConfiguration]
+    build_configuration=BuildConfiguration(),  # type: BuildConfiguration
+    transitive=True,  # type: bool
+    dependency_configuration=DependencyConfiguration(),  # type: DependencyConfiguration
+):
+    # type: (...) -> Union[PylockSubsetResult, Error]
+
+    parsed_requirements = tuple(requirement_configuration.parse_requirements(network_configuration))
+    constraints = tuple(
+        parsed_constraint.requirement
+        for parsed_constraint in requirement_configuration.parse_constraints(network_configuration)
+    )
+    missing_local_projects = []  # type: List[Text]
+    requirements_to_resolve = OrderedSet()  # type: OrderedSet[Requirement]
+    for parsed_requirement in parsed_requirements:
+        if isinstance(parsed_requirement, LocalProjectRequirement):
+            local_project_requirement = pylock.local_project_requirement_mapping.get(
+                os.path.abspath(parsed_requirement.path)
+            )
+            if local_project_requirement:
+                requirements_to_resolve.add(
+                    attr.evolve(local_project_requirement, editable=parsed_requirement.editable)
+                )
+            else:
+                missing_local_projects.append(parsed_requirement.line.processed_text)
+        else:
+            requirements_to_resolve.add(parsed_requirement.requirement)
+    if missing_local_projects:
+        return Error(
+            "Found {count} local project {requirements} not present in the lock at {lock}:\n"
+            "{missing}\n"
+            "\n"
+            "Perhaps{for_example} you meant to use `--project {project}`?".format(
+                count=len(missing_local_projects),
+                requirements=pluralize(missing_local_projects, "requirement"),
+                lock=pylock.render_description(),
+                missing="\n".join(
+                    "{index}. {missing}".format(index=index, missing=missing)
+                    for index, missing in enumerate(missing_local_projects, start=1)
+                ),
+                for_example=", as one example," if len(missing_local_projects) > 1 else "",
+                project=missing_local_projects[0],
+            )
+        )
+
+    resolved_packages_by_target = OrderedDict()  # type: OrderedDict[Target, ResolvedPackages]
+    errors_by_target = {}  # type: Dict[Target, Error]
+    with TRACER.timed(
+        "Resolving urls to fetch for {count} requirements from lock {lockfile}".format(
+            count=len(parsed_requirements), lockfile=pylock.render_description()
+        )
+    ):
+        for target in targets.unique_targets():
+            if pylock.environments and not any(
+                marker.evaluate(target.marker_environment.as_dict())
+                for marker in pylock.environments
+            ):
+                errors_by_target[target] = Error(
+                    "This lock only works in limited environments, none of which support the "
+                    "current target.\n"
+                    "The supported environments are:\n"
+                    "{environments}".format(
+                        environments="\n".join(
+                            "+ {env}".format(env=env) for env in pylock.environments
+                        ),
+                    )
+                )
+                continue
+
+            resolved_packages = pylock.resolve(
+                target,
+                requirements_to_resolve,
+                constraints=constraints,
+                build_configuration=build_configuration,
+                transitive=transitive,
+                dependency_configuration=dependency_configuration,
+            )
+            if isinstance(resolved_packages, ResolvedPackages):
+                resolved_packages_by_target[target] = resolved_packages
+            else:
+                errors_by_target[target] = resolved_packages
+
+    if errors_by_target:
+        return Error(
+            "Failed to resolve compatible artifacts from {lock} for {count} {targets}:\n"
+            "{errors}".format(
+                lock="lock {source}".format(source=pylock.render_description()),
+                count=len(errors_by_target),
+                targets=pluralize(errors_by_target, "target"),
+                errors="\n".join(
+                    "{index}. {target}: {error}".format(index=index, target=target, error=error)
+                    for index, (target, error) in enumerate(errors_by_target.items(), start=1)
+                ),
+            )
+        )
+
+    parsed_requirements = parsed_requirements or tuple(
+        OrderedSet(
+            package.as_parsed_requirement()
+            for resolved_packages in resolved_packages_by_target.values()
+            for package in resolved_packages.resolve_roots()
+        )
+    )
+
+    return PylockSubsetResult(
+        subset_result=SubsetResult[Pylock](
+            requirements=parsed_requirements,
+            subsets=tuple(
+                Subset[Pylock](target=target, resolved=resolved_packages.resolved)
+                for target, resolved_packages in resolved_packages_by_target.items()
+            ),
+        ),
+        packages_by_target={
+            target: resolved_packages.packages
+            for target, resolved_packages in resolved_packages_by_target.items()
+        },
+    )

--- a/pex/resolve/lockfile/updater.py
+++ b/pex/resolve/lockfile/updater.py
@@ -8,6 +8,7 @@ import logging
 from collections import OrderedDict
 from contextlib import contextmanager
 
+from pex.artifact_url import ArtifactURL, Fingerprint
 from pex.common import pluralize
 from pex.dependency_configuration import DependencyConfiguration
 from pex.dist_metadata import Constraint, Requirement
@@ -26,7 +27,6 @@ from pex.resolve.locked_resolve import (
 from pex.resolve.lockfile.create import create
 from pex.resolve.lockfile.model import Lockfile
 from pex.resolve.requirement_configuration import RequirementConfiguration
-from pex.resolve.resolved_requirement import ArtifactURL, Fingerprint
 from pex.resolve.resolver_configuration import PipConfiguration, PipLog, ReposConfiguration
 from pex.result import Error, ResultError, catch, try_
 from pex.sorted_tuple import SortedTuple
@@ -526,7 +526,7 @@ class ResolveUpdater(object):
                 )
             )
             included_projects = frozenset(
-                artifact.pin.project_name for artifact in resolve.downloadable_artifacts
+                artifact.project_name for artifact in resolve.downloadable_artifacts
             )
             updates.update(
                 (locked_requirement.pin.project_name, DeleteUpdate(locked_requirement.pin.version))

--- a/pex/resolve/pep_691/api.py
+++ b/pex/resolve/pep_691/api.py
@@ -7,12 +7,12 @@ import io
 import json
 import sys
 
+from pex.artifact_url import ArtifactURL, Fingerprint
 from pex.compatibility import HTTPError, string, text, urlparse
 from pex.fetcher import URLFetcher
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.resolve.pep_691.model import Endpoint, File, Meta, Project
-from pex.resolve.resolved_requirement import ArtifactURL, Fingerprint
 from pex.sorted_tuple import SortedTuple
 from pex.third_party.packaging.version import Version as PackagingVersion
 from pex.tracer import TRACER

--- a/pex/resolve/pep_691/fingerprint_service.py
+++ b/pex/resolve/pep_691/fingerprint_service.py
@@ -10,6 +10,7 @@ from itertools import repeat
 from multiprocessing.pool import ThreadPool
 
 from pex import pex_warnings
+from pex.artifact_url import Fingerprint
 from pex.atomic_directory import atomic_directory
 from pex.cache.dirs import CacheDir
 from pex.compatibility import cpu_count
@@ -17,7 +18,7 @@ from pex.fetcher import URLFetcher
 from pex.os import WINDOWS
 from pex.resolve.pep_691.api import Client
 from pex.resolve.pep_691.model import Endpoint, Project
-from pex.resolve.resolved_requirement import Fingerprint, PartialArtifact
+from pex.resolve.resolved_requirement import PartialArtifact
 from pex.resolve.resolvers import MAX_PARALLEL_DOWNLOADS
 from pex.result import Error, catch
 from pex.tracer import TRACER

--- a/pex/resolve/pep_691/model.py
+++ b/pex/resolve/pep_691/model.py
@@ -5,9 +5,9 @@ from __future__ import absolute_import
 
 import hashlib
 
+from pex.artifact_url import ArtifactURL, Fingerprint
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
-from pex.resolve.resolved_requirement import ArtifactURL, Fingerprint
 from pex.sorted_tuple import SortedTuple
 from pex.typing import TYPE_CHECKING
 

--- a/pex/resolve/resolved_requirement.py
+++ b/pex/resolve/resolved_requirement.py
@@ -3,20 +3,14 @@
 
 from __future__ import absolute_import
 
-import hashlib
-
-from pex import hashing
-from pex.compatibility import url_unquote, urlparse
-from pex.dist_metadata import ProjectNameAndVersion, Requirement, is_wheel
-from pex.hashing import HashlibHasher
+from pex.artifact_url import ArtifactURL, Fingerprint
+from pex.dist_metadata import ProjectNameAndVersion, Requirement
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
-from pex.requirements import ArchiveScheme, VCSScheme, parse_scheme
-from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import BinaryIO, Iterator, Mapping, Optional, Sequence, Tuple, Union
+    from typing import Iterator, Optional, Tuple, Union
 
     import attr  # vendor:skip
 else:
@@ -47,112 +41,6 @@ class Pin(object):
         return "{project_name} {version}".format(
             project_name=self.project_name, version=self.version
         )
-
-
-@attr.s(frozen=True)
-class Fingerprint(object):
-    @classmethod
-    def from_stream(
-        cls,
-        stream,  # type: BinaryIO
-        algorithm="sha256",  # type: str
-    ):
-        # type: (...) -> Fingerprint
-        digest = hashlib.new(algorithm)
-        hashing.update_hash(filelike=stream, digest=digest)
-        return cls(algorithm=algorithm, hash=digest.hexdigest())
-
-    @classmethod
-    def from_digest(cls, digest):
-        # type: (HashlibHasher) -> Fingerprint
-        return cls.from_hashing_fingerprint(digest.hexdigest())
-
-    @classmethod
-    def from_hashing_fingerprint(cls, fingerprint):
-        # type: (hashing.Fingerprint) -> Fingerprint
-        return cls(algorithm=fingerprint.algorithm, hash=fingerprint)
-
-    algorithm = attr.ib()  # type: str
-    hash = attr.ib()  # type: str
-
-
-@attr.s(frozen=True)
-class ArtifactURL(object):
-    # These ranks prefer the highest digest size and then use alphabetic order for a tie-break.
-
-    _RANKED_ALGORITHMS = tuple(
-        sorted(
-            hashlib.algorithms_guaranteed,
-            key=lambda alg: (-hashlib.new(alg).digest_size, alg),
-        )
-    )
-
-    @classmethod
-    def parse(cls, url):
-        # type: (str) -> ArtifactURL
-        url_info = urlparse.urlparse(url)
-        scheme = parse_scheme(url_info.scheme) if url_info.scheme else "file"
-        path = url_unquote(url_info.path)
-
-        fingerprints = []
-        fragment_parameters = urlparse.parse_qs(url_info.fragment)
-        if fragment_parameters:
-            # Artifact URLs from indexes may contain pre-computed hashes. We isolate those here,
-            # centrally, if present.
-            # See: https://peps.python.org/pep-0503/#specification
-            for alg in cls._RANKED_ALGORITHMS:
-                hashes = fragment_parameters.pop(alg, None)
-                if not hashes:
-                    continue
-                if len(hashes) > 1 and len(set(hashes)) > 1:
-                    TRACER.log(
-                        "The artifact url contains multiple distinct hash values for the {alg} "
-                        "algorithm, not trusting any of these: {url}".format(alg=alg, url=url)
-                    )
-                    continue
-                fingerprints.append(Fingerprint(algorithm=alg, hash=hashes[0]))
-
-        download_url = urlparse.urlunparse(
-            url_info._replace(
-                fragment="&".join(
-                    sorted(
-                        "{name}={value}".format(name=name, value=value)
-                        for name, values in fragment_parameters.items()
-                        for value in values
-                    )
-                )
-            )
-        )
-        normalized_url = urlparse.urlunparse(
-            url_info._replace(path=path, params="", query="", fragment="")
-        )
-        return cls(
-            raw_url=url,
-            download_url=download_url,
-            normalized_url=normalized_url,
-            scheme=scheme,
-            path=path,
-            fragment_parameters=fragment_parameters,
-            fingerprints=tuple(fingerprints),
-        )
-
-    raw_url = attr.ib(eq=False)  # type: str
-    download_url = attr.ib(eq=False)  # type: str
-    normalized_url = attr.ib()  # type: str
-    scheme = attr.ib(eq=False)  # type: Union[str, ArchiveScheme.Value, VCSScheme]
-    path = attr.ib(eq=False)  # type: str
-    fragment_parameters = attr.ib(eq=False)  # type: Mapping[str, Sequence[str]]
-    fingerprints = attr.ib(eq=False)  # type: Tuple[Fingerprint, ...]
-
-    @property
-    def is_wheel(self):
-        # type: () -> bool
-        return is_wheel(self.path)
-
-    @property
-    def fingerprint(self):
-        # type: () -> Optional[Fingerprint]
-        return self.fingerprints[0] if self.fingerprints else None
 
 
 def _convert_url(value):

--- a/pex/resolve/resolver_configuration.py
+++ b/pex/resolve/resolver_configuration.py
@@ -245,6 +245,22 @@ class LockRepositoryConfiguration(object):
 
 
 @attr.s(frozen=True)
+class PylockRepositoryConfiguration(object):
+    lock_file_path = attr.ib()  # type: str
+    pip_configuration = attr.ib()  # type: PipConfiguration
+
+    @property
+    def repos_configuration(self):
+        # type: () -> ReposConfiguration
+        return self.pip_configuration.repos_configuration
+
+    @property
+    def network_configuration(self):
+        # type: () -> NetworkConfiguration
+        return self.pip_configuration.network_configuration
+
+
+@attr.s(frozen=True)
 class PreResolvedConfiguration(object):
     sdists = attr.ib()  # type: Tuple[str, ...]
     wheels = attr.ib()  # type: Tuple[str, ...]

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.38.1"
+__version__ = "2.39.0"

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,10 @@ if __name__ == "__main__":
         # sub-command options we pass below work around the otherwise default `<CWD>/build/`
         # directory for all three which defeats concurrency in tests.
         options={
-            "egg_info": {"egg_base": unique_build_dir("egg_base")},
             "build": {"build_base": unique_build_dir("build_base")},
             "bdist_wheel": {"bdist_dir": unique_build_dir("bdist_dir")},
+            "editable_wheel": {"dist_dir": unique_build_dir("edist_dir")},
+            "egg_info": {"egg_base": unique_build_dir("egg_base")},
+            "sdist": {"dist_dir": unique_build_dir("sdist_dir")},
         },
     )

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -810,6 +810,7 @@ def run_commands_with_jitter(
     path_argument,  # type: str
     extra_env=None,  # type: Optional[Mapping[str, str]]
     delay=2.0,  # type: float
+    dest=None,  # type: Optional[str]
 ):
     # type: (...) -> List[str]
     """Runs the commands with tactics that attempt to introduce randomness in outputs.
@@ -820,12 +821,12 @@ def run_commands_with_jitter(
     Additionally, a delay is inserted between executions. By default, this delay is 2s to ensure zip
     precision is stressed. See: https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT.
     """
-    td = safe_mkdtemp()
-    pex_root = os.path.join(td, "pex_root")
+    dest_dir = dest or safe_mkdtemp()
+    pex_root = os.path.join(dest_dir, "pex_root")
 
     paths = []
     for index, command in enumerate(commands):
-        path = os.path.join(td, str(index))
+        path = os.path.join(dest_dir, str(index))
         cmd = list(command) + [path_argument, path]
 
         # Note that we change the `PYTHONHASHSEED` to ensure we're impervious to data structure
@@ -850,6 +851,7 @@ def run_command_with_jitter(
     extra_env=None,  # type: Optional[Mapping[str, str]]
     delay=2.0,  # type: float
     count=3,  # type: int
+    dest=None,  # type: Optional[str]
 ):
     # type: (...) -> List[str]
     """Runs the command `count` times in an attempt to introduce randomness.
@@ -866,6 +868,7 @@ def run_command_with_jitter(
         path_argument=path_argument,
         extra_env=extra_env,
         delay=delay,
+        dest=dest,
     )
 
 

--- a/tests/integration/cli/commands/test_export.py
+++ b/tests/integration/cli/commands/test_export.py
@@ -11,6 +11,7 @@ from textwrap import dedent
 
 import pytest
 
+from pex.artifact_url import ArtifactURL, Fingerprint
 from pex.dist_metadata import Requirement
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
@@ -25,7 +26,7 @@ from pex.resolve.locked_resolve import (
 )
 from pex.resolve.lockfile import json_codec
 from pex.resolve.lockfile.model import Lockfile
-from pex.resolve.resolved_requirement import ArtifactURL, Fingerprint, Pin
+from pex.resolve.resolved_requirement import Pin
 from pex.resolve.resolver_configuration import ResolverVersion
 from pex.sorted_tuple import SortedTuple
 from pex.typing import TYPE_CHECKING

--- a/tests/integration/cli/commands/test_issue_1413.py
+++ b/tests/integration/cli/commands/test_issue_1413.py
@@ -6,13 +6,14 @@ import shutil
 
 import pytest
 
+from pex.artifact_url import ArtifactURL
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.resolve.locked_resolve import LockedRequirement
 from pex.resolve.lockfile import json_codec
 from pex.resolve.lockfile.model import Lockfile
 from pex.resolve.path_mappings import PathMapping, PathMappings
-from pex.resolve.resolved_requirement import ArtifactURL, Pin
+from pex.resolve.resolved_requirement import Pin
 from pex.typing import TYPE_CHECKING
 from testing import make_env, run_pex_command, subprocess
 from testing.cli import run_pex3

--- a/tests/integration/cli/commands/test_issue_1711.py
+++ b/tests/integration/cli/commands/test_issue_1711.py
@@ -3,13 +3,13 @@
 
 import os
 
+from pex.artifact_url import ArtifactURL, Fingerprint
 from pex.compatibility import PY3
 from pex.interpreter import PythonInterpreter
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.resolve.locked_resolve import Artifact, FileArtifact, LockedRequirement
 from pex.resolve.lockfile import json_codec
-from pex.resolve.resolved_requirement import ArtifactURL, Fingerprint
 from pex.typing import TYPE_CHECKING
 from testing import IS_PYPY, PY_VER, run_pex_command
 from testing.cli import run_pex3

--- a/tests/integration/cli/commands/test_issue_2414.py
+++ b/tests/integration/cli/commands/test_issue_2414.py
@@ -5,6 +5,7 @@ import os.path
 
 import pytest
 
+from pex.artifact_url import ArtifactURL, Fingerprint
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.pip.log_analyzer import ErrorMessage
@@ -12,13 +13,7 @@ from pex.requirements import parse_requirement_string
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.locked_resolve import LockConfiguration, LockStyle
 from pex.resolve.locker import Locker, LockResult
-from pex.resolve.resolved_requirement import (
-    ArtifactURL,
-    Fingerprint,
-    PartialArtifact,
-    Pin,
-    ResolvedRequirement,
-)
+from pex.resolve.resolved_requirement import PartialArtifact, Pin, ResolvedRequirement
 from pex.targets import LocalInterpreter
 from pex.typing import TYPE_CHECKING
 from testing import data

--- a/tests/integration/cli/commands/test_lock.py
+++ b/tests/integration/cli/commands/test_lock.py
@@ -11,6 +11,7 @@ from textwrap import dedent
 
 import pytest
 
+from pex.artifact_url import Fingerprint
 from pex.cache.dirs import CacheDir
 from pex.common import safe_open
 from pex.dist_metadata import Constraint, Requirement
@@ -24,7 +25,7 @@ from pex.resolve.locked_resolve import Artifact, LockedRequirement
 from pex.resolve.lockfile import json_codec
 from pex.resolve.lockfile.download_manager import DownloadedArtifact
 from pex.resolve.lockfile.model import Lockfile
-from pex.resolve.resolved_requirement import Fingerprint, Pin
+from pex.resolve.resolved_requirement import Pin
 from pex.resolve.resolver_configuration import ResolverVersion
 from pex.sorted_tuple import SortedTuple
 from pex.targets import AbbreviatedPlatform, LocalInterpreter

--- a/tests/integration/cli/commands/test_lock_update.py
+++ b/tests/integration/cli/commands/test_lock_update.py
@@ -8,13 +8,13 @@ import shutil
 
 import pytest
 
+from pex.artifact_url import ArtifactURL
 from pex.common import safe_open
 from pex.fetcher import URLFetcher
 from pex.pip.version import PipVersion
 from pex.resolve.locked_resolve import Artifact, FileArtifact, LockedRequirement
 from pex.resolve.lockfile import json_codec
 from pex.resolve.lockfile.model import Lockfile
-from pex.resolve.resolved_requirement import ArtifactURL
 from pex.typing import TYPE_CHECKING
 from testing import make_env, run_pex_command, subprocess
 from testing.cli import run_pex3

--- a/tests/integration/cli/commands/test_pep_751.py
+++ b/tests/integration/cli/commands/test_pep_751.py
@@ -3,6 +3,10 @@
 
 from __future__ import absolute_import
 
+import filecmp
+import itertools
+import os.path
+import re
 import subprocess
 import sys
 from textwrap import dedent
@@ -11,14 +15,17 @@ from typing import Any, Dict, Iterator, Text
 import pytest
 
 from pex import toml
+from pex.common import CopyMode, iter_copytree, safe_copy
 from pex.compatibility import string
 from pex.interpreter import PythonInterpreter
+from pex.os import WINDOWS
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
+from pex.pex import PEX
 from pex.resolve.resolved_requirement import Pin
 from pex.venv.virtualenv import Virtualenv
 from pex.wheel import Wheel
-from testing import IS_PYPY, data
+from testing import IS_PYPY, data, run_pex_command
 from testing.cli import run_pex3
 from testing.pytest_utils.tmp import Tempdir
 
@@ -391,3 +398,158 @@ def test_lock_all_package_types(
             },
         },
     } == packages_by_name["cowsay"]
+
+
+@pytest.mark.skipif(
+    sys.version_info[:2] < (3, 8),
+    reason="Building Pex requires Python >= 3.8 to read pyproject.toml heterogeneous arrays.",
+)
+def test_locks_equivalent_round_trip(
+    tmpdir,  # type: Tempdir
+    pex_project_dir,  # type: str
+):
+    # type: (...) -> None
+
+    pex_management_req = "{pex_project_dir}[management]".format(pex_project_dir=pex_project_dir)
+
+    requirements = tmpdir.join("requirements.txt")
+    with open(requirements, "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                # Stress the editable bit for directory packages as well as handling extras.
+                -e {pex_management_req}
+
+                # Stress archive subdirectory handling.
+                git+https://github.com/SerialDev/sdev_py_utils.git@bd4d36a0#egg=sdev_logging_utils&subdirectory=sdev_logging_utils
+
+                # Stress VCS subdirectory handling as well as sdists and wheels (insta-science has
+                # a fair number of transitive deps).
+                insta-science @ https://github.com/a-scie/science-installers/archive/refs/tags/python-v0.6.1.zip#subdirectory=python
+                """.format(
+                    pex_management_req=pex_management_req
+                )
+            )
+        )
+    lock = tmpdir.join("lock.json")
+    run_pex3(
+        "lock",
+        "create",
+        "--pip-version",
+        "latest-compatible",
+        "--style",
+        "sources",
+        "-r",
+        requirements,
+        "--indent",
+        "2",
+        "-o",
+        lock,
+    ).assert_success()
+
+    pylock_toml = tmpdir.join("pylock.toml")
+    run_pex3("lock", "export", "--format", "pep-751", lock, "-o", pylock_toml).assert_success()
+
+    lock_pex_full = tmpdir.join("lock.pex")
+    pylock_pex_full = tmpdir.join("pylock.pex")
+    lock_pex_subset = tmpdir.join("lock.subset.pex")
+    pylock_pex_subset = tmpdir.join("pylock.subset.pex")
+
+    lock_full_args = ["--pip-version", "latest-compatible"]
+    lock_subset_args = lock_full_args + [pex_management_req]
+    results = [
+        run_pex_command(args=lock_full_args + ["--lock", lock, "-o", lock_pex_full]),
+        run_pex_command(args=lock_full_args + ["--pylock", pylock_toml, "-o", pylock_pex_full]),
+        run_pex_command(args=lock_subset_args + ["--lock", lock, "-o", lock_pex_subset]),
+        run_pex_command(args=lock_subset_args + ["--pylock", pylock_toml, "-o", pylock_pex_subset]),
+    ]
+    for result in results:
+        result.assert_success()
+
+    filecmp.cmp(lock_pex_full, pylock_pex_full, shallow=False)
+    filecmp.cmp(lock_pex_subset, pylock_pex_subset, shallow=False)
+
+    assert {ProjectName("pex"), ProjectName("psutil")} == {
+        dist.metadata.project_name for dist in PEX(pylock_pex_subset).resolve()
+    }, (
+        "Expected extras in root requirements to be respected throughout the lock, export and PEX "
+        "build chain of custody."
+    )
+
+
+@pytest.mark.skipif(
+    sys.version_info[:2] < (3, 8),
+    reason="Building Pex requires Python >= 3.8 to read pyproject.toml heterogeneous arrays.",
+)
+def test_uv_pylock_interop(
+    tmpdir,  # type: Tempdir
+    pex_project_dir,  # type: str
+):
+    # type: (...) -> None
+
+    chroot = tmpdir.join("chroot")
+    list(
+        itertools.chain.from_iterable(
+            (
+                iter_copytree(
+                    src=os.path.join(pex_project_dir, "build-backend"),
+                    dst=os.path.join(chroot, "build-backend"),
+                    copy_mode=CopyMode.LINK if WINDOWS else CopyMode.SYMLINK,
+                ),
+                iter_copytree(
+                    src=os.path.join(pex_project_dir, "pex"),
+                    dst=os.path.join(chroot, "pex"),
+                    copy_mode=CopyMode.LINK if WINDOWS else CopyMode.SYMLINK,
+                ),
+            )
+        )
+    )
+    for file in "MANIFEST.in", "pyproject.toml", "setup.cfg", "setup.py", "uv.lock":
+        safe_copy(os.path.join(pex_project_dir, file), os.path.join(chroot, file))
+
+    pylock_toml = os.path.join(chroot, "pylock.toml")
+    subprocess.check_call(
+        args=[
+            "uv",
+            "export",
+            "--directory",
+            chroot,
+            "--no-dev",
+            "--extra",
+            "management",
+            "--format",
+            "pylock.toml",
+            "-q",
+            "-o",
+            pylock_toml,
+        ]
+    )
+
+    management_pex = tmpdir.join("management.pex")
+    run_pex_command(
+        args=[".[management]", "--pylock", pylock_toml, "-o", management_pex],
+        cwd=chroot,
+        quiet=True,
+    ).assert_failure(
+        expected_error_re=r"^{escaped}$".format(
+            escaped=re.escape(
+                "The following projects were resolved:\n"
+                "+ pex\n"
+                "\n"
+                "These additional dependencies need to be resolved (as well as any transitive "
+                "dependencies they may have):\n"
+                "+ psutil\n"
+                "\n"
+                "The lock {pylock} created by uv likely does not include optional `dependencies` "
+                "metadata for its packages.\n"
+                "This metadata is required for Pex to subset a PEP-751 lock.".format(
+                    pylock=pylock_toml
+                )
+            )
+        )
+    )
+
+    run_pex_command(args=["--pylock", pylock_toml, "-o", management_pex]).assert_success()
+    assert {ProjectName("pex"), ProjectName("psutil")} == {
+        dist.metadata.project_name for dist in PEX(management_pex).resolve()
+    }

--- a/tests/integration/cli/commands/test_pep_751.py
+++ b/tests/integration/cli/commands/test_pep_751.py
@@ -54,7 +54,7 @@ def test_universal_export_subset(devpi_server_lock):
 
     assert {
         "lock-version": "1.0",
-        "environments": ["platform_system = 'Darwin'", "platform_system = 'Linux'"],
+        "environments": ["platform_system == 'Darwin'", "platform_system == 'Linux'"],
         "requires-python": "<3.14,>=3.10",
         "extras": [],
         "dependency-groups": [],
@@ -127,7 +127,7 @@ def test_universal_export_subset_no_dependency_info(devpi_server_lock):
 
     assert {
         "lock-version": "1.0",
-        "environments": ["platform_system = 'Darwin'", "platform_system = 'Linux'"],
+        "environments": ["platform_system == 'Darwin'", "platform_system == 'Linux'"],
         "requires-python": "<3.14,>=3.10",
         "extras": [],
         "dependency-groups": [],
@@ -374,7 +374,7 @@ def test_lock_all_package_types(
         "version": "1.7",
         "vcs": {
             "type": "git",
-            "url": "git+https://github.com/Anorov/PySocks",
+            "url": "https://github.com/Anorov/PySocks",
             "requested-revision": "1.7.0",
             "commit-id": "91dcdf0fec424b6afe9ceef88de63b72d2f8fcfe",
         },

--- a/tests/integration/cli/commands/test_pep_751.py
+++ b/tests/integration/cli/commands/test_pep_751.py
@@ -556,7 +556,15 @@ def test_uv_pylock_interop(
 
     management_pex = tmpdir.join("management.pex")
     run_pex_command(
-        args=[".[management]", "--pylock", pylock_toml, "-o", management_pex],
+        args=[
+            ".[management]",
+            "--pylock",
+            pylock_toml,
+            "--pip-version",
+            "latest-compatible",
+            "-o",
+            management_pex,
+        ],
         cwd=chroot,
         quiet=True,
     ).assert_failure(
@@ -578,7 +586,9 @@ def test_uv_pylock_interop(
         )
     )
 
-    run_pex_command(args=["--pylock", pylock_toml, "-o", management_pex]).assert_success()
+    run_pex_command(
+        args=["--pylock", pylock_toml, "--pip-version", "latest-compatible", "-o", management_pex]
+    ).assert_success()
     assert {ProjectName("pex"), ProjectName("psutil")} == {
         dist.metadata.project_name for dist in PEX(management_pex).resolve()
     }

--- a/tests/integration/resolve/pep_691/test_api.py
+++ b/tests/integration/resolve/pep_691/test_api.py
@@ -5,10 +5,10 @@ import re
 
 import pytest
 
+from pex.artifact_url import Fingerprint
 from pex.pep_503 import ProjectName
 from pex.resolve.pep_691.api import Client
 from pex.resolve.pep_691.model import Endpoint, Project
-from pex.resolve.resolved_requirement import Fingerprint
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/tests/integration/resolve/test_issue_1918.py
+++ b/tests/integration/resolve/test_issue_1918.py
@@ -1,18 +1,16 @@
 # Copyright 2022 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import itertools
 import os.path
 
 import pytest
 
+from pex.artifact_url import VCS, ArtifactURL
 from pex.compatibility import safe_commonpath
 from pex.dist_metadata import Requirement
 from pex.pip.version import PipVersion, PipVersionValue
-from pex.requirements import VCS
 from pex.resolve.locked_resolve import VCSArtifact
 from pex.resolve.lockfile import json_codec
-from pex.resolve.resolved_requirement import ArtifactURL
 from pex.resolve.resolver_configuration import ResolverVersion
 from pex.sorted_tuple import SortedTuple
 from pex.typing import TYPE_CHECKING
@@ -77,8 +75,7 @@ class PipParameters(object):
             "ansicolors @ {vcs_url}".format(vcs_url=VCS_URL), VCS_URL, id="direct-reference"
         ),
         pytest.param(
-            *itertools.repeat("{vcs_url}#egg=ansicolors".format(vcs_url=VCS_URL), 2),
-            id="pip-proprietary"
+            "{vcs_url}#egg=ansicolors".format(vcs_url=VCS_URL), VCS_URL, id="pip-proprietary"
         ),
     ],
 )
@@ -119,14 +116,7 @@ def test_redacted_requirement_handling(
     ).assert_success()
     lockfile = json_codec.load(lock)
     assert (
-        SortedTuple(
-            [
-                attr.evolve(
-                    Requirement.parse("ansicolors"),
-                    url=ArtifactURL.parse(expected_url).normalized_url,
-                )
-            ]
-        )
+        SortedTuple([attr.evolve(Requirement.parse("ansicolors"), url=expected_url)])
         == lockfile.requirements
     )
 

--- a/tests/integration/test_downloads.py
+++ b/tests/integration/test_downloads.py
@@ -5,10 +5,11 @@ import os.path
 
 import pytest
 
+from pex.artifact_url import Fingerprint
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.downloads import ArtifactDownloader
 from pex.resolve.locked_resolve import Artifact, FileArtifact, LockConfiguration, LockStyle
-from pex.resolve.resolved_requirement import Fingerprint, PartialArtifact
+from pex.resolve.resolved_requirement import PartialArtifact
 from pex.typing import TYPE_CHECKING
 from testing import IS_LINUX
 

--- a/tests/integration/test_reproducible.py
+++ b/tests/integration/test_reproducible.py
@@ -69,6 +69,7 @@ def assert_reproducible_build(
             zf.extractall(path=destination_dir)
             return [os.path.join(destination_dir, member) for member in sorted(zf.namelist())]
 
+    pexes_dir = tmpdir.join("pexes")
     if pythons:
         pexes = run_commands_with_jitter(
             path_argument="--output-file",
@@ -80,12 +81,14 @@ def assert_reproducible_build(
                 )
                 for python in pythons
             ],
+            dest=pexes_dir,
         )
     else:
         pexes = run_command_with_jitter(
             create_pex_command(args=args, quiet=True),
             path_argument="--output-file",
             count=3,
+            dest=pexes_dir,
         )
 
     pex_members = {pex: explode_pex(path=pex) for pex in pexes}

--- a/tests/resolve/lockfile/test_download_manager.py
+++ b/tests/resolve/lockfile/test_download_manager.py
@@ -8,12 +8,12 @@ from io import BytesIO
 import pytest
 
 from pex import hashing
+from pex.artifact_url import ArtifactURL, Fingerprint
 from pex.cache.dirs import CacheDir
 from pex.hashing import Sha1Fingerprint, Sha256Fingerprint
 from pex.pep_503 import ProjectName
 from pex.resolve.locked_resolve import FileArtifact
 from pex.resolve.lockfile.download_manager import DownloadedArtifact, DownloadManager
-from pex.resolve.resolved_requirement import ArtifactURL, Fingerprint
 from pex.result import Error, catch
 from pex.typing import TYPE_CHECKING
 from pex.variables import ENV, Variables

--- a/tests/resolve/lockfile/test_json_codec.py
+++ b/tests/resolve/lockfile/test_json_codec.py
@@ -8,6 +8,7 @@ from textwrap import dedent
 
 import pytest
 
+from pex.artifact_url import ArtifactURL, Fingerprint
 from pex.compatibility import PY2
 from pex.dist_metadata import Constraint, Requirement
 from pex.pep_440 import Version
@@ -18,7 +19,7 @@ from pex.resolve.lockfile import json_codec
 from pex.resolve.lockfile.json_codec import ParseError, PathMappingError
 from pex.resolve.lockfile.model import Lockfile
 from pex.resolve.path_mappings import PathMapping, PathMappings
-from pex.resolve.resolved_requirement import ArtifactURL, Fingerprint, Pin
+from pex.resolve.resolved_requirement import Pin
 from pex.resolve.resolver_configuration import BuildConfiguration, ResolverVersion
 from pex.sorted_tuple import SortedTuple
 from pex.third_party.packaging import tags

--- a/tests/resolve/lockfile/test_pep_751.py
+++ b/tests/resolve/lockfile/test_pep_751.py
@@ -278,8 +278,8 @@ def test_pylock_parse_toplevel_items():
         dedent(
             """\
             environments = [
-                "platform_system == 'Darwin' and python_version >= '3.12'",
-                "platform_system == 'Linux'"
+                "platform_system == \\"Darwin\\" and python_version >=\\"3.12\\"",
+                "platform_system == \\"Linux\\""
             ]
             requires-python = ">=3.9"
             extras = ["admin"]
@@ -291,9 +291,9 @@ def test_pylock_parse_toplevel_items():
     )
 
     assert (
-        Marker("platform_system == 'Darwin' and python_version >= '3.12'"),
-        Marker("platform_system == 'Linux'"),
-    ) == pylock.environments
+        'platform_system == "Darwin" and python_version >= "3.12"',
+        'platform_system == "Linux"',
+    ) == tuple(map(str, pylock.environments))
     assert ">=3.9" == str(pylock.requires_python)
     assert tuple(["admin"]) == pylock.extras
     assert ("dev", "debug") == pylock.dependency_groups
@@ -549,7 +549,7 @@ def test_pylock_parse_archive():
             [[packages]]
             name = "foo"
             version = "1.2.3"
-            marker = "python_version >= '3.9'"
+            marker = "python_version >= \\"3.9\\""
             [packages.archive]
             name = "foo-1.2.3.tar.gz"
             url = "https://example.org/foo-1.2.3.tar.gz"
@@ -562,7 +562,7 @@ def test_pylock_parse_archive():
 
     assert ProjectName("foo") == package.project_name
     assert Version("1.2.3") == package.version
-    assert Marker("python_version >= '3.9'") == package.marker
+    assert 'python_version >= "3.9"' == str(package.marker)
     assert isinstance(package.artifact, FileArtifact)
     assert not package.artifact.verified
     assert package.artifact.is_source
@@ -714,7 +714,7 @@ def test_pylock_parse_errors(tmpdir):
 
     assert_pylock_error(
         "Failed to parse the PEP-751 lock at {lock_path}. "
-        "Error parsing content at packages[0]{{name = 'foo'}}.\n"
+        'Error parsing content at packages[0]{{name = "foo"}}.\n'
         "Package must define an artifact.".format(lock_path=lock_path),
         dedent(
             """\
@@ -726,10 +726,10 @@ def test_pylock_parse_errors(tmpdir):
 
     assert_pylock_error(
         "Failed to parse the PEP-751 lock at {lock_path}. "
-        "Error parsing content at packages[0]{{name = 'foo'}}.\n"
-        "These artifacts are mutually exclusive with packages[0]{{name = 'foo'}}.vcs:\n"
-        "+ packages[0]{{name = 'foo'}}.sdist\n"
-        "+ packages[0]{{name = 'foo'}}.wheels".format(lock_path=lock_path),
+        'Error parsing content at packages[0]{{name = "foo"}}.\n'
+        'These artifacts are mutually exclusive with packages[0]{{name = "foo"}}.vcs:\n'
+        '+ packages[0]{{name = "foo"}}.sdist\n'
+        '+ packages[0]{{name = "foo"}}.wheels'.format(lock_path=lock_path),
         dedent(
             """\
             [[packages]]
@@ -743,7 +743,7 @@ def test_pylock_parse_errors(tmpdir):
 
     assert_pylock_error(
         "Failed to parse the PEP-751 lock at {lock_path}. "
-        "Error parsing content at packages[0]{{name = 'A'}}.dependencies[0]{{name = 'C'}}.\n"
+        'Error parsing content at packages[0]{{name = "A"}}.dependencies[0]{{name = "C"}}.\n'
         "The A package depends on C, but there is no C package in the packages array.".format(
             lock_path=lock_path
         ),
@@ -753,19 +753,19 @@ def test_pylock_parse_errors(tmpdir):
             name = "A"
             version = "1"
             dependencies = [{name = "C"}]
-            directory = "A"
+            directory = {path = "A"}
             
             [[packages]]
             name = "B"
             version = "2"
-            directory = "B"
+            directory = {path = "B"}
             """
         ),
     )
 
     assert_pylock_error(
         "Failed to parse the PEP-751 lock at {lock_path}. "
-        "Error parsing content at packages[0]{{name = 'A'}}.dependencies[0]{{name = 'B'}}.\n"
+        'Error parsing content at packages[0]{{name = "A"}}.dependencies[0]{{name = "B"}}.\n'
         "No matching B package could be found for A dependencies[0].".format(lock_path=lock_path),
         dedent(
             """\
@@ -773,19 +773,19 @@ def test_pylock_parse_errors(tmpdir):
             name = "A"
             version = "1"
             dependencies = [{name = "B", version = "1"}]
-            directory = "A"
+            directory = {path = "A"}
             
             [[packages]]
             name = "B"
             version = "2"
-            directory = "B"
+            directory = {path = "B"}
             """
         ),
     )
 
     assert_pylock_error(
         "Failed to parse the PEP-751 lock at {lock_path}. "
-        "Error parsing content at packages[0]{{name = 'A'}}.dependencies[0]{{name = 'B'}}.\n"
+        'Error parsing content at packages[0]{{name = "A"}}.dependencies[0]{{name = "B"}}.\n'
         "More than one package matches A dependencies[0]:\n"
         "+ packages[1]\n"
         "+ packages[2]".format(lock_path=lock_path),
@@ -795,19 +795,17 @@ def test_pylock_parse_errors(tmpdir):
             name = "A"
             version = "1"
             dependencies = [{name = "B", version = "1"}]
-            directory = "A"
+            directory = {path = "A"}
             
             [[packages]]
             name = "B"
             version = "1"
-            directory = "B"
-            subdirectory = "standard-b"
+            directory = {path = "B", subdirectory = "standard-b"}
             
             [[packages]]
             name = "B"
             version = "1"
-            directory = "B"
-            subdirectory = "special-b"
+            directory = {path = "B", subdirectory = "special-b"}
             """
         ),
     )

--- a/tests/resolve/lockfile/test_pep_751.py
+++ b/tests/resolve/lockfile/test_pep_751.py
@@ -3,13 +3,29 @@
 
 from __future__ import absolute_import
 
+import functools
+import os.path
+import re
 from collections import defaultdict
+from textwrap import dedent
 
+import pytest
+
+from pex.artifact_url import VCS, ArtifactURL, Fingerprint
+from pex.common import safe_mkdtemp, safe_open
 from pex.orderedset import OrderedSet
+from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
-from pex.resolve.lockfile.pep_751 import _calculate_marker, _elide_extras
+from pex.resolve.locked_resolve import (
+    FileArtifact,
+    UnFingerprintedLocalProjectArtifact,
+    UnFingerprintedVCSArtifact,
+)
+from pex.resolve.lockfile.pep_751 import Pylock, _calculate_marker, _elide_extras
+from pex.result import ResultError, try_
 from pex.third_party.packaging.markers import Marker
 from pex.typing import TYPE_CHECKING
+from testing.pytest_utils.tmp import Tempdir
 
 if TYPE_CHECKING:
     from typing import DefaultDict, Mapping, Optional, Tuple
@@ -228,4 +244,570 @@ def test_calculate_marker_indirect_and():
     assert_markers_equal(
         Marker("sys_platform == 'win32' and python_version == '3.9.*'"),
         _calculate_marker(ProjectName("D"), dependants_mapping),
+    )
+
+
+def parse_lock(
+    content,  # type: str
+    expected_package_count=1,  # type: int
+    path=None,  # type: Optional[str]
+):
+    # type: (...) -> Pylock
+
+    lock_path = path or os.path.join(safe_mkdtemp(), "pylock.toml")
+    with safe_open(lock_path, mode="w") as fp:
+        fp.write(
+            dedent(
+                """\
+                lock-version = "1.0"
+                created-by = "test"
+                
+                {content}
+                """
+            ).format(content=content)
+        )
+    pylock = try_(Pylock.parse(lock_path))
+    assert Version("1.0") == pylock.lock_version
+    assert "test" == pylock.created_by
+    assert len(pylock.packages) == expected_package_count
+    return pylock
+
+
+def test_pylock_parse_toplevel_items():
+    pylock = parse_lock(
+        dedent(
+            """\
+            environments = [
+                "platform_system == 'Darwin' and python_version >= '3.12'",
+                "platform_system == 'Linux'"
+            ]
+            requires-python = ">=3.9"
+            extras = ["admin"]
+            dependency-groups = ["dev", "debug"]
+            default-groups = ["dev"]
+            """
+        ),
+        expected_package_count=0,
+    )
+
+    assert (
+        Marker("platform_system == 'Darwin' and python_version >= '3.12'"),
+        Marker("platform_system == 'Linux'"),
+    ) == pylock.environments
+    assert ">=3.9" == str(pylock.requires_python)
+    assert tuple(["admin"]) == pylock.extras
+    assert ("dev", "debug") == pylock.dependency_groups
+    assert tuple(["dev"]) == pylock.default_groups
+
+
+def test_pylock_parse_sdist_url():
+    # type: () -> None
+
+    pylock = parse_lock(
+        dedent(
+            """\
+            [[packages]]
+            name = "foo"
+            version = "1.2.3"
+            [packages.sdist]
+            name = "foo-1.2.3.tar.gz"
+            url = "https://example.org/foo-1.2.3.tar.gz/content-endpoint"
+            hashes = {md5 = "4321dcba", sha256 = "abcd1234"}
+            """
+        )
+    )
+    package = pylock.packages[0]
+
+    assert ProjectName("foo") == package.project_name
+    assert Version("1.2.3") == package.version
+    assert isinstance(package.artifact, FileArtifact)
+    assert not package.artifact.verified
+    assert package.artifact.is_source
+    assert "foo-1.2.3.tar.gz" == package.artifact.filename
+    assert (
+        ArtifactURL.parse("https://example.org/foo-1.2.3.tar.gz/content-endpoint")
+        == package.artifact.url
+    )
+    assert (
+        Fingerprint(algorithm="sha256", hash="abcd1234") == package.artifact.fingerprint
+    ), "Expected the strongest hash to be selected."
+    assert len(package.additional_wheels) == 0
+
+
+def test_pylock_parse_sdist_relative_path():
+    # type: () -> None
+
+    pylock = parse_lock(
+        dedent(
+            """\
+            [[packages]]
+            name = "foo"
+            version = "1.2.3"
+            [packages.sdist]
+            name = "foo-1.2.3.tar.gz"
+            path = "dists/foo-1.2.3.tar.gz"
+            hashes = {md5 = "4321dcba"}
+            """
+        )
+    )
+    package = pylock.packages[0]
+
+    assert ProjectName("foo") == package.project_name
+    assert Version("1.2.3") == package.version
+    assert isinstance(package.artifact, FileArtifact)
+    assert not package.artifact.verified
+    assert package.artifact.is_source
+    assert "foo-1.2.3.tar.gz" == package.artifact.filename
+    assert (
+        ArtifactURL.parse(
+            "file://{lock_path}/dists/foo-1.2.3.tar.gz".format(
+                lock_path=os.path.dirname(pylock.source)
+            )
+        )
+        == package.artifact.url
+    )
+    assert Fingerprint(algorithm="md5", hash="4321dcba")
+    assert len(package.additional_wheels) == 0
+
+
+def test_pylock_parse_sdist_absolute_path():
+    # type: () -> None
+
+    pylock = parse_lock(
+        dedent(
+            """\
+            [[packages]]
+            name = "foo"
+            version = "1.2.3"
+            [packages.sdist]
+            name = "foo-1.2.3.tar.gz"
+            path = "/mnt/nfs/dists/foo-1.2.3.tar.gz"
+            hashes = {md5 = "4321dcba"}
+            """
+        )
+    )
+    package = pylock.packages[0]
+
+    assert ProjectName("foo") == package.project_name
+    assert Version("1.2.3") == package.version
+    assert isinstance(package.artifact, FileArtifact)
+    assert not package.artifact.verified
+    assert package.artifact.is_source
+    assert "foo-1.2.3.tar.gz" == package.artifact.filename
+    assert ArtifactURL.parse("file:///mnt/nfs/dists/foo-1.2.3.tar.gz") == package.artifact.url
+    assert Fingerprint(algorithm="md5", hash="4321dcba")
+    assert len(package.additional_wheels) == 0
+
+
+def test_pylock_parse_wheel():
+    # type: () -> None
+
+    pylock = parse_lock(
+        dedent(
+            """\
+            [[packages]]
+            name = "foo"
+            version = "1.2.3"
+            [[packages.wheels]]
+            name = "foo-1.2.3-py3-none-any.whl"
+            url = "file:///mnt/nfs/dists/foo-1.2.3-py3-none-any.whl"
+            hashes = {md5 = "4321dcba", sha1 = "abcd1234"}
+            """
+        )
+    )
+    package = pylock.packages[0]
+
+    assert ProjectName("foo") == package.project_name
+    assert Version("1.2.3") == package.version
+    assert isinstance(package.artifact, FileArtifact)
+    assert not package.artifact.verified
+    assert package.artifact.is_wheel
+    assert "foo-1.2.3-py3-none-any.whl" == package.artifact.filename
+    assert (
+        ArtifactURL.parse("file:///mnt/nfs/dists/foo-1.2.3-py3-none-any.whl")
+        == package.artifact.url
+    )
+    assert (
+        Fingerprint(algorithm="sha1", hash="abcd1234") == package.artifact.fingerprint
+    ), "Expected the strongest hash to be selected."
+    assert len(package.additional_wheels) == 0
+
+
+def test_pylock_parse_wheels():
+    # type: () -> None
+
+    pylock = parse_lock(
+        dedent(
+            """\
+            [[packages]]
+            name = "foo"
+            version = "1.2.3"
+            [[packages.wheels]]
+            name = "foo-1.2.3-py3-none-any.whl"
+            url = "file:///mnt/nfs/dists/foo-1.2.3-py3-none-any.whl"
+            hashes = {md5 = "4321dcba", sha1 = "abcd1234"}
+            [[packages.wheels]]
+            name = "foo-1.2.3-py2-none-any.whl"
+            url = "https://example.org/foo-1.2.3-py2-none-any.whl/content-endpoint"
+            hashes = {sha256 = "4321dcba"}
+            """
+        )
+    )
+    package = pylock.packages[0]
+
+    assert ProjectName("foo") == package.project_name
+    assert Version("1.2.3") == package.version
+
+    assert isinstance(package.artifact, FileArtifact)
+    assert not package.artifact.verified
+    assert package.artifact.is_wheel
+    assert "foo-1.2.3-py3-none-any.whl" == package.artifact.filename
+    assert (
+        ArtifactURL.parse("file:///mnt/nfs/dists/foo-1.2.3-py3-none-any.whl")
+        == package.artifact.url
+    )
+    assert (
+        Fingerprint(algorithm="sha1", hash="abcd1234") == package.artifact.fingerprint
+    ), "Expected the strongest hash to be selected."
+    assert len(package.additional_wheels) == 1
+
+    additional_wheel = package.additional_wheels[0]
+    assert isinstance(additional_wheel, FileArtifact)
+    assert not additional_wheel.verified
+    assert additional_wheel.is_wheel
+    assert "foo-1.2.3-py2-none-any.whl" == additional_wheel.filename
+    assert (
+        ArtifactURL.parse("https://example.org/foo-1.2.3-py2-none-any.whl/content-endpoint")
+        == additional_wheel.url
+    )
+    assert Fingerprint(algorithm="sha256", hash="4321dcba") == additional_wheel.fingerprint
+
+
+def test_pylock_parse_sdist_and_wheels():
+    # type: () -> None
+
+    pylock = parse_lock(
+        dedent(
+            """\
+            [[packages]]
+            name = "foo"
+            version = "1.2.3"
+            [packages.sdist]
+            name = "foo-1.2.3.tar.gz"
+            url = "https://example.org/foo-1.2.3.tar.gz"
+            hashes = {md5 = "4321dcba", sha256 = "abcd1234"}
+            [[packages.wheels]]
+            name = "foo-1.2.3-py3-none-any.whl"
+            url = "file:///mnt/nfs/dists/foo-1.2.3-py3-none-any.whl"
+            hashes = {md5 = "4321dcba", sha1 = "abcd1234"}
+            [[packages.wheels]]
+            url = "https://example.org/foo-1.2.3-py2-none-any.whl"
+            hashes = {sha256 = "4321dcba"}
+            """
+        )
+    )
+    package = pylock.packages[0]
+
+    assert ProjectName("foo") == package.project_name
+    assert Version("1.2.3") == package.version
+
+    assert isinstance(package.artifact, FileArtifact)
+    assert not package.artifact.verified
+    assert package.artifact.is_source
+    assert "foo-1.2.3.tar.gz" == package.artifact.filename
+    assert ArtifactURL.parse("https://example.org/foo-1.2.3.tar.gz") == package.artifact.url
+    assert (
+        Fingerprint(algorithm="sha256", hash="abcd1234") == package.artifact.fingerprint
+    ), "Expected the strongest hash to be selected."
+    assert len(package.additional_wheels) == 2
+
+    wheel1 = package.additional_wheels[0]
+    assert isinstance(wheel1, FileArtifact)
+    assert not wheel1.verified
+    assert wheel1.is_wheel
+    assert "foo-1.2.3-py3-none-any.whl" == wheel1.filename
+    assert ArtifactURL.parse("file:///mnt/nfs/dists/foo-1.2.3-py3-none-any.whl") == wheel1.url
+    assert (
+        Fingerprint(algorithm="sha1", hash="abcd1234") == wheel1.fingerprint
+    ), "Expected the strongest hash to be selected."
+
+    wheel2 = package.additional_wheels[1]
+    assert isinstance(wheel2, FileArtifact)
+    assert not wheel2.verified
+    assert wheel2.is_wheel
+    assert "foo-1.2.3-py2-none-any.whl" == wheel2.filename
+    assert ArtifactURL.parse("https://example.org/foo-1.2.3-py2-none-any.whl") == wheel2.url
+    assert Fingerprint(algorithm="sha256", hash="4321dcba") == wheel2.fingerprint
+
+
+def test_pylock_parse_archive():
+    # type: () -> None
+
+    pylock = parse_lock(
+        dedent(
+            """\
+            [[packages]]
+            name = "foo"
+            version = "1.2.3"
+            marker = "python_version >= '3.9'"
+            [packages.archive]
+            name = "foo-1.2.3.tar.gz"
+            url = "https://example.org/foo-1.2.3.tar.gz"
+            hashes = {sha256 = "abcd1234"}
+            subdirectory = "bar"
+            """
+        )
+    )
+    package = pylock.packages[0]
+
+    assert ProjectName("foo") == package.project_name
+    assert Version("1.2.3") == package.version
+    assert Marker("python_version >= '3.9'") == package.marker
+    assert isinstance(package.artifact, FileArtifact)
+    assert not package.artifact.verified
+    assert package.artifact.is_source
+    assert "foo-1.2.3.tar.gz" == package.artifact.filename
+    assert ArtifactURL.parse("https://example.org/foo-1.2.3.tar.gz") == package.artifact.url
+    assert Fingerprint(algorithm="sha256", hash="abcd1234") == package.artifact.fingerprint
+    assert "bar" == package.artifact.subdirectory
+    assert len(package.additional_wheels) == 0
+
+
+def test_pylock_parse_directory():
+    # type: () -> None
+
+    pylock = parse_lock(
+        dedent(
+            """\
+            [[packages]]
+            name = "foo"
+            [packages.directory]
+            path = "."
+            editable = true
+            subdirectory = "foo"
+            """
+        )
+    )
+    package = pylock.packages[0]
+
+    assert ProjectName("foo") == package.project_name
+    assert package.version is None
+    assert isinstance(package.artifact, UnFingerprintedLocalProjectArtifact)
+    assert package.artifact.verified
+    assert os.path.join(os.path.dirname(pylock.source), "foo") == package.artifact.directory
+    assert package.artifact.editable
+    assert package.artifact.subdirectory is None
+    assert len(package.additional_wheels) == 0
+
+
+def test_pylock_parse_vcs():
+    # type: () -> None
+
+    pylock = parse_lock(
+        dedent(
+            """\
+            [[packages]]
+            name = "foo"
+            [packages.vcs]
+            type = "git"
+            requested-revision = "main"
+            commit-id = "abcd1234"
+            url = "https://github.com/foo/foo"
+            subdirectory = "bar"
+            """
+        )
+    )
+    package = pylock.packages[0]
+
+    assert ProjectName("foo") == package.project_name
+    assert isinstance(package.artifact, UnFingerprintedVCSArtifact)
+    assert package.artifact.verified
+    assert package.artifact.vcs is VCS.Git
+    assert "main" == package.artifact.requested_revision
+    assert "abcd1234" == package.artifact.commit_id
+    assert ArtifactURL.parse("https://github.com/foo/foo") == package.artifact.url
+    assert "bar" == package.artifact.subdirectory
+    assert len(package.additional_wheels) == 0
+
+
+def test_pylock_parse_dependencies():
+    pylock = parse_lock(
+        dedent(
+            """\
+            [[packages]]
+            name = "A"
+            version = "1"
+            dependencies = [
+                {name = "B", wheels = [{hashes = {sha1 = "123"}}]},
+                {name = "E", wheels = [{"url" = "https://example.org/e-5-py3-none-any.whl"}]}
+            ]
+            wheels = [{"url" = "https://example.org/a-1-py3-none-any.whl", hashes = {md5 = "abc"}}]
+            
+            [[packages]]
+            name = "B"
+            version = "2"
+            dependencies = [{name = "C"}]
+            [[packages.wheels]]
+            url = "https://example.org/b-2-py3-none-any.whl"
+            hashes = {md5 = "def", "sha1" = "123"}
+            
+            [[packages]]
+            name = "C"
+            version = "3"
+            wheels = [{"url" = "https://example.org/c-3-py3-none-any.whl", hashes = {md5 = "ghi"}}]
+            
+            [[packages]]
+            name = "D"
+            version = "4"
+            dependencies = [{name = "E"}]
+            wheels = [{"url" = "https://example.org/d-4-py3-none-any.whl", hashes = {md5 = "jkl"}}]
+            
+            [[packages]]
+            name = "E"
+            version = "5"
+            wheels = [{"url" = "https://example.org/e-5-py3-none-any.whl", hashes = {md5 = "mno"}}]
+            """
+        ),
+        expected_package_count=5,
+    )
+
+    packages_by_project_name = {package.project_name: package for package in pylock.packages}
+    package_A = packages_by_project_name.pop(ProjectName("A"))
+    package_B = packages_by_project_name.pop(ProjectName("B"))
+    package_C = packages_by_project_name.pop(ProjectName("C"))
+    package_D = packages_by_project_name.pop(ProjectName("D"))
+    package_E = packages_by_project_name.pop(ProjectName("E"))
+    assert not packages_by_project_name
+    assert (package_B, package_E) == package_A.dependencies
+    assert tuple([package_C]) == package_B.dependencies
+    assert not package_C.dependencies
+    assert tuple([package_E]) == package_D.dependencies
+    assert not package_E.dependencies
+
+
+def assert_lock_error(
+    lock_path,  # type: str
+    match,  # type: str
+    content,  # type: str
+):
+    # type: (...) -> None
+    with pytest.raises(ResultError, match=r"^{match}$".format(match=re.escape(match))):
+        parse_lock(content, path=lock_path)
+
+
+def test_pylock_parse_errors(tmpdir):
+    # type: (Tempdir) -> None
+
+    lock_path = tmpdir.join("pylock.toml")
+    assert_pylock_error = functools.partial(assert_lock_error, lock_path)
+
+    assert_pylock_error(
+        "Failed to parse the PEP-751 lock at {lock_path}. "
+        "Error parsing content at packages[0].\n"
+        "A value for packages[0].name is required.".format(lock_path=lock_path),
+        dedent(
+            """\
+            [[packages]]
+            """
+        ),
+    )
+
+    assert_pylock_error(
+        "Failed to parse the PEP-751 lock at {lock_path}. "
+        "Error parsing content at packages[0]{{name = 'foo'}}.\n"
+        "Package must define an artifact.".format(lock_path=lock_path),
+        dedent(
+            """\
+            [[packages]]
+            name = "foo"
+            """
+        ),
+    )
+
+    assert_pylock_error(
+        "Failed to parse the PEP-751 lock at {lock_path}. "
+        "Error parsing content at packages[0]{{name = 'foo'}}.\n"
+        "These artifacts are mutually exclusive with packages[0]{{name = 'foo'}}.vcs:\n"
+        "+ packages[0]{{name = 'foo'}}.sdist\n"
+        "+ packages[0]{{name = 'foo'}}.wheels".format(lock_path=lock_path),
+        dedent(
+            """\
+            [[packages]]
+            name = "foo"
+            vcs = {type = "git"}
+            sdist = {name = "foo-1.0.tar.gz"}
+            wheels = [{name = "foo-1.0-py2.py3-none-any.whl"}]
+            """
+        ),
+    )
+
+    assert_pylock_error(
+        "Failed to parse the PEP-751 lock at {lock_path}. "
+        "Error parsing content at packages[0]{{name = 'A'}}.dependencies[0]{{name = 'C'}}.\n"
+        "The A package depends on C, but there is no C package in the packages array.".format(
+            lock_path=lock_path
+        ),
+        dedent(
+            """\
+            [[packages]]
+            name = "A"
+            version = "1"
+            dependencies = [{name = "C"}]
+            directory = "A"
+            
+            [[packages]]
+            name = "B"
+            version = "2"
+            directory = "B"
+            """
+        ),
+    )
+
+    assert_pylock_error(
+        "Failed to parse the PEP-751 lock at {lock_path}. "
+        "Error parsing content at packages[0]{{name = 'A'}}.dependencies[0]{{name = 'B'}}.\n"
+        "No matching B package could be found for A dependencies[0].".format(lock_path=lock_path),
+        dedent(
+            """\
+            [[packages]]
+            name = "A"
+            version = "1"
+            dependencies = [{name = "B", version = "1"}]
+            directory = "A"
+            
+            [[packages]]
+            name = "B"
+            version = "2"
+            directory = "B"
+            """
+        ),
+    )
+
+    assert_pylock_error(
+        "Failed to parse the PEP-751 lock at {lock_path}. "
+        "Error parsing content at packages[0]{{name = 'A'}}.dependencies[0]{{name = 'B'}}.\n"
+        "More than one package matches A dependencies[0]:\n"
+        "+ packages[1]\n"
+        "+ packages[2]".format(lock_path=lock_path),
+        dedent(
+            """\
+            [[packages]]
+            name = "A"
+            version = "1"
+            dependencies = [{name = "B", version = "1"}]
+            directory = "A"
+            
+            [[packages]]
+            name = "B"
+            version = "1"
+            directory = "B"
+            subdirectory = "standard-b"
+            
+            [[packages]]
+            name = "B"
+            version = "1"
+            directory = "B"
+            subdirectory = "special-b"
+            """
+        ),
     )

--- a/tests/resolve/lockfile/test_requires_dist.py
+++ b/tests/resolve/lockfile/test_requires_dist.py
@@ -3,12 +3,13 @@
 
 from __future__ import absolute_import
 
+from pex.artifact_url import Fingerprint
 from pex.dist_metadata import Requirement
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.resolve.locked_resolve import Artifact, LockedRequirement, LockedResolve
 from pex.resolve.lockfile import requires_dist
-from pex.resolve.resolved_requirement import Fingerprint, Pin
+from pex.resolve.resolved_requirement import Pin
 from pex.sorted_tuple import SortedTuple
 
 req = Requirement.parse

--- a/tests/resolve/pep_691/test_api.py
+++ b/tests/resolve/pep_691/test_api.py
@@ -12,12 +12,12 @@ except ImportError:
 
 import pytest
 
+from pex.artifact_url import ArtifactURL, Fingerprint
 from pex.fetcher import URLFetcher
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.resolve.pep_691.api import Client
 from pex.resolve.pep_691.model import Endpoint, File, Meta, Project
-from pex.resolve.resolved_requirement import ArtifactURL, Fingerprint
 from pex.sorted_tuple import SortedTuple
 from pex.typing import TYPE_CHECKING
 

--- a/tests/resolve/pep_691/test_fingerprint_service.py
+++ b/tests/resolve/pep_691/test_fingerprint_service.py
@@ -11,13 +11,14 @@ try:
 except ImportError:
     import mock  # type: ignore[no-redef,import]
 
+from pex.artifact_url import ArtifactURL, Fingerprint
 from pex.compatibility import urlparse
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.resolve.pep_691.api import Client
 from pex.resolve.pep_691.fingerprint_service import FingerprintService
 from pex.resolve.pep_691.model import Endpoint, File, Meta, Project
-from pex.resolve.resolved_requirement import ArtifactURL, Fingerprint, PartialArtifact
+from pex.resolve.resolved_requirement import PartialArtifact
 from pex.sorted_tuple import SortedTuple
 from pex.typing import TYPE_CHECKING
 

--- a/tests/resolve/pep_691/test_model.py
+++ b/tests/resolve/pep_691/test_model.py
@@ -6,8 +6,8 @@ from collections import defaultdict
 
 import pytest
 
+from pex.artifact_url import Fingerprint
 from pex.resolve.pep_691.model import File
-from pex.resolve.resolved_requirement import Fingerprint
 from pex.sorted_tuple import SortedTuple
 from pex.typing import TYPE_CHECKING
 

--- a/tests/resolve/test_resolved_requirement.py
+++ b/tests/resolve/test_resolved_requirement.py
@@ -1,8 +1,7 @@
 # Copyright 2024 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pex.requirements import ArchiveScheme
-from pex.resolve.resolved_requirement import ArtifactURL, Fingerprint
+from pex.artifact_url import ArchiveScheme, ArtifactURL, Fingerprint
 
 
 def test_artifact_url_escaping():

--- a/tests/test_artifact_url.py
+++ b/tests/test_artifact_url.py
@@ -1,0 +1,24 @@
+# Copyright 2025 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from pex.artifact_url import VCS, ArchiveScheme, VCSScheme, parse_scheme
+
+
+def test_parse_scheme():
+    # type: () -> None
+
+    assert "not a scheme" == parse_scheme("not a scheme")
+    assert "gopher" == parse_scheme("gopher")
+
+    assert ArchiveScheme.FTP == parse_scheme("ftp")
+    assert ArchiveScheme.HTTP == parse_scheme("http")
+    assert ArchiveScheme.HTTPS == parse_scheme("https")
+
+    assert VCSScheme(VCS.Bazaar, "nfs") == parse_scheme("bzr+nfs")
+    assert VCSScheme(VCS.Git, "file") == parse_scheme("git+file")
+    assert VCSScheme(VCS.Mercurial, "http") == parse_scheme("hg+http")
+    assert VCSScheme(VCS.Subversion, "https") == parse_scheme("svn+https")
+
+    assert "cvs+https" == parse_scheme("cvs+https")

--- a/tests/test_pex_builder.py
+++ b/tests/test_pex_builder.py
@@ -201,7 +201,7 @@ def test_pex_builder_deterministic_timestamp():
     pb = PEXBuilder()
     with temporary_dir() as td:
         target = os.path.join(td, "foo.pex")
-        pb.build(target, deterministic_timestamp=True)
+        pb.build(target, deterministic=True)
         with zipfile.ZipFile(target) as zf:
             assert all(zinfo.date_time == (1980, 1, 1, 0, 0, 0) for zinfo in zf.infolist())
 


### PR DESCRIPTION
Pex can now resolve from PEP-751 locks. To support sub-setting, the lock
must carry `dependencies` metadata for its locked packages, which is
only optional data per the spec. The pylock resolver machinery will
check the resulting resolve to confirm there are no missing dependencies
and fail if holes are found. For example, as of this writing, `uv`
PEP-751 lock exports don't include dependencies metadata and cannot be
sub-setted. Pex PEP-751 lock exports do, but this is not too useful
since you can just use a native Pex lock for that.

Closes #2756