### PR TITLE
Support PEP-751 extras and dependency groups.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 2.40.0
+
+This release fills out `--pylock` support with `--pylock-extra` and `--pylock-group` to have Pex
+resolve extras and dependency groups defined for a PEP-751 lock. This support only works when Pex
+is run under Python 3.8 or newer.
+
+* Support PEP-751 extras and dependency groups. (#2770)
+
 ## 2.39.0
 
 This release adds support for `pex --pylock` and `pex3 venv create --pylock` for building PEXes and

--- a/pex/resolve/configured_resolve.py
+++ b/pex/resolve/configured_resolve.py
@@ -84,6 +84,8 @@ def resolve(
                     resolver=ConfiguredResolver(pip_configuration=pip_configuration),
                     requirements=requirement_configuration.requirements,
                     requirement_files=requirement_configuration.requirement_files,
+                    extras=resolver_configuration.extras,
+                    dependency_groups=resolver_configuration.dependency_groups,
                     constraint_files=requirement_configuration.constraint_files,
                     transitive=pip_configuration.transitive,
                     indexes=pip_configuration.repos_configuration.indexes,

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -37,7 +37,7 @@ from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import DefaultDict, Iterable, List, Optional, Sequence, Set, Tuple, Union
+    from typing import DefaultDict, FrozenSet, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
 
 def _check_subset(
@@ -101,6 +101,8 @@ def resolve_from_pylock(
     resolver,  # type: Resolver
     requirements=None,  # type: Optional[Iterable[str]]
     requirement_files=None,  # type: Optional[Iterable[str]]
+    extras=frozenset(),  # type: FrozenSet[str]
+    dependency_groups=frozenset(),  # type: FrozenSet[str]
     constraint_files=None,  # type: Optional[Iterable[str]]
     indexes=None,  # type: Optional[Sequence[str]]
     find_links=None,  # type: Optional[Sequence[str]]
@@ -131,6 +133,8 @@ def resolve_from_pylock(
             targets=targets,
             pylock=pylock,
             requirement_configuration=requirement_configuration,
+            extras=extras,
+            dependency_groups=dependency_groups,
             network_configuration=network_configuration,
             build_configuration=build_configuration,
             transitive=transitive,

--- a/pex/resolve/resolver_configuration.py
+++ b/pex/resolve/resolver_configuration.py
@@ -247,6 +247,8 @@ class LockRepositoryConfiguration(object):
 @attr.s(frozen=True)
 class PylockRepositoryConfiguration(object):
     lock_file_path = attr.ib()  # type: str
+    extras = attr.ib()  # type: FrozenSet[str]
+    dependency_groups = attr.ib()  # type: FrozenSet[str]
     pip_configuration = attr.ib()  # type: PipConfiguration
 
     @property

--- a/pex/resolve/resolver_options.py
+++ b/pex/resolve/resolver_options.py
@@ -236,6 +236,23 @@ def register(
                 "dependencies information, which is optional in PEP-751."
             ),
         )
+        parser.add_argument(
+            "--pylock-extra",
+            dest="pylock_extras",
+            default=[],
+            type=str,
+            action="append",
+            help="The extras to include when resolving from the `--pylock` lock.",
+        )
+        parser.add_argument(
+            "--pylock-group",
+            "--pylock-dependency-group",
+            dest="pylock_dependency_groups",
+            default=[],
+            type=str,
+            action="append",
+            help="The dependency groups to include when resolving from the `--pylock` lock.",
+        )
     if include_pre_resolved:
         repository_choice.add_argument(
             "--pre-resolved-dist",
@@ -655,6 +672,8 @@ def configure(
     if pylock:
         return PylockRepositoryConfiguration(
             lock_file_path=pylock,
+            extras=frozenset(options.pylock_extras),
+            dependency_groups=frozenset(options.pylock_dependency_groups),
             pip_configuration=pip_configuration,
         )
 

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.39.0"
+__version__ = "2.40.0"

--- a/tests/resolve/lockfile/test_pep_751.py
+++ b/tests/resolve/lockfile/test_pep_751.py
@@ -295,9 +295,9 @@ def test_pylock_parse_toplevel_items():
         'platform_system == "Linux"',
     ) == tuple(map(str, pylock.environments))
     assert ">=3.9" == str(pylock.requires_python)
-    assert tuple(["admin"]) == pylock.extras
-    assert ("dev", "debug") == pylock.dependency_groups
-    assert tuple(["dev"]) == pylock.default_groups
+    assert frozenset(["admin"]) == pylock.extras
+    assert frozenset(["dev", "debug"]) == pylock.dependency_groups
+    assert frozenset(["dev"]) == pylock.default_groups
 
 
 def test_pylock_parse_sdist_url():


### PR DESCRIPTION
Introduce `pex --pylock ... --pylock-extra+ --pylock-group+`. This is
only supported for Python 3.8 or newer.