### PR TITLE
Flexible marker matching for `pyproject.toml`

### DIFF
--- a/pex/resolve/lockfile/pep_751.py
+++ b/pex/resolve/lockfile/pep_751.py
@@ -805,6 +805,16 @@ def spec_matches(
 
     if isinstance(spec, dict) and isinstance(package_data, dict):
         for key, value in spec.items():
+            if key == "marker":
+                spec_marker = spec.get("marker")
+                package_data_marker = package_data.get("marker")
+                if (
+                    spec_marker == package_data_marker
+                    or spec_marker is None
+                    or package_data_marker is None
+                ):
+                    return True
+                return Marker(f"({spec_marker}) and ({package_data_marker})").evaluate()
             if not spec_matches(value, package_data.get(key)):
                 return False
         return True

--- a/pex/resolve/lockfile/pep_751.py
+++ b/pex/resolve/lockfile/pep_751.py
@@ -814,7 +814,7 @@ def spec_matches(
                     or package_data_marker is None
                 ):
                     return True
-                return Marker(f"({spec_marker}) and ({package_data_marker})").evaluate()
+                return cast(bool, Marker(f"({spec_marker}) and ({package_data_marker})").evaluate())
             if not spec_matches(value, package_data.get(key)):
                 return False
         return True

--- a/pex/resolve/lockfile/pep_751.py
+++ b/pex/resolve/lockfile/pep_751.py
@@ -814,7 +814,10 @@ def spec_matches(
                     or package_data_marker is None
                 ):
                     return True
-                return cast(bool, Marker(f"({spec_marker}) and ({package_data_marker})").evaluate())
+                return cast(
+                    bool,
+                    Marker("({}) and ({})".format(spec_marker, package_data_marker)).evaluate(),
+                )
             if not spec_matches(value, package_data.get(key)):
                 return False
         return True

--- a/tests/resolve/lockfile/test_pep_751.py
+++ b/tests/resolve/lockfile/test_pep_751.py
@@ -836,3 +836,39 @@ def test_pylock_parse_cyclic_dependencies():
     # The cyclic dependencies should be preserved
     assert tuple([package_b.as_dependency()]) == package_a.dependencies
     assert tuple([package_a.as_dependency()]) == package_b.dependencies
+
+
+def test_spec_matches_marker():
+    # type: () -> None
+    from pex.resolve.lockfile.pep_751 import spec_matches
+
+    # Case 1: Both spec and package have same marker
+    assert spec_matches(
+        {"marker": "python_version >= '3.8'"}, {"marker": "python_version >= '3.8'"}
+    )
+
+    # Case 2: spec has no marker (None)
+    assert spec_matches({"marker": None}, {"marker": "python_version >= '3.8'"})
+
+    # Case 3: package has no marker (None)
+    assert spec_matches({"marker": "python_version >= '3.8'"}, {"marker": None})
+
+    # Case 4: Both have None markers
+    assert spec_matches({"marker": None}, {"marker": None})
+
+    # Case 5: spec has no marker key at all
+    assert spec_matches({}, {"marker": "python_version >= '3.8'"})
+
+    # Case 6: package has no marker key at all
+    assert spec_matches({"marker": "python_version >= '3.8'"}, {})
+
+    # Case 7: Different markers - should combine with AND and evaluate
+    # This will return True if both conditions can be satisfied
+    assert spec_matches(
+        {"marker": "python_version >= '3.8'"}, {"marker": "sys_platform == 'linux'"}
+    )
+
+    # Case 8: Conflicting markers - should return False
+    assert not spec_matches(
+        {"marker": "python_version < '3.8'"}, {"marker": "python_version >= '3.9'"}
+    )


### PR DESCRIPTION
Fixes #2885

This adds special handling for the 'marker' key in spec_matches(). Rather than just matching strings, the logic handles:

- Equal markers (direct match)
- None/missing markers (always match)
- Different markers (combine with AND and evaluate) - test if the markers are compatible.

Also adds comprehensive test coverage for all marker matching scenarios.