### PR TITLE
Support dependency replacement with `--override`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## 2.55.0
+
+This release adds support for `--override <project name>=<requirement>` wherever
+`--override <requirement>` is currently accepted. This can be useful when you need to supply a
+patch to an existing published project and would prefer to depend on wheels you pre-build instead
+of using a VCS source dependency `--override`, which can be slow to build.
+
+* Support dependency replacement with `--override`. (#2894)
+
 ## 2.54.2
 
 This release fixes `pex3 lock create` when multiple `--index` are configured and they provide the

--- a/pex/cli/commands/lock.py
+++ b/pex/cli/commands/lock.py
@@ -52,7 +52,6 @@ from pex.resolve.locked_resolve import (
     LockedResolve,
     LockStyle,
     Resolved,
-    TargetSystem,
     VCSArtifact,
 )
 from pex.resolve.lockfile import json_codec, pep_751, requires_dist
@@ -77,6 +76,7 @@ from pex.resolve.resolver_options import parse_lockfile
 from pex.resolve.resolvers import Resolver
 from pex.resolve.script_metadata import ScriptMetadataApplication, apply_script_metadata
 from pex.resolve.target_configuration import InterpreterConstraintsNotSatisfied, TargetConfiguration
+from pex.resolve.target_system import TargetSystem
 from pex.result import Error, Ok, Result, try_
 from pex.sorted_tuple import SortedTuple
 from pex.targets import LocalInterpreter, Target, Targets
@@ -1036,13 +1036,12 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
             requirement_configuration = script_metadata_application.requirement_configuration
             target_configuration = script_metadata_application.target_configuration
         if self.options.style == LockStyle.UNIVERSAL:
-            lock_configuration = LockConfiguration(
-                style=LockStyle.UNIVERSAL,
-                requires_python=tuple(
+            lock_configuration = LockConfiguration.universal(
+                requires_python=[
                     str(interpreter_constraint.requires_python)
                     for interpreter_constraint in target_configuration.interpreter_constraints
-                ),
-                target_systems=tuple(self.options.target_systems),
+                ],
+                systems=self.options.target_systems,
                 elide_unused_requires_dist=self.options.elide_unused_requires_dist,
             )
         elif self.options.target_systems:
@@ -2261,6 +2260,7 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
                 extra_pip_requirements=pip_configuration.extra_requirements,
                 keyring_provider=pip_configuration.keyring_provider,
                 result_type=InstallableType.INSTALLED_WHEEL_CHROOT,
+                dependency_configuration=dependency_config,
             )
         )
         return sync_target.sync(

--- a/pex/dependency_configuration.py
+++ b/pex/dependency_configuration.py
@@ -4,10 +4,11 @@
 from __future__ import absolute_import
 
 import itertools
+import re
 from argparse import Namespace, _ActionsContainer
 from collections import defaultdict
 
-from pex.dist_metadata import Distribution, Requirement
+from pex.dist_metadata import Distribution, Requirement, RequirementParseError
 from pex.orderedset import OrderedSet
 from pex.pep_503 import ProjectName
 from pex.pex_info import PexInfo
@@ -23,12 +24,68 @@ else:
 
 
 @attr.s(frozen=True)
+class Override(object):
+    class InvalidError(ValueError):
+        pass
+
+    @classmethod
+    def parse(cls, override):
+        # type: (str) -> Override
+
+        project_name = None  # type: Optional[ProjectName]
+        raw_requirement = override
+
+        # See: https://peps.python.org/pep-0508/#names
+        project_name_re = r"[A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9]"
+        match = re.match(
+            r"^(?P<project>{project_name_re})\s*=\s*(?P<requirement>{project_name_re}.*)$".format(
+                project_name_re=project_name_re
+            ),
+            override,
+            re.IGNORECASE,
+        )
+        if match:
+            raw_project_name = match.group("project")
+            raw_requirement = match.group("requirement")
+            try:
+                project_name = ProjectName(raw_project_name)
+            except ProjectName.InvalidError as e:
+                raise cls.InvalidError(
+                    "Invalid project name {raw_project_name!r} in override {override!r}: "
+                    "{err}".format(raw_project_name=raw_project_name, override=override, err=e)
+                )
+        try:
+            requirement = Requirement.parse(raw_requirement)
+        except RequirementParseError as e:
+            raise cls.InvalidError(
+                "Invalid override requirement {raw_requirement!r}: {err}".format(
+                    raw_requirement=raw_requirement, err=e
+                )
+            )
+
+        return cls(project_name=project_name or requirement.project_name, requirement=requirement)
+
+    project_name = attr.ib()  # type: ProjectName
+    requirement = attr.ib()  # type: Requirement
+
+    def __str__(self):
+        # type: () -> str
+
+        if self.requirement.project_name == self.project_name:
+            return str(self.requirement)
+
+        return "{project_name}={requirement}".format(
+            project_name=self.project_name, requirement=self.requirement
+        )
+
+
+@attr.s(frozen=True)
 class DependencyConfiguration(object):
     @classmethod
     def create(
         cls,
         excluded=(),  # type: Iterable[Union[str, Requirement]]
-        overridden=(),  # type: Iterable[Union[str, Requirement]]
+        overridden=(),  # type: Iterable[Union[str, Override]]
     ):
         # type: (...) -> DependencyConfiguration
 
@@ -36,8 +93,8 @@ class DependencyConfiguration(object):
             OrderedSet
         )  # type: DefaultDict[ProjectName, OrderedSet[Requirement]]
         for o in overridden:
