### PR TITLE
Do not clean fallback `PEX_ROOT` prematurely.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## 2.45.3
+
+This release fixes a bug introduced in 2.45.2 by #2820 that would cause a temporary `PEX_ROOT` (
+these are created when the default `PEX_ROOT` directory is not writeable) to be cleaned up too
+early, leading to PEX boot failures.
+
+* Do not clean fallback `PEX_ROOT` prematurely. (#2823)
+
 ## 2.45.2
 
 This release fixes a long-standing temporary directory resource leak when running PEXes built with

--- a/pex/common.py
+++ b/pex/common.py
@@ -466,27 +466,6 @@ def safe_sleep(seconds):
             current_time = time.time()
 
 
-def can_write_dir(path):
-    # type: (str) -> bool
-    """Determines if the directory at path can be written to by the current process.
-
-    If the directory doesn't exist, determines if it can be created and thus written to.
-
-    N.B.: This is a best-effort check only that uses permission heuristics and does not actually test
-    that the directory can be written to with and writes.
-
-    :param path: The directory path to test.
-    :return:`True` if the given path is a directory that can be written to by the current process.
-    """
-    while not os.access(path, os.F_OK):
-        parent_path = os.path.dirname(path)
-        if not parent_path or (parent_path == path):
-            # We've recursed up to the root without success, which shouldn't happen,
-            return False
-        path = parent_path
-    return os.path.isdir(path) and os.access(path, os.R_OK | os.W_OK | os.X_OK)
-
-
 def touch(
     file,  # type: _Text
     times=None,  # type: Optional[Union[int, float, Tuple[int, int], Tuple[float, float]]]

--- a/pex/os.py
+++ b/pex/os.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 import os
 import sys
 
+from pex import pex_root
 from pex.enum import Enum
 from pex.typing import TYPE_CHECKING
 
@@ -65,7 +66,8 @@ if WINDOWS:
         from pex import atexit
 
         atexit.perform_exit()
-        sys.exit(subprocess.call(args=argv))
+        with pex_root.preserve_fallback():
+            sys.exit(subprocess.call(args=argv))
 
 else:
 
@@ -75,7 +77,8 @@ else:
         from pex import atexit
 
         atexit.perform_exit()
-        os.execv(argv[0], argv)
+        with pex_root.preserve_fallback() as env:
+            os.execve(argv[0], argv, env)
 
 
 if WINDOWS:

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -509,9 +509,9 @@ class PexInfo(object):
     @property
     def pex_root(self):
         # type: () -> str
-        writeable_pex_root = self._pex_info["pex_root"] = pex_root.ensure_writeable(
-            self.raw_pex_root
-        )
+        writeable_pex_root, is_fallback = pex_root.ensure_writeable(self.raw_pex_root)
+        if is_fallback:
+            self._pex_info["pex_root"] = writeable_pex_root
         return writeable_pex_root
 
     @pex_root.setter

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -7,9 +7,9 @@ import json
 import os
 import zipfile
 
-from pex import layout, pex_warnings, variables
+from pex import layout, pex_root, pex_warnings, variables
 from pex.cache import root as cache_root
-from pex.common import can_write_dir, open_zip, safe_mkdtemp
+from pex.common import open_zip
 from pex.compatibility import PY2
 from pex.compatibility import string as compatibility_string
 from pex.inherit_path import InheritPath
@@ -509,16 +509,10 @@ class PexInfo(object):
     @property
     def pex_root(self):
         # type: () -> str
-        pex_root = os.path.realpath(os.path.expanduser(self.raw_pex_root))
-        if not can_write_dir(pex_root):
-            tmp_root = os.path.realpath(safe_mkdtemp())
-            pex_warnings.warn(
-                "PEX_ROOT is configured as {pex_root} but that path is un-writeable, "
-                "falling back to a temporary PEX_ROOT of {tmp_root} which will hurt "
-                "performance.".format(pex_root=pex_root, tmp_root=tmp_root)
-            )
-            pex_root = self._pex_info["pex_root"] = tmp_root
-        return pex_root
+        writeable_pex_root = self._pex_info["pex_root"] = pex_root.ensure_writeable(
+            self.raw_pex_root
+        )
+        return writeable_pex_root
 
     @pex_root.setter
     def pex_root(self, value):

--- a/pex/pex_root.py
+++ b/pex/pex_root.py
@@ -1,0 +1,77 @@
+# Copyright 2025 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import atexit
+import os
+import shutil
+import tempfile
+from contextlib import contextmanager
+
+from pex import pex_warnings
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Dict, Iterator, Optional
+
+
+_FALLBACK = None  # type: Optional[str]
+
+
+def _cleanup_fallback():
+    # type: () -> None
+
+    global _FALLBACK
+    if _FALLBACK and os.path.exists(_FALLBACK):
+        shutil.rmtree(_FALLBACK, True)
+
+
+def can_write_dir(path):
+    # type: (str) -> bool
+    while not os.access(path, os.F_OK):
+        parent_path = os.path.dirname(path)
+        if not parent_path or (parent_path == path):
+            # We've recursed up to the root without success, which shouldn't happen,
+            return False
+        path = parent_path
+    return os.path.isdir(path) and os.access(path, os.R_OK | os.W_OK | os.X_OK)
+
+
+def ensure_writeable(raw_pex_root):
+    # type: (str) -> str
+
+    pex_root = os.path.realpath(os.path.expanduser(raw_pex_root))
+    if not can_write_dir(pex_root):
+        fallback = os.environ.pop("_PEX_ROOT_FALLBACK", None)
+        if not fallback:
+            fallback = os.path.realpath(
+                tempfile.mkdtemp(prefix="pex-root.", suffix=".readonly-fallback")
+            )
+        pex_warnings.warn(
+            "PEX_ROOT is configured as {pex_root} but that path is un-writeable, "
+            "falling back to a temporary PEX_ROOT of {fallback} which will hurt "
+            "performance.".format(pex_root=pex_root, fallback=fallback)
+        )
+        global _FALLBACK
+        pex_root = _FALLBACK = fallback
+        atexit.register(_cleanup_fallback)
+    return pex_root
+
+
+@contextmanager
+def preserve_fallback():
+    # type: () -> Iterator[Dict[str, str]]
+
+    global _FALLBACK
+    fallback = _FALLBACK
+    _FALLBACK = None
+
+    env = os.environ.copy()
+    if fallback:
+        env["_PEX_ROOT_FALLBACK"] = fallback
+    try:
+        yield env
+    finally:
+        if fallback:
+            _FALLBACK = fallback

--- a/pex/pex_root.py
+++ b/pex/pex_root.py
@@ -13,8 +13,7 @@ from pex import pex_warnings
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Dict, Iterator, Optional
-
+    from typing import Dict, Iterator, Optional, Tuple
 
 _FALLBACK = None  # type: Optional[str]
 
@@ -39,9 +38,10 @@ def can_write_dir(path):
 
 
 def ensure_writeable(raw_pex_root):
-    # type: (str) -> str
+    # type: (str) -> Tuple[str, bool]
 
     pex_root = os.path.realpath(os.path.expanduser(raw_pex_root))
+    is_fallback = False
     if not can_write_dir(pex_root):
         fallback = os.environ.pop("_PEX_ROOT_FALLBACK", None)
         if not fallback:
@@ -55,8 +55,9 @@ def ensure_writeable(raw_pex_root):
         )
         global _FALLBACK
         pex_root = _FALLBACK = fallback
+        is_fallback = True
         atexit.register(_cleanup_fallback)
-    return pex_root
+    return pex_root, is_fallback
 
 
 @contextmanager

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -660,7 +660,9 @@ class Variables(object):
 
     @PEX_ROOT.validator
     def _ensure_writeable_pex_root(self, raw_pex_root):
-        writeable_pex_root = self._environ["PEX_ROOT"] = pex_root.ensure_writeable(raw_pex_root)
+        writeable_pex_root, is_fallback = pex_root.ensure_writeable(raw_pex_root)
+        if is_fallback:
+            self._environ["PEX_ROOT"] = writeable_pex_root
         return writeable_pex_root
 
     @property

--- a/pex/variables.py
+++ b/pex/variables.py
@@ -14,8 +14,8 @@ import sys
 from contextlib import contextmanager
 from textwrap import dedent
 
-from pex import pex_warnings
-from pex.common import can_write_dir, die, safe_mkdtemp
+from pex import pex_root, pex_warnings
+from pex.common import die
 from pex.inherit_path import InheritPath
 from pex.orderedset import OrderedSet
 from pex.typing import TYPE_CHECKING, Generic, overload
@@ -660,16 +660,8 @@ class Variables(object):
 
     @PEX_ROOT.validator
     def _ensure_writeable_pex_root(self, raw_pex_root):
-        pex_root = os.path.realpath(os.path.expanduser(raw_pex_root))
-        if not can_write_dir(pex_root):
-            tmp_root = os.path.realpath(safe_mkdtemp())
-            pex_warnings.warn(
-                "PEX_ROOT is configured as {pex_root} but that path is un-writeable, "
-                "falling back to a temporary PEX_ROOT of {tmp_root} which will hurt "
-                "performance.".format(pex_root=pex_root, tmp_root=tmp_root)
-            )
-            pex_root = self._environ["PEX_ROOT"] = tmp_root
-        return pex_root
+        writeable_pex_root = self._environ["PEX_ROOT"] = pex_root.ensure_writeable(raw_pex_root)
+        return writeable_pex_root
 
     @property
     def PEX_PATH(self):

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.45.2"
+__version__ = "2.45.3"

--- a/tests/integration/test_issue_2819.py
+++ b/tests/integration/test_issue_2819.py
@@ -5,38 +5,9 @@ from __future__ import absolute_import
 
 import os
 import subprocess
-import sys
 
-import pytest
-from _pytest.monkeypatch import MonkeyPatch
-
-from pex.common import safe_mkdir, safe_rmtree
-from pex.compatibility import commonpath
 from testing import run_pex_command
 from testing.pytest_utils.tmp import Tempdir
-
-
-@pytest.fixture
-def fake_system_tmp_dir(
-    tmpdir,  # type: Tempdir
-    monkeypatch,  # type: MonkeyPatch
-):
-    # type: (...) -> str
-
-    fake_system_tmp_dir = safe_mkdir(tmpdir.join("tmp"))
-    monkeypatch.setenv("TMPDIR", fake_system_tmp_dir)
-
-    tmpdir_path = (
-        subprocess.check_output(
-            args=[sys.executable, "-c", "import tempfile; print(tempfile.mkdtemp())"]
-        )
-        .decode("utf-8")
-        .strip()
-    )
-    safe_rmtree(tmpdir_path)
-    assert fake_system_tmp_dir == commonpath((fake_system_tmp_dir, tmpdir_path))
-
-    return fake_system_tmp_dir
 
 
 def test_tmp_dir_leak(

--- a/tests/integration/test_issue_2822.py
+++ b/tests/integration/test_issue_2822.py
@@ -1,0 +1,63 @@
+# Copyright 2025 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os
+import subprocess
+from os import mkdir
+
+import pytest
+
+from pex.compatibility import commonpath
+from pex.typing import TYPE_CHECKING
+from testing import run_pex_command
+from testing.pytest_utils.tmp import Tempdir
+
+if TYPE_CHECKING:
+    from typing import Iterator, List
+
+
+@pytest.fixture
+def read_only_pex_root(tmpdir):
+    # type: (Tempdir) -> Iterator[str]
+
+    pex_root = tmpdir.join("pex-root")
+    mkdir(pex_root)
+    os.chmod(pex_root, 0o555)
+    try:
+        yield pex_root
+    finally:
+        os.chmod(pex_root, 755)
+
+
+@pytest.mark.parametrize(
+    "execution_mode_args",
+    [
+        pytest.param([], id="ZIPAPP"),
+        pytest.param(["--sh-boot"], id="SH_BOOT"),
+        pytest.param(["--venv"], id="VENV"),
+        pytest.param(["--venv", "--sh-boot"], id="VENV-SH_BOOT"),
+    ],
+)
+def test_tmp_pex_root(
+    tmpdir,  # type: Tempdir
+    read_only_pex_root,  # type: str
+    fake_system_tmp_dir,  # type: str
+    execution_mode_args,  # type: List[str]
+):
+    # type: (...) -> None
+
+    pex = tmpdir.join("pex")
+    run_pex_command(
+        args=["ansicolors==1.1.8", "-o", pex, "--runtime-pex-root", read_only_pex_root]
+        + execution_mode_args
+    ).assert_success()
+
+    colors_module = (
+        subprocess.check_output(args=[pex, "-c", "import colors; print(colors.__file__)"])
+        .decode("utf-8")
+        .strip()
+    )
+    assert fake_system_tmp_dir == commonpath((fake_system_tmp_dir, colors_module))
+    assert "--venv" in execution_mode_args or not os.path.exists(colors_module)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -10,7 +10,6 @@ import pytest
 from pex.common import (
     Chroot,
     ZipFileEx,
-    can_write_dir,
     deterministic_walk,
     open_zip,
     safe_open,
@@ -247,32 +246,6 @@ def test_deterministic_walk():
             (dir_b, [], ["file_b"]),
         ], "Modifying dirs should not affect the order of the walk"
         assert result_a == result_b, "Should be resilient to os.walk yielding in arbitrary order"
-
-
-def test_can_write_dir_writeable_perms():
-    # type: () -> None
-    with temporary_dir() as writeable:
-        assert can_write_dir(writeable)
-
-        path = os.path.join(writeable, "does/not/exist/yet")
-        assert can_write_dir(path)
-        touch(path)
-        assert not can_write_dir(path), "Should not be able to write to a file."
-
-
-def test_can_write_dir_unwriteable_perms():
-    # type: () -> None
-    with temporary_dir() as writeable:
-        no_perms_path = os.path.join(writeable, "no_perms")
-        os.mkdir(no_perms_path, 0o444)
-        assert not can_write_dir(no_perms_path)
-
-        path_that_does_not_exist_yet = os.path.join(no_perms_path, "does/not/exist/yet")
-        assert not can_write_dir(path_that_does_not_exist_yet)
-
-        os.chmod(no_perms_path, 0o744)
-        assert can_write_dir(no_perms_path)
-        assert can_write_dir(path_that_does_not_exist_yet)
 
 
 @pytest.fixture

--- a/tests/test_pex_root.py
+++ b/tests/test_pex_root.py
@@ -1,0 +1,36 @@
+# Copyright 2025 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os
+
+from pex.common import touch
+from pex.pex_root import can_write_dir
+from testing.pytest_utils.tmp import Tempdir
+
+
+def test_can_write_dir_writeable_perms(tmpdir):
+    # type: (Tempdir) -> None
+
+    assert can_write_dir(tmpdir.path)
+
+    path = tmpdir.join("does", "not", "exist", "yet")
+    assert can_write_dir(path)
+    touch(path)
+    assert not can_write_dir(path), "Should not be able to write to a file."
+
+
+def test_can_write_dir_unwriteable_perms(tmpdir):
+    # type: (Tempdir) -> None
+
+    no_perms_path = tmpdir.join("no_perms")
+    os.mkdir(no_perms_path, 0o444)
+    assert not can_write_dir(no_perms_path)
+
+    path_that_does_not_exist_yet = os.path.join(no_perms_path, "does", "not", "exist", "yet")
+    assert not can_write_dir(path_that_does_not_exist_yet)
+
+    os.chmod(no_perms_path, 0o744)
+    assert can_write_dir(no_perms_path)
+    assert can_write_dir(path_that_does_not_exist_yet)


### PR DESCRIPTION
Fixes #2822