### PR TITLE
Prepare the 2.40.2 release.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 2.40.2
+
+This relase fixes Pex to work in more scenarios on Windows. Windows is still not officially
+supported though!
+
+* Fix some Windows cross-drive issues. (#2781)
+
 ## 2.40.1
 
 This release fixes `pex --pylock` for locked sdist and wheel artifacts whose locked URL path

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.40.1"
+__version__ = "2.40.2"


### PR DESCRIPTION
Pexcz can use the Windows fixes in its own tests.