-            override = o if isinstance(o, Requirement) else Requirement.parse(o)
-            overridden_projects[override.project_name].add(override)
+            override = o if isinstance(o, Override) else Override.parse(o)
+            overridden_projects[override.project_name].add(override.requirement)
 
         return cls(
             excluded=tuple(
@@ -64,18 +121,21 @@ class DependencyConfiguration(object):
         # type: (PexInfo) -> None
         for excluded in self.excluded:
             pex_info.add_exclude(excluded)
-        for override in sorted(
-            itertools.chain.from_iterable(self.overridden.values()), key=lambda req: req.key
-        ):
-            pex_info.add_override(override)
+        for project_name, overrides in self.overridden.items():
+            for override in sorted(overrides, key=lambda req: req.key):
+                pex_info.add_override(Override(project_name=project_name, requirement=override))
 
     def excluded_by(self, item):
         # type: (Union[Distribution, Requirement]) -> Tuple[Requirement, ...]
         return tuple(req for req in self.excluded if item in req)
 
     def all_overrides(self):
-        # type: () -> Tuple[Requirement, ...]
-        return tuple(itertools.chain.from_iterable(self.overridden.values()))
+        # type: () -> Tuple[Override, ...]
+        return tuple(
+            Override(project_name=project_name, requirement=requirement)
+            for project_name, requirements in self.overridden.items()
+            for requirement in requirements
+        )
 
     def overrides_for(self, requirement):
         # type: (Requirement) -> Tuple[Requirement, ...]
@@ -152,9 +212,17 @@ def register(parser):
         type=str,
         action="append",
         help=(
-            "Specifies a transitive requirement to override when resolving. Any distribution "
-            "requirement in the PEX's resolve that matches the override project name is replaced "
-            "with the given override requirement. This option can be used multiple times."
+            "Specifies a transitive requirement to override when resolving. Overrides can either "
+            "modify an existing dependency on a project name by changing extras, version "
+            "constraints or markers or else they can completely swap out the dependency for a "
+            "dependency on another project altogether. For the former, simply supply the "
+            "requirement you wish. For example, specifying `--override cowsay==5.0` will override "
+            "any transitive dependency on cowsay that has any combination of extras, version "
+            "constraints or markers with the requirement `cowsay==5.0`. To completely replace "
+            "cowsay with another library altogether, you can specify an override like "
+            "`--override cowsay=my-cowsay>2`. This will replace any transitive dependency on "
+            "cowsay that has any combination of extras, version constraints or markers with the "
+            "requirement `my-cowsay>2`. This option can be used multiple times."
         ),
     )
 

--- a/pex/pex_info.py
+++ b/pex/pex_info.py
@@ -25,11 +25,11 @@ if TYPE_CHECKING:
     from typing import Collection  # type: ignore[attr-defined]
     from typing import Any, Dict, Iterable, Mapping, Optional, Text, Tuple, Union
 
-    from pex.cache.dirs import VenvDir
-    from pex.dist_metadata import Requirement
-
     # N.B.: These are expensive imports and PexInfo is used during PEX bootstrapping which we want
     # to be as fast as possible.
+    from pex.cache.dirs import VenvDir
+    from pex.dependency_configuration import Override
+    from pex.dist_metadata import Requirement
     from pex.interpreter import PythonInterpreter
     from pex.interpreter_constraints import InterpreterConstraints
 
@@ -491,9 +491,9 @@ class PexInfo(object):
         # type: () -> Iterable[str]
         return self._excluded
 
-    def add_override(self, requirement):
-        # type: (Requirement) -> None
-        self._overridden.add(str(requirement))
+    def add_override(self, override):
+        # type: (Override) -> None
+        self._overridden.add(str(override))
 
     @property
     def overridden(self):

--- a/pex/pip/dependencies/__init__.py
+++ b/pex/pip/dependencies/__init__.py
@@ -8,30 +8,75 @@ import os
 
 from pex.common import safe_mkdtemp
 from pex.dependency_configuration import DependencyConfiguration
+from pex.exceptions import reportable_unexpected_error_msg
+from pex.pep_508 import MarkerEnvironment
 from pex.pip.download_observer import DownloadObserver, Patch, PatchSet
-from pex.typing import TYPE_CHECKING
+from pex.resolve.target_system import TargetSystem, UniversalTarget
+from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from typing import Mapping, Optional
+    from typing import Mapping, Optional, Union
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
 
 
+@attr.s(frozen=True)
 class PatchContext(object):
     _PEX_DEP_CONFIG_FILE_ENV_VAR_NAME = "_PEX_DEP_CONFIG_FILE"
 
     @classmethod
-    def load_dependency_configuration(cls):
-        # type: () -> DependencyConfiguration
+    def load(cls):
+        # type: () -> PatchContext
 
         dep_config_file = os.environ.pop(cls._PEX_DEP_CONFIG_FILE_ENV_VAR_NAME)
         with open(dep_config_file) as fp:
             data = json.load(fp)
-        return DependencyConfiguration.create(
-            excluded=data["excluded"], overridden=data["overridden"]
+
+        universal_target = None  # type: Optional[UniversalTarget]
+        universal_target_data = data["universal_target"]
+        if universal_target_data:
+            universal_target = UniversalTarget(
+                requires_python=tuple(
+                    requires_python for requires_python in universal_target_data["requires_python"]
+                ),
+                systems=tuple(
+                    TargetSystem.for_value(system) for system in universal_target_data["systems"]
+                ),
+            )
+
+        marker_environment = None  # type: Optional[MarkerEnvironment]
+        marker_environment_data = data["marker_environment"]
+        if marker_environment_data:
+            marker_environment = MarkerEnvironment(**marker_environment_data)
+
+        if not (bool(universal_target) ^ bool(marker_environment)):
+            raise AssertionError(
+                reportable_unexpected_error_msg(
+                    "Expected exactly one of lock_configuration or marker_environment to be "
+                    "defined, found data: {data}",
+                    data=data,
+                )
+            )
+
+        return cls(
+            dependency_configuration=DependencyConfiguration.create(
+                excluded=data["excluded"], overridden=data["overridden"]
+            ),
+            extra_data=cast(
+                "Union[UniversalTarget, MarkerEnvironment]",
+                universal_target or marker_environment,
+            ),
         )
 
     @classmethod
-    def dump_dependency_configuration(cls, dependency_configuration):
-        # type: (DependencyConfiguration) -> Mapping[str, str]
+    def dump(
+        cls,
+        dependency_configuration,  # type: DependencyConfiguration
+        extra_data,  # type: Union[UniversalTarget, MarkerEnvironment]
+    ):
+        # type: (...) -> Mapping[str, str]
 
         dep_config_file = os.path.join(safe_mkdtemp(), "dep_config.json")
         with open(dep_config_file, "w") as fp:
@@ -41,14 +86,31 @@ class PatchContext(object):
                     "overridden": [
                         str(override) for override in dependency_configuration.all_overrides()
                     ],
+                    "universal_target": (
+                        {
+                            "requires_python": extra_data.requires_python,
+                            "systems": [str(system) for system in extra_data.systems],
+                        }
+                        if isinstance(extra_data, UniversalTarget)
+                        else None
+                    ),
+                    "marker_environment": (
+                        extra_data.as_dict() if isinstance(extra_data, MarkerEnvironment) else None
+                    ),
                 },
                 fp,
             )
         return {cls._PEX_DEP_CONFIG_FILE_ENV_VAR_NAME: dep_config_file}
 
