### PR TITLE
Fix more `commonpath` uses; use `safe_commonpath`.

### DIFF
--- a/pex/cli_util.py
+++ b/pex/cli_util.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 import os
 import sys
 
-from pex.compatibility import commonpath
+from pex.compatibility import safe_commonpath
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -19,7 +19,7 @@ def prog_path(prog=None):
 
     exe_path = os.path.abspath(prog or sys.argv[0])
     cwd = os.path.abspath(os.getcwd())
-    if commonpath((exe_path, cwd)) == cwd:
+    if safe_commonpath((exe_path, cwd)) == cwd:
         exe_path = os.path.relpath(exe_path, cwd)
         # Handle users that do not have . as a PATH entry.
         if not os.path.dirname(exe_path) and os.curdir not in os.environ.get("PATH", "").split(

--- a/tests/integration/resolve/test_issue_2772.py
+++ b/tests/integration/resolve/test_issue_2772.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 
 import pytest
 
-from pex.compatibility import commonpath
+from pex.compatibility import safe_commonpath
 from testing import run_pex_command
 from testing.pytest_utils.tmp import Tempdir
 
@@ -68,4 +68,4 @@ def test_uv_lock_export_name_normalization(tmpdir):
         .decode("utf-8")
         .strip()
     )
-    assert pex_root == commonpath((pex_root, pyyaml_package_path))
+    assert pex_root == safe_commonpath((pex_root, pyyaml_package_path))

--- a/tests/integration/scie/test_issue_2740.py
+++ b/tests/integration/scie/test_issue_2740.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 
 import pytest
 
-from pex.compatibility import commonpath
+from pex.compatibility import safe_commonpath
 from pex.typing import TYPE_CHECKING
 from testing import run_pex_command
 from testing.pytest_utils.tmp import Tempdir
@@ -98,6 +98,6 @@ def test_use_pex_scie_as_interpreter(
             ]
         )
     )
-    assert pex_root == commonpath((pex_root, data.pop("pip")))
-    assert pex_root == commonpath((pex_root, data.pop("setproctitle")))
+    assert pex_root == safe_commonpath((pex_root, data.pop("pip")))
+    assert pex_root == safe_commonpath((pex_root, data.pop("setproctitle")))
     assert not data

--- a/tests/integration/test_issue_2706.py
+++ b/tests/integration/test_issue_2706.py
@@ -8,7 +8,7 @@ import subprocess
 
 from pex.cache.dirs import CacheDir
 from pex.common import safe_mkdir
-from pex.compatibility import commonpath
+from pex.compatibility import safe_commonpath
 from pex.pip.version import PipVersion
 from pex.venv.virtualenv import InstallationChoice, Virtualenv
 from testing import built_wheel, run_pex_command
@@ -58,7 +58,7 @@ def test_extras_from_dup_root_reqs(tmpdir):
 
         installed_wheel_dir = CacheDir.INSTALLED_WHEELS.path(pex_root=pex_root)
         for module in "foo", "bar", "baz":
-            assert installed_wheel_dir == commonpath(
+            assert installed_wheel_dir == safe_commonpath(
                 (
                     installed_wheel_dir,
                     subprocess.check_output(


### PR DESCRIPTION
This fixes production use of a PEX repl as well as all PEX_TOOLS.