### PR TITLE
Add `pex3 download`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## 2.41.0
+
+This release adds support for `pex3 download [ --lock | --pylock ] [requirements args] ...`. This
+allows downloading distributions that satisfy a resolve directly or through a lock. Foreign targets
+via `--platform` and `--complete-platform` are supported as well as sub-setting when a lock is
+used.
+
+* Add `pex3 download`. (#2791)
+
 ## 2.40.3
 
 This release updates vendored Pip's vendored certifi's cacert.pem to that from certifi 2025.6.15.

--- a/pex/cli/commands/__init__.py
+++ b/pex/cli/commands/__init__.py
@@ -4,6 +4,7 @@
 from pex.cli.command import BuildTimeCommand
 from pex.cli.commands.cache.command import Cache
 from pex.cli.commands.docs import Docs
+from pex.cli.commands.download import Download
 from pex.cli.commands.interpreter import Interpreter
 from pex.cli.commands.lock import Lock
 from pex.cli.commands.venv import Venv
@@ -15,4 +16,4 @@ if TYPE_CHECKING:
 
 def all_commands():
     # type: () -> Iterable[Type[BuildTimeCommand]]
-    return Cache, Docs, Interpreter, Lock, Venv
+    return Cache, Docs, Download, Interpreter, Lock, Venv

--- a/pex/cli/commands/download.py
+++ b/pex/cli/commands/download.py
@@ -136,7 +136,7 @@ class Download(BuildTimeCommand):
                 reportable_unexpected_error_msg(
                     "Pex should only allow the download subcommand against Pex lock files, PEP-751 "
                     "lock files (pylock.toml) and simple index / find-links configurations. "
-                    "Encountered an unexpected`{resolver_configuration}` resolver "
+                    "Encountered an unexpected `{resolver_configuration}` resolver "
                     "configuration.".format(
                         resolver_configuration=type(resolver_configuration).__name__
                     )

--- a/pex/cli/commands/download.py
+++ b/pex/cli/commands/download.py
@@ -1,0 +1,117 @@
+# Copyright 2025 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os.path
+
+from pex import dependency_configuration
+from pex import resolver as pip_resolver
+from pex.cli.command import BuildTimeCommand
+from pex.common import safe_copy, safe_mkdir
+from pex.exceptions import reportable_unexpected_error_msg
+from pex.resolve import lock_resolver, requirement_options, resolver_options, target_options
+from pex.resolve.configured_resolver import ConfiguredResolver
+from pex.resolve.resolver_configuration import LockRepositoryConfiguration, PipConfiguration
+from pex.result import Error, Ok, Result, try_
+
+
+class Download(BuildTimeCommand):
+    """Download distributions instead of resolving them into a PEX."""
+
+    @classmethod
+    def add_extra_arguments(cls, parser):
+        parser.add_argument(
+            "-d",
+            "--dest-dir",
+            metavar="PATH",
+            help="The path to download distribution to.",
+        )
+        requirement_options.register(parser)
+        resolver_options.register(parser, include_pex_lock=True)
+        target_options.register(parser, include_platforms=True)
+        dependency_configuration.register(parser)
+
+    def run(self):
+        # type: () -> Result
+
+        requirement_configuration = requirement_options.configure(self.options)
+        dep_configuration = dependency_configuration.configure(self.options)
+        resolver_configuration = resolver_options.configure(self.options)
+        pip_configuration = (
+            resolver_configuration
+            if isinstance(resolver_configuration, PipConfiguration)
+            else resolver_configuration.pip_configuration
+        )
+        resolver = ConfiguredResolver(pip_configuration=pip_configuration)
+        targets = target_options.configure(
+            self.options, pip_configuration=pip_configuration
+        ).resolve_targets()
+
+        if isinstance(resolver_configuration, LockRepositoryConfiguration):
+            lock = try_(resolver_configuration.parse_lock())
+            artifact_paths = try_(
+                lock_resolver.download_from_pex_lock(
+                    targets,
+                    lock,
+                    resolver,
+                    requirements=requirement_configuration.requirements,
+                    requirement_files=requirement_configuration.requirement_files,
+                    constraint_files=requirement_configuration.constraint_files,
+                    indexes=resolver_configuration.repos_configuration.indexes,
+                    find_links=resolver_configuration.repos_configuration.find_links,
+                    resolver_version=pip_configuration.resolver_version,
+                    network_configuration=resolver_configuration.network_configuration,
+                    password_entries=pip_configuration.repos_configuration.password_entries,
+                    build_configuration=pip_configuration.build_configuration,
+                    transitive=pip_configuration.transitive,
+                    max_parallel_jobs=pip_configuration.max_jobs,
+                    pip_version=pip_configuration.version,
+                    use_pip_config=pip_configuration.use_pip_config,
+                    extra_pip_requirements=pip_configuration.extra_requirements,
+                    keyring_provider=pip_configuration.keyring_provider,
+                    dependency_configuration=dep_configuration,
+                )
+            )
+        elif isinstance(resolver_configuration, PipConfiguration):
+            artifact_paths = tuple(
+                local_distribution.path
+                for local_distribution in try_(
+                    pip_resolver.download(
+                        targets=targets,
+                        requirements=requirement_configuration.requirements,
+                        requirement_files=requirement_configuration.requirement_files,
+                        constraint_files=requirement_configuration.constraint_files,
+                        allow_prereleases=pip_configuration.allow_prereleases,
+                        transitive=pip_configuration.transitive,
+                        indexes=resolver_configuration.repos_configuration.indexes,
+                        find_links=resolver_configuration.repos_configuration.find_links,
+                        resolver_version=pip_configuration.resolver_version,
+                        network_configuration=resolver_configuration.network_configuration,
+                        password_entries=pip_configuration.repos_configuration.password_entries,
+                        build_configuration=pip_configuration.build_configuration,
+                        max_parallel_jobs=pip_configuration.max_jobs,
+                        pip_log=pip_configuration.log,
+                        pip_version=pip_configuration.version,
+                        resolver=resolver,
+                        use_pip_config=pip_configuration.use_pip_config,
+                        extra_pip_requirements=pip_configuration.extra_requirements,
+                        keyring_provider=pip_configuration.keyring_provider,
+                        dependency_configuration=dep_configuration,
+                    )
+                ).local_distributions
+            )
+        else:
+            return Error(
+                reportable_unexpected_error_msg(
+                    "Pex should only allow the download subcommand against Pex lock files and "
+                    "simple index / find-links configurations. Encountered an unexpected "
+                    "`{resolver_configuration}` resolver configuration.".format(
+                        resolver_configuration=type(resolver_configuration).__name__
+                    )
+                )
+            )
+
+        safe_mkdir(self.options.dest_dir)
+        for path in artifact_paths:
+            safe_copy(path, os.path.join(self.options.dest_dir, os.path.basename(path)))
+
+        return Ok()

--- a/pex/cli/commands/download.py
+++ b/pex/cli/commands/download.py
@@ -134,9 +134,10 @@ class Download(BuildTimeCommand):
         else:
             return Error(
                 reportable_unexpected_error_msg(
-                    "Pex should only allow the download subcommand against Pex lock files and "
-                    "simple index / find-links configurations. Encountered an unexpected "
-                    "`{resolver_configuration}` resolver configuration.".format(
+                    "Pex should only allow the download subcommand against Pex lock files, PEP-751 "
+                    "lock files (pylock.toml) and simple index / find-links configurations. "
+                    "Encountered an unexpected`{resolver_configuration}` resolver "
+                    "configuration.".format(
                         resolver_configuration=type(resolver_configuration).__name__
                     )
                 )

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.40.3"
+__version__ = "2.41.0"

--- a/tests/integration/cli/commands/test_download.py
+++ b/tests/integration/cli/commands/test_download.py
@@ -74,7 +74,9 @@ def test_download_via_pip(
     # type: (...) -> None
 
     dest_dir = tmpdir.join("dest")
-    run_pex3("download", "-r", requirements_txt, "-d", dest_dir).assert_success()
+    run_pex3(
+        "download", "--pip-version", "latest-compatible", "-r", requirements_txt, "-d", dest_dir
+    ).assert_success()
     assert_downloaded_requirements(dest_dir)
 
 
@@ -88,11 +90,15 @@ def test_download_via_pex_lock(
     run_pex3("lock", "create", "-r", requirements_txt, "--indent", "2", "-o", lock).assert_success()
 
     dest_dir = tmpdir.join("dest")
-    run_pex3("download", "--lock", lock, "-d", dest_dir).assert_success()
+    run_pex3(
+        "download", "--pip-version", "latest-compatible", "--lock", lock, "-d", dest_dir
+    ).assert_success()
     assert_downloaded_requirements(dest_dir)
 
     shutil.rmtree(dest_dir)
-    run_pex3("download", "cowsay", "--lock", lock, "-d", dest_dir).assert_success()
+    run_pex3(
+        "download", "cowsay", "--pip-version", "latest-compatible", "--lock", lock, "-d", dest_dir
+    ).assert_success()
     assert ["cowsay-5.0.tar.gz"] == os.listdir(dest_dir)
 
 
@@ -146,5 +152,7 @@ def test_download_via_pylock(
     )
 
     dest_dir = tmpdir.join("dest")
-    run_pex3("download", "--pylock", pylock_toml, "-d", dest_dir).assert_success()
+    run_pex3(
+        "download", "--pip-version", "latest-compatible", "--pylock", pylock_toml, "-d", dest_dir
+    ).assert_success()
     assert_downloaded_requirements(dest_dir)

--- a/tests/integration/cli/commands/test_download.py
+++ b/tests/integration/cli/commands/test_download.py
@@ -1,0 +1,94 @@
+# Copyright 2025 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os
+import shutil
+import sys
+from textwrap import dedent
+
+import pytest
+
+from pex.interpreter import PythonInterpreter
+from pex.os import LINUX, MAC, WINDOWS
+from testing.cli import run_pex3
+from testing.pytest_utils.tmp import Tempdir
+
+
+@pytest.fixture
+def requirements_txt(tmpdir):
+    # type: (Tempdir) -> str
+    with open(tmpdir.join("requirements.txt"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                cowsay<6
+                psutil<7
+                """
+            )
+        )
+    return fp.name
+
+
+def assert_downloaded_requirements(dest_dir):
+    # type: (str) -> None
+
+    # N.B.: This is currently tuned to cases in our CI setup and may need to change as we change
+    # that.
+    interpreter = PythonInterpreter.get()
+    platform = interpreter.platform
+    if interpreter.is_pypy:
+        expected_psutil = "psutil-6.1.1.tar.gz"
+    elif LINUX and sys.version_info[0] == 2:
+        expected_psutil = "psutil-6.1.1-cp27-{abi}-manylinux2010_x86_64.whl".format(
+            abi=platform.abi
+        )
+    elif LINUX and sys.version_info[:2] == (3, 5):
+        expected_psutil = "psutil-6.1.1.tar.gz"
+    elif LINUX and sys.version_info[:2] >= (3, 6):
+        expected_psutil = (
+            "psutil-6.1.1-cp36-abi3-"
+            "manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64"
+            ".whl"
+        )
+    elif MAC:
+        if "arm64" in platform.platform:
+            expected_psutil = "psutil-6.1.1-cp36-abi3-macosx_11_0_arm64.whl"
+        else:
+            expected_psutil = "psutil-6.1.1-cp36-abi3-macosx_10_9_x86_64.whl"
+    elif WINDOWS:
+        expected_psutil = "psutil-6.1.1-cp37-abi3-win_amd64.whl"
+    else:
+        assert False, "The current OS / arch / interpreter is not supported by this test."
+
+    assert sorted(("cowsay-5.0.tar.gz", expected_psutil)) == sorted(os.listdir(dest_dir))
+
+
+def test_download_via_pip(
+    tmpdir,  # type: Tempdir
+    requirements_txt,  # type: str
+):
+    # type: (...) -> None
+
+    dest_dir = tmpdir.join("dest")
+    run_pex3("download", "-r", requirements_txt, "-d", dest_dir).assert_success()
+    assert_downloaded_requirements(dest_dir)
+
+
+def test_download_via_lock(
+    tmpdir,  # type: Tempdir
+    requirements_txt,  # type: str
+):
+    # type: (...) -> None
+
+    lock = tmpdir.join("lock.json")
+    run_pex3("lock", "create", "-r", requirements_txt, "--indent", "2", "-o", lock).assert_success()
+
+    dest_dir = tmpdir.join("dest")
+    run_pex3("download", "--lock", lock, "-d", dest_dir).assert_success()
+    assert_downloaded_requirements(dest_dir)
+
+    shutil.rmtree(dest_dir)
+    run_pex3("download", "cowsay", "--lock", lock, "-d", dest_dir).assert_success()
+    assert ["cowsay-5.0.tar.gz"] == os.listdir(dest_dir)


### PR DESCRIPTION
Allow downloading distributions directly instead of building a PEX or
creating a venv from a resolve.

Closes #2790