+    dependency_configuration = attr.ib()  # type: DependencyConfiguration
+    extra_data = attr.ib()  # type: Union[UniversalTarget, MarkerEnvironment]
 
-def patch(dependency_configuration):
-    # type: (DependencyConfiguration) -> Optional[DownloadObserver]
+
+def patch(
+    dependency_configuration,  # type: DependencyConfiguration
+    extra_data,  # type: Union[UniversalTarget, MarkerEnvironment]
+):
+    # type: (...) -> Optional[DownloadObserver]
 
     if not dependency_configuration:
         return None
@@ -57,9 +119,7 @@ def patch(dependency_configuration):
         analyzer=None,
         patch_set=PatchSet.create(
             Patch.from_code_resource(
-                __name__,
-                "requires.py",
-                **PatchContext.dump_dependency_configuration(dependency_configuration)
+                __name__, "requires.py", **PatchContext.dump(dependency_configuration, extra_data)
             )
         ),
     )

--- a/pex/pip/tool.py
+++ b/pex/pip/tool.py
@@ -36,6 +36,7 @@ from pex.resolve.resolver_configuration import (
     ReposConfiguration,
     ResolverVersion,
 )
+from pex.resolve.target_system import UniversalTarget
 from pex.targets import Target
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
@@ -576,6 +577,7 @@ class Pip(object):
         build_configuration=BuildConfiguration(),  # type: BuildConfiguration
         observer=None,  # type: Optional[DownloadObserver]
         dependency_configuration=DependencyConfiguration(),  # type: DependencyConfiguration
+        universal_target=None,  # type: Optional[UniversalTarget]
         log=None,  # type: Optional[str]
     ):
         # type: (...) -> Job
@@ -623,7 +625,9 @@ class Pip(object):
         for obs in (
             foreign_platform_observer,
             observer,
-            dependencies.patch(dependency_configuration),
+            dependencies.patch(
+                dependency_configuration, extra_data=universal_target or target.marker_environment
+            ),
         ):
             if obs:
                 if obs.analyzer:

--- a/pex/resolve/configured_resolver.py
+++ b/pex/resolve/configured_resolver.py
@@ -7,11 +7,8 @@ from pex import resolver
 from pex.dist_metadata import Requirement
 from pex.pep_427 import InstallableType
 from pex.pip.version import PipVersion, PipVersionValue
-from pex.resolve import lock_resolver
-from pex.resolve.lockfile.model import Lockfile
 from pex.resolve.resolver_configuration import PipConfiguration, ReposConfiguration, ResolverVersion
 from pex.resolve.resolvers import Resolver, ResolveResult
-from pex.result import try_
 from pex.targets import Targets
 from pex.typing import TYPE_CHECKING
 
@@ -51,36 +48,6 @@ class ConfiguredResolver(Resolver):
     def use_system_time(self):
         # type: () -> bool
         return self.pip_configuration.build_configuration.use_system_time
-
-    def resolve_lock(
-        self,
-        lock,  # type: Lockfile
-        targets=Targets(),  # type: Targets
-        pip_version=None,  # type: Optional[PipVersionValue]
-        result_type=InstallableType.INSTALLED_WHEEL_CHROOT,  # type: InstallableType.Value
-    ):
-        # type: (...) -> ResolveResult
-        return try_(
-            lock_resolver.resolve_from_pex_lock(
-                targets=targets,
-                lock=lock,
-                resolver=self,
-                indexes=self.pip_configuration.repos_configuration.indexes,
-                find_links=self.pip_configuration.repos_configuration.find_links,
-                resolver_version=self.pip_configuration.resolver_version,
-                network_configuration=self.pip_configuration.network_configuration,
-                build_configuration=self.pip_configuration.build_configuration,
-                compile=False,
-                transitive=self.pip_configuration.transitive,
-                verify_wheels=True,
-                max_parallel_jobs=self.pip_configuration.max_jobs,
-                pip_version=pip_version or self.pip_configuration.version,
-                use_pip_config=self.pip_configuration.use_pip_config,
-                extra_pip_requirements=self.pip_configuration.extra_requirements,
-                keyring_provider=self.pip_configuration.keyring_provider,
-                result_type=result_type,
-            )
-        )
 
     def resolve_requirements(
         self,

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -19,7 +19,6 @@ from pex.resolve.locked_resolve import (
     DownloadableArtifact,
     LocalProjectArtifact,
     LockConfiguration,
-    LockStyle,
     UnFingerprintedLocalProjectArtifact,
 )
 from pex.resolve.lockfile.download_manager import DownloadedArtifact
@@ -157,9 +156,8 @@ def resolve_from_pylock(
         pylock_subset_result.subset_result,
         # This ensures artifact downloads via Pip will not be rejected by Pip for mismatched
         # target interpreters, etc.
-        lock_configuration=LockConfiguration(
-            style=LockStyle.UNIVERSAL,
-            requires_python=tuple([pylock.requires_python]) if pylock.requires_python else (),
+        lock_configuration=LockConfiguration.universal(
+            requires_python=[pylock.requires_python] if pylock.requires_python else []
         ),
         resolver=resolver,
         indexes=indexes,
@@ -242,9 +240,8 @@ def download_from_pylock(
         pylock_subset_result.subset_result,
         # This ensures artifact downloads via Pip will not be rejected by Pip for mismatched
         # target interpreters, etc.
-        lock_configuration=LockConfiguration(
-            style=LockStyle.UNIVERSAL,
-            requires_python=tuple([pylock.requires_python]) if pylock.requires_python else (),
+        lock_configuration=LockConfiguration.universal(
+            requires_python=[pylock.requires_python] if pylock.requires_python else [],
         ),
         resolver=resolver,
         indexes=indexes,

--- a/pex/resolve/locker.py
+++ b/pex/resolve/locker.py
@@ -24,11 +24,12 @@ from pex.pip.log_analyzer import LogAnalyzer
 from pex.pip.vcs import fingerprint_downloaded_vcs_archive
 from pex.pip.version import PipVersionValue
 from pex.requirements import LocalProjectRequirement, VCSRequirement
-from pex.resolve.locked_resolve import LockConfiguration, LockStyle, TargetSystem
+from pex.resolve.locked_resolve import LockConfiguration, LockStyle
 from pex.resolve.pep_691.fingerprint_service import FingerprintService
 from pex.resolve.pep_691.model import Endpoint
 from pex.resolve.resolved_requirement import PartialArtifact, Pin, ResolvedRequirement
 from pex.resolve.resolvers import Resolver
+from pex.resolve.target_system import TargetSystem
 from pex.targets import Target
 from pex.typing import TYPE_CHECKING
 

--- a/pex/resolve/lockfile/create.py
+++ b/pex/resolve/lockfile/create.py
@@ -529,6 +529,7 @@ def create(
             extra_pip_requirements=pip_configuration.extra_requirements,
             keyring_provider=pip_configuration.keyring_provider,
             dependency_configuration=dependency_configuration,
+            universal_target=lock_configuration.target,
         )
     except resolvers.ResolveError as e:
         return Error(str(e))
@@ -600,6 +601,7 @@ def create(
                     pip_version=pip_configuration.version,
                     use_pip_config=pip_configuration.use_pip_config,
                     extra_pip_requirements=pip_configuration.extra_requirements,
+                    dependency_configuration=dependency_configuration,
                 )
             )
 

--- a/pex/resolve/lockfile/download_manager.py
+++ b/pex/resolve/lockfile/download_manager.py
@@ -142,7 +142,11 @@ class DownloadManager(Generic["_A"]):
             )  # type: str
             with atomic_directory(download_dir, lock_style=self._file_lock_style) as atomic_dir:
                 if atomic_dir.is_finalized():
-                    TRACER.log("Using cached artifact at {} for {}".format(download_dir, artifact))
+                    TRACER.log(
+                        "Using cached artifact at {} for {}".format(
+                            download_dir, artifact.url.raw_url
+                        )
+                    )
                 else:
                     self._download(artifact, project_name, atomic_dir.work_dir)
         else:

--- a/pex/resolve/lockfile/json_codec.py
+++ b/pex/resolve/lockfile/json_codec.py
@@ -7,6 +7,7 @@ import json
 
 from pex import compatibility
 from pex.artifact_url import Fingerprint
+from pex.dependency_configuration import Override
 from pex.dist_metadata import Requirement, RequirementParseError
 from pex.enum import Enum
 from pex.pep_440 import Version
@@ -19,13 +20,13 @@ from pex.resolve.locked_resolve import (
     LockedRequirement,
     LockedResolve,
     LockStyle,
-    TargetSystem,
     VCSArtifact,
 )
 from pex.resolve.lockfile.model import Lockfile
 from pex.resolve.path_mappings import PathMappings
 from pex.resolve.resolved_requirement import Pin
 from pex.resolve.resolver_configuration import BuildConfiguration, PipConfiguration, ResolverVersion
+from pex.resolve.target_system import TargetSystem
 from pex.sorted_tuple import SortedTuple
 from pex.third_party.packaging import tags
 from pex.third_party.packaging.specifiers import InvalidSpecifier, SpecifierSet
@@ -184,6 +185,18 @@ def loads(
                 "The requirement string at '{path}' is invalid: {err}".format(path=path, err=e)
             )
 
+    def parse_override(
+        raw_override,  # type: str
+        path,  # type: str
+    ):
+        # type: (...) -> Override
+        try:
+            return Override.parse(raw_override)
+        except Override.InvalidError as e:
+            raise ParseError(
+                "The override string at '{path}' is invalid: {err}".format(path=path, err=e)
+            )
+
     def parse_version_specifier(
         raw_version_specifier,  # type: str
         path,  # type: str
@@ -245,8 +258,8 @@ def loads(
     ]
 
     overridden = [
-        parse_requirement(req, path=".overridden[{index}]".format(index=index))
-        for index, req in enumerate(get("overridden", list, optional=True) or ())
+        parse_override(override, path=".overridden[{index}]".format(index=index))
+        for index, override in enumerate(get("overridden", list, optional=True) or ())
     ]
 
     def assemble_tag(

--- a/pex/resolve/lockfile/pep_751.py
+++ b/pex/resolve/lockfile/pep_751.py
@@ -27,7 +27,6 @@ from pex.resolve.locked_resolve import (
     LockedRequirement,
     LockedResolve,
     Resolved,
-    TargetSystem,
     UnFingerprintedLocalProjectArtifact,
     UnFingerprintedVCSArtifact,
     VCSArtifact,
@@ -38,6 +37,7 @@ from pex.resolve.lockfile.subset import Subset, SubsetResult
 from pex.resolve.requirement_configuration import RequirementConfiguration
 from pex.resolve.resolved_requirement import Pin
 from pex.resolve.resolver_configuration import BuildConfiguration
+from pex.resolve.target_system import TargetSystem
 from pex.result import Error, ResultError, try_
 from pex.sorted_tuple import SortedTuple
 from pex.targets import Target, Targets

--- a/pex/resolve/resolvers.py
+++ b/pex/resolve/resolvers.py
@@ -16,7 +16,6 @@ from pex.fingerprinted_distribution import FingerprintedDistribution
 from pex.pep_427 import InstallableType
 from pex.pep_503 import ProjectName
 from pex.pip.version import PipVersionValue
-from pex.resolve.lockfile.model import Lockfile
 from pex.sorted_tuple import SortedTuple
 from pex.targets import AbbreviatedPlatform, Target, Targets
 from pex.typing import TYPE_CHECKING
@@ -245,17 +244,6 @@ class Resolver(object):
 
     def use_system_time(self):
         # type: () -> bool
-        raise NotImplementedError()
-
-    @abstractmethod
-    def resolve_lock(
-        self,
-        lock,  # type: Lockfile
-        targets=Targets(),  # type: Targets
-        pip_version=None,  # type: Optional[PipVersionValue]
-        result_type=InstallableType.INSTALLED_WHEEL_CHROOT,  # type: InstallableType.Value
-    ):
-        # type: (...) -> ResolveResult
         raise NotImplementedError()
 
     @abstractmethod

--- a/pex/resolve/target_system.py
+++ b/pex/resolve/target_system.py
@@ -1,0 +1,32 @@
+# Copyright 2021 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from pex.enum import Enum
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Tuple
+
+    import attr  # vendor:skip
+else:
+    from pex.third_party import attr
+
+
+class TargetSystem(Enum["TargetSystem.Value"]):
+    class Value(Enum.Value):
+        pass
+
+    LINUX = Value("linux")
+    MAC = Value("mac")
+    WINDOWS = Value("windows")
+
+
+TargetSystem.seal()
+
+
+@attr.s(frozen=True)
+class UniversalTarget(object):
+    requires_python = attr.ib(default=())  # type: Tuple[str, ...]
+    systems = attr.ib(default=())  # type: Tuple[TargetSystem.Value, ...]

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -59,6 +59,7 @@ from pex.resolve.resolvers import (
     Untranslatable,
     check_resolve,
 )
+from pex.resolve.target_system import UniversalTarget
 from pex.targets import AbbreviatedPlatform, CompletePlatform, LocalInterpreter, Target, Targets
 from pex.third_party.packaging.tags import Tag
 from pex.tracer import TRACER
@@ -176,6 +177,7 @@ class DownloadRequest(object):
     dependency_configuration = attr.ib(
         default=DependencyConfiguration()
     )  # type: DependencyConfiguration
+    universal_target = attr.ib(default=None)  # type: Optional[UniversalTarget]
 
     def iter_local_projects(self):
         # type: () -> Iterator[BuildRequest]
@@ -279,6 +281,7 @@ class DownloadRequest(object):
             build_configuration=self.build_configuration,
             observer=observer,
             dependency_configuration=self.dependency_configuration,
+            universal_target=self.universal_target,
             log=log_manager.get_log(target),
         )
 
@@ -1341,6 +1344,7 @@ def _download_internal(
     pip_version=None,  # type: Optional[PipVersionValue]
     resolver=None,  # type: Optional[Resolver]
     dependency_configuration=DependencyConfiguration(),  # type: DependencyConfiguration
+    universal_target=None,  # type: Optional[UniversalTarget]
 ):
     # type: (...) -> Tuple[List[BuildRequest], List[DownloadResult]]
 
@@ -1360,6 +1364,7 @@ def _download_internal(
         pip_version=pip_version,
         resolver=resolver,
         dependency_configuration=dependency_configuration,
+        universal_target=universal_target,
     )
 
     local_projects = list(download_request.iter_local_projects())
@@ -1424,6 +1429,7 @@ def download(
     extra_pip_requirements=(),  # type: Tuple[Requirement, ...]
     keyring_provider=None,  # type: Optional[str]
     dependency_configuration=DependencyConfiguration(),  # type: DependencyConfiguration
+    universal_target=None,  # type: Optional[UniversalTarget]
 ):
     # type: (...) -> Downloaded
     """Downloads all distributions needed to meet requirements for multiple distribution targets.
@@ -1488,6 +1494,7 @@ def download(
         pip_version=pip_version,
         resolver=resolver,
         dependency_configuration=dependency_configuration,
+        universal_target=universal_target,
     )
 
     local_distributions = []

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.54.2"
+__version__ = "2.55.0"

--- a/tests/integration/cli/commands/test_issue_1821.py
+++ b/tests/integration/cli/commands/test_issue_1821.py
@@ -9,10 +9,11 @@ import pytest
 from pex.interpreter import PythonInterpreter
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
-from pex.resolve.locked_resolve import Artifact, FileArtifact, LockStyle, TargetSystem
+from pex.resolve.locked_resolve import Artifact, FileArtifact, LockStyle
 from pex.resolve.lockfile import json_codec
 from pex.resolve.lockfile.model import Lockfile
 from pex.resolve.resolved_requirement import Pin
+from pex.resolve.target_system import TargetSystem
 from pex.sorted_tuple import SortedTuple
 from pex.typing import TYPE_CHECKING
 from testing import IntegResults, run_pex_command

--- a/tests/integration/test_downloads.py
+++ b/tests/integration/test_downloads.py
@@ -8,7 +8,7 @@ import pytest
 from pex.artifact_url import Fingerprint
 from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.downloads import ArtifactDownloader
-from pex.resolve.locked_resolve import Artifact, FileArtifact, LockConfiguration, LockStyle
+from pex.resolve.locked_resolve import Artifact, FileArtifact, LockConfiguration
 from pex.resolve.resolved_requirement import PartialArtifact
 from pex.typing import TYPE_CHECKING
 from testing import IS_LINUX
@@ -57,7 +57,7 @@ def downloader():
     # type: () -> ArtifactDownloader
     return ArtifactDownloader(
         resolver=ConfiguredResolver.default(),
-        lock_configuration=LockConfiguration(style=LockStyle.UNIVERSAL),
+        lock_configuration=LockConfiguration.universal(),
     )
 
 

--- a/tests/integration/test_override_replace.py
+++ b/tests/integration/test_override_replace.py
@@ -1,0 +1,379 @@
+# Copyright 2024 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import os.path
+import shutil
+import subprocess
+from textwrap import dedent
+from typing import List
+
+import pytest
+
+from pex.common import safe_mkdir, safe_open
+from pex.interpreter import PythonInterpreter
+from pex.pep_503 import ProjectName
+from pex.resolve.lockfile import json_codec
+from pex.typing import TYPE_CHECKING
+from testing import PY39, PY310, PY311, WheelBuilder, ensure_python_interpreter, run_pex_command
+from testing.cli import run_pex3
+from testing.pytest_utils.tmp import Tempdir
+
+if TYPE_CHECKING:
+    import colors  # vendor:skip
+else:
+    from pex.third_party import colors
+
+
+def add_build_system_boilerplate(project_dir):
+    # type: (str) -> None
+
+    with safe_open(os.path.join(project_dir, "pyproject.toml"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                [build-system]
+                requires = ["setuptools"]
+                build-backend = "setuptools.build_meta"
+                """
+            )
+        )
+    with safe_open(os.path.join(project_dir, "setup.py"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                from setuptools import setup
+
+
+                setup()
+                """
+            )
+        )
+
+
+@pytest.fixture
+def project_with_ansicolors_dep(tmpdir):
+    # type: (Tempdir) -> str
+
+    project_dir = tmpdir.join("project")
+    add_build_system_boilerplate(project_dir)
+    with safe_open(os.path.join(project_dir, "module.py"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                import sys
+
+                import colors
+
+
+                def print_green():
+                    print(colors.green("Green?"))
+
+
+                if __name__ == "__main__":
+                    print_green()
+                    sys.exit(0)
+                """
+            )
+        )
+    with safe_open(os.path.join(project_dir, "setup.cfg"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                [metadata]
+                name = module
+                version = 0.1.0
+
+                [options]
+                py_modules = module
+                install_requires =
+                    ansicolors==1.1.8
+
+                [options.entry_points]
+                console_scripts =
+                    script = module:print_green
+                """
+            )
+        )
+    return project_dir
+
+
+def create_custom_ansicolors(
+    tmpdir,  # type: Tempdir
+    project_name,  # type: str
+    green_code,  # type: str
+):
+    # type: (...) -> str
+
+    project_dir = tmpdir.join(project_name)
+    add_build_system_boilerplate(project_dir)
+    with safe_open(os.path.join(project_dir, "colors.py"), "w") as fp:
+        fp.write(green_code)
+    with safe_open(os.path.join(project_dir, "setup.cfg"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                [metadata]
+                name = {project_name}
+                version = 0.1.0
+
+                [options]
+                py_modules = colors
+
+                [bdist_wheel]
+                python_tag=py2.py3
+                """
+            ).format(project_name=project_name)
+        )
+    return project_dir
+
+
+@pytest.fixture
+def my_ansicolors_asterisks(tmpdir):
+    # type: (Tempdir) -> str
+
+    return create_custom_ansicolors(
+        tmpdir=tmpdir,
+        project_name="my_ansicolors_asterisks",
+        green_code=dedent(
+            """\
+            def green(text):
+                return "*** {text} ***".format(text=text)
+            """
+        ),
+    )
+
+
+@pytest.fixture
+def my_ansicolors_dashes(tmpdir):
+    # type: (Tempdir) -> str
+
+    return create_custom_ansicolors(
+        tmpdir=tmpdir,
+        project_name="my_ansicolors_dashes",
+        green_code=dedent(
+            """\
+            def green(text):
+                return "--- {text} ---".format(text=text)
+            """
+        ),
+    )
+
+
+@pytest.fixture
+def find_links_repo(
+    tmpdir,  # type: Tempdir
+    my_ansicolors_asterisks,  # type: str
+    my_ansicolors_dashes,  # type: str
+):
+    # type: (...) -> str
+
+    my_ansicolors_asterisks_wheel = WheelBuilder(my_ansicolors_asterisks).bdist()
+    my_ansicolors_dashes_wheel = WheelBuilder(my_ansicolors_dashes).bdist()
+
+    find_links_repo = safe_mkdir(tmpdir.join("find-links"))
+    shutil.copy(
+        my_ansicolors_asterisks_wheel,
+        os.path.join(find_links_repo, os.path.basename(my_ansicolors_asterisks_wheel)),
+    )
+    shutil.copy(
+        my_ansicolors_dashes_wheel,
+        os.path.join(find_links_repo, os.path.basename(my_ansicolors_dashes_wheel)),
+    )
+    return find_links_repo
+
+
+def version(interpreter):
+    # type: (PythonInterpreter) -> str
+    return "{major}.{minor}".format(major=interpreter.version[0], minor=interpreter.version[1])
+
+
+ANSICOLORS_PYTHON = PythonInterpreter.get()
+ASTERISKS_PYTHON = PythonInterpreter.from_binary(
+    ensure_python_interpreter(PY310 if version(ANSICOLORS_PYTHON) == "3.11" else PY311)
+)
+DASHES_PYTHON = PythonInterpreter.from_binary(ensure_python_interpreter(PY39))
+
+
+def assert_multi_override_pex(
+    tmpdir,  # type: Tempdir
+    extra_pex_args,  # type: List[str]
+    is_exhaustive_override,  # type: bool
+):
+    # type: (...) -> None
+
+    pex = tmpdir.join("pex")
+    args = [
+        "--python",
+        ASTERISKS_PYTHON.binary,
+        "--python",
+        DASHES_PYTHON.binary,
+        "-c",
+        "script",
+        "-o",
+        pex,
+    ]
+    if not is_exhaustive_override:
+        args.append("--python")
+        args.append(ANSICOLORS_PYTHON.binary)
+    args.extend(extra_pex_args)
+
+    run_pex_command(args=args).assert_success()
+    if not is_exhaustive_override:
+        assert (
+            colors.green("Green?")
+            == subprocess.check_output(args=[ANSICOLORS_PYTHON.binary, pex]).decode("utf-8").strip()
+        )
+    assert (
+        "*** Green? ***"
+        == subprocess.check_output(args=[ASTERISKS_PYTHON.binary, pex]).decode("utf-8").strip()
+    )
+    assert (
+        "--- Green? ---"
+        == subprocess.check_output(args=[DASHES_PYTHON.binary, pex]).decode("utf-8").strip()
+    )
+
+
+@pytest.fixture
+def multi_override_args(
+    find_links_repo,  # type: str
+    project_with_ansicolors_dep,  # type: str
+):
+    # type: (...) -> List[str]
+
+    return [
+        "--find-links",
+        find_links_repo,
+        "--override",
+        "ansicolors=my-ansicolors-asterisks; python_version == '{version}'".format(
+            version=version(ASTERISKS_PYTHON)
+        ),
+        "--override",
+        "ansicolors=my-ansicolors-dashes; python_version == '{version}'".format(
+            version=version(DASHES_PYTHON)
+        ),
+        project_with_ansicolors_dep,
+    ]
+
+
+def test_replace_pex(
+    tmpdir,  # type: Tempdir
+    project_with_ansicolors_dep,  # type: str
+    find_links_repo,  # type: str
+    multi_override_args,  # type: List[str]
+):
+    # type: (...) -> None
+
+    pex = tmpdir.join("pex")
+    run_pex_command(args=[project_with_ansicolors_dep, "-c", "script", "-o", pex]).assert_success()
+    assert colors.green("Green?") == subprocess.check_output(args=[pex]).decode("utf-8").strip()
+
+    run_pex_command(
+        args=[
+            "--find-links",
+            find_links_repo,
+            project_with_ansicolors_dep,
+            "-c",
+            "script",
+            "-o",
+            pex,
+        ]
+    ).assert_success()
+    assert colors.green("Green?") == subprocess.check_output(args=[pex]).decode("utf-8").strip()
+
+    run_pex_command(
+        args=[
+            "--find-links",
+            find_links_repo,
+            "--override",
+            "ansicolors=my-ansicolors-asterisks",
+            project_with_ansicolors_dep,
+            "-c",
+            "script",
+            "-o",
+            pex,
+        ]
+    ).assert_success()
+    assert "*** Green? ***" == subprocess.check_output(args=[pex]).decode("utf-8").strip()
+
+    assert_multi_override_pex(tmpdir, multi_override_args, is_exhaustive_override=False)
+
+
+def test_replace_lock_partial(
+    tmpdir,  # type: Tempdir
+    project_with_ansicolors_dep,  # type: str
+    find_links_repo,  # type: str
+    multi_override_args,  # type: List[str]
+):
+    # type: (...) -> None
+
+    lock = tmpdir.join("lock.json")
+    lock_args = [
+        "lock",
+        "create",
+        "--style",
+        "universal",
+        "--interpreter-constraint",
+        ">=3.9,<3.12",
+        "--indent",
+        "2",
+        "-o",
+        lock,
+    ] + multi_override_args
+
+    run_pex3(*lock_args).assert_success()
+    assert_multi_override_pex(tmpdir, ["--lock", lock], is_exhaustive_override=False)
+    assert_multi_override_pex(
+        tmpdir, ["--lock", lock, project_with_ansicolors_dep], is_exhaustive_override=False
+    )
+
+    run_pex3(*(lock_args + ["--elide-unused-requires-dist", "-v"])).assert_success()
+    assert_multi_override_pex(tmpdir, ["--lock", lock], is_exhaustive_override=False)
+    assert_multi_override_pex(
+        tmpdir, ["--lock", lock, project_with_ansicolors_dep], is_exhaustive_override=False
+    )
+
+
+def assert_no_ansicolors(lock):
+    # type: (str) -> None
+
+    lockfile = json_codec.load(lock)
+    locked_projects = {
+        locked_requirement.pin.project_name
+        for locked_resolve in lockfile.locked_resolves
+        for locked_requirement in locked_resolve.locked_requirements
+    }
+    assert ProjectName("ansicolors") not in locked_projects
+
+
+def test_replace_lock_full(
+    tmpdir,  # type: Tempdir
+    project_with_ansicolors_dep,  # type: str
+    find_links_repo,  # type: str
+    multi_override_args,  # type: List[str]
+):
+    # type: (...) -> None
+
+    lock = tmpdir.join("lock.json")
+    lock_args = [
+        "lock",
+        "create",
+        "--style",
+        "universal",
+        "--indent",
+        "2",
+        "-o",
+        lock,
+    ] + multi_override_args
+    for interpreter in ASTERISKS_PYTHON, DASHES_PYTHON:
+        lock_args.append("--interpreter-constraint")
+        lock_args.append("=={version}.*".format(version=interpreter.python))
+
+    run_pex3(*lock_args).assert_success()
+    assert_no_ansicolors(lock)
+    assert_multi_override_pex(tmpdir, ["--lock", lock], is_exhaustive_override=True)
+
+    run_pex3(*(lock_args + ["--elide-unused-requires-dist", "-v"])).assert_success()
+    assert_no_ansicolors(lock)
+    assert_multi_override_pex(tmpdir, ["--lock", lock], is_exhaustive_override=True)

--- a/tests/test_dependency_configuration.py
+++ b/tests/test_dependency_configuration.py
@@ -1,0 +1,97 @@
+# Copyright 2025 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import pytest
+
+from pex.dependency_configuration import DependencyConfiguration, Override
+from pex.dist_metadata import Requirement
+from pex.pep_503 import ProjectName
+
+
+def test_override_parse():
+    # type: () -> None
+
+    def assert_cowsay_override(override):
+        # type: (str) -> None
+        assert Override(
+            project_name=ProjectName("cowsay"), requirement=Requirement.parse(override)
+        ) == Override.parse(override)
+
+    assert_cowsay_override("cowsay")
+    assert_cowsay_override("cowsay<6")
+    assert_cowsay_override("cowsay==5.0")
+    assert_cowsay_override("cowsay[tux]; python_version >= '3.5'")
+
+    def assert_cowsay_replace(replacement):
+        # type: (str) -> None
+        assert Override(
+            project_name=ProjectName("cowsay"), requirement=Requirement.parse(replacement)
+        ) == Override.parse("cowsay={replacement}".format(replacement=replacement))
+
+    assert_cowsay_replace("my-cowsay")
+    assert_cowsay_replace("my-cowsay>2")
+    assert_cowsay_replace("my-cowsay[foo, bar] >= 2; python_version == '3.11.*'")
+
+    with pytest.raises(Override.InvalidError, match=r"Invalid override requirement '42!': "):
+        Override.parse("42!")
+
+    with pytest.raises(Override.InvalidError, match=r"Invalid override requirement '42!': "):
+        Override.parse("cowsay=42!")
+
+
+def test_override_str():
+    # type: () -> None
+
+    def assert_cowsay_override_str(override):
+        # type: (str) -> None
+        requirement = Requirement.parse(override)
+        expected_str = str(requirement)
+        assert expected_str == str(
+            Override(project_name=ProjectName("cowsay"), requirement=requirement)
+        )
+        assert expected_str == str(Override.parse(override))
+
+    assert_cowsay_override_str("cowsay")
+    assert_cowsay_override_str("cowsay<6")
+    assert_cowsay_override_str("cowsay[tux]<6; python_version < '3'")
+
+    def assert_cowsay_replace_str(replacement):
+        # type: (str) -> None
+        requirement = Requirement.parse(replacement)
+        expected_str = "cowsay={requirement}".format(requirement=requirement)
+        assert expected_str == str(
+            Override(project_name=ProjectName("cowsay"), requirement=requirement)
+        )
+        assert expected_str == str(
+            Override.parse("cowsay={replacement}".format(replacement=replacement))
+        )
+
+    assert_cowsay_replace_str("my-cowsay")
+    assert_cowsay_replace_str("my-cowsay>2")
+    assert_cowsay_replace_str("my-cowsay[foo, bar] >= 2; python_version == '3.11.*'")
+
+
+def test_create():
+    # type: () -> None
+
+    assert DependencyConfiguration() == DependencyConfiguration.create()
+    assert DependencyConfiguration(
+        excluded=(Requirement.parse("foo"), Requirement.parse("bar")),
+        overridden={
+            ProjectName("baz"): tuple([Requirement.parse("baz")]),
+            ProjectName("spam"): tuple([Requirement.parse("spam")]),
+            ProjectName("eggs"): tuple([Requirement.parse("green"), Requirement.parse("brown")]),
+            ProjectName("fizz"): tuple([Requirement.parse("buzz")]),
+        },
+    ) == DependencyConfiguration.create(
+        excluded=["foo", Requirement.parse("bar")],
+        overridden=[
+            "baz",
+            Override(ProjectName("spam"), Requirement.parse("spam")),
+            "eggs=green",
+            Override.parse("fizz=buzz"),
+            Override(ProjectName("eggs"), Requirement.parse("brown")),
+        ],
+    )


### PR DESCRIPTION
Instead of just accepting PEP-508 requirement strings for `--override`
values, Pex now also accepts values of the form
`<project name>=<requirement>` to override any transitive requirement
on one project with a requirement on a completely different project.

This can be useful when you need to supply a patch to an existing
published project and would prefer to depend on wheels you pre-build
instead of using a VCS source dependency `--override`, which can be slow
to build.

Addresses #2891 and completes the suggested use cases in #2425 for which
`--override` was originally introduced.