### PR TITLE
Respect `--interpreter-constraint` impl in locks.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## 2.55.1
+
+This release fixes a bug present since the inception of `pex3 lock create --style universal`
+support. Previously, if the universal lock was created with `--interpreter-constraint`s, the
+Python implementation information was discarded; so, for example, even with
+`--interpreter-constraint CPython==3.13.*`, the lock resolve would consider PyPy in-play.
+
+* Respect `--interpreter-constraint` impl in locks. (#2898)
+
 ## 2.55.0
 
 This release adds support for `--override <project name>=<requirement>` wherever

--- a/pex/cli/commands/lock.py
+++ b/pex/cli/commands/lock.py
@@ -1037,10 +1037,7 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
             target_configuration = script_metadata_application.target_configuration
         if self.options.style == LockStyle.UNIVERSAL:
             lock_configuration = LockConfiguration.universal(
-                requires_python=[
-                    str(interpreter_constraint.requires_python)
-                    for interpreter_constraint in target_configuration.interpreter_constraints
-                ],
+                interpreter_constraints=target_configuration.interpreter_constraints,
                 systems=self.options.target_systems,
                 elide_unused_requires_dist=self.options.elide_unused_requires_dist,
             )
@@ -1157,7 +1154,7 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
         # type: (RequirementConfiguration) -> Result
 
         lockfile_path, lock_file = self._load_lockfile()
-        if self.options.format is ExportFormat.PEP_751 and lock_file.style is LockStyle.UNIVERSAL:
+        if self.options.format is ExportFormat.PEP_751 and lock_file.configuration.universal_target:
             self._check_pylock_toml_output_name()
             production_assert(
                 len(lock_file.locked_resolves) == 1,
@@ -1180,18 +1177,11 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
                     locked_resolves=lock_file.locked_resolves,
                 )
 
-            if len(lock_file.requires_python) > 1:
-                # TODO(John Sirois): Provide a better error message. We could guide on OR
-                #  to and AND paired with != to remove disjoint portions of the range.
-                raise ValueError(
-                    "Can only export a lock file with a single interpreter constraint."
-                )
             with self.output(self.options, binary=True) as toml_output:
                 pep_751.convert(
                     root_requirements=lock_subset.root_requirements,
                     locked_resolve=lock_subset.locked_resolves[0],
-                    requires_python=lock_file.requires_python[0],
-                    target_systems=lock_file.target_systems,
+                    universal_target=lock_file.configuration.universal_target,
                     output=toml_output,
                     include_dependency_info=self.options.include_dependency_info,
                 )
@@ -1460,13 +1450,13 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
         locking_configuration = LockingConfiguration(
             requirement_configuration,
             target_configuration=target_configuration,
-            lock_configuration=lock_file.lock_configuration(),
+            lock_configuration=lock_file.configuration,
             script_metadata_application=script_metadata_application,
         )
         targets = try_(
             self._resolve_targets(
                 action="creating",
-                style=lock_file.style,
+                style=lock_file.configuration.style,
                 target_configuration=locking_configuration.target_configuration,
             )
         )
@@ -1585,8 +1575,7 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
                         requires_dist.filter_dependencies(
                             req,
                             locked_req,
-                            requires_python=lock_file.requires_python,
-                            target_systems=lock_file.target_systems,
+                            universal_target=lock_file.configuration.universal_target,
                         )
                     )
 
@@ -1657,7 +1646,9 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
         )
         targets = try_(
             self._resolve_targets(
-                action="updating", style=lock_file.style, target_configuration=target_configuration
+                action="updating",
+                style=lock_file.configuration.style,
+                target_configuration=target_configuration,
             )
         )
 
@@ -1675,7 +1666,7 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
 
         with TRACER.timed("Selecting locks to update"):
             locked_resolve_count = len(lock_file.locked_resolves)
-            if lock_file.style is LockStyle.UNIVERSAL and locked_resolve_count != 1:
+            if lock_file.configuration.style is LockStyle.UNIVERSAL and locked_resolve_count != 1:
                 return Error(
                     "The lock at {path} contains {count} locked resolves; so it "
                     "cannot be updated as a universal lock which requires exactly one locked "
@@ -1685,7 +1676,7 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
                 locked_resolve = lock_file.locked_resolves[0]
                 update_targets = (
                     [LocalInterpreter.create(targets.interpreter)]
-                    if lock_file.style is LockStyle.UNIVERSAL
+                    if lock_file.configuration.style is LockStyle.UNIVERSAL
                     else targets.unique_targets()
                 )
                 update_requests = [
@@ -1722,7 +1713,10 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
                     )
                     for resolved_subset in subset_result.subsets
                 ]
-        if getattr(self.options, "strict", False) and lock_file.style is not LockStyle.UNIVERSAL:
+        if (
+            getattr(self.options, "strict", False)
+            and lock_file.configuration.style is not LockStyle.UNIVERSAL
+        ):
             missing_updates = set(lock_file.locked_resolves) - {
                 update_request.locked_resolve for update_request in update_requests
             }
@@ -2086,10 +2080,7 @@ class Lock(OutputMixin, JsonMixin, BuildTimeCommand):
             original_lock_file = try_(parse_lockfile(self.options, lock_file_path=lock_file_path))
             lock_file = attr.evolve(
                 original_lock_file,
-                style=lock_configuration.style,
-                requires_python=SortedTuple(lock_configuration.requires_python),
-                target_systems=SortedTuple(lock_configuration.target_systems),
-                elide_unused_requires_dist=lock_configuration.elide_unused_requires_dist,
+                configuration=lock_configuration,
                 pip_version=pip_configuration.version,
                 resolver_version=pip_configuration.resolver_version,
                 allow_prereleases=pip_configuration.allow_prereleases,

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -768,10 +768,10 @@ class PEXEnvironment(object):
                 current_interpreter = PythonInterpreter.get()
                 pex_warnings.warn(
                     "The legacy `pkg_resources` package cannot be imported by the "
-                    "{interpreter} {version} interpreter at {path}.\n"
+                    "{implementation} {version} interpreter at {path}.\n"
                     "The following distributions need `pkg_resources` to load some legacy "
                     "namespace packages and may fail to work properly:\n{dists}".format(
-                        interpreter=current_interpreter.identity.interpreter,
+                        implementation=current_interpreter.identity.implementation,
                         version=current_interpreter.python,
                         path=current_interpreter.binary,
                         dists=dists,

--- a/pex/interpreter_constraints.py
+++ b/pex/interpreter_constraints.py
@@ -13,9 +13,10 @@ from pex.compatibility import indent
 from pex.dist_metadata import Requirement, RequirementParseError
 from pex.enum import Enum
 from pex.interpreter import PythonInterpreter
+from pex.interpreter_implementation import InterpreterImplementation
 from pex.orderedset import OrderedSet
 from pex.specifier_sets import UnsatisfiableSpecifierSet, as_range
-from pex.third_party.packaging.specifiers import SpecifierSet
+from pex.third_party.packaging.specifiers import InvalidSpecifier, SpecifierSet
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -38,23 +39,19 @@ class InterpreterConstraint(object):
     def parse(
         cls,
         constraint,  # type: str
-        default_interpreter=None,  # type: Optional[str]
+        default_interpreter=None,  # type: Optional[InterpreterImplementation.Value]
     ):
         # type: (...) -> InterpreterConstraint
         try:
             requirement = Requirement.parse(constraint)
-            return cls(specifier=requirement.specifier, name=requirement.name)
+            return cls(
+                specifier=requirement.specifier,
+                implementation=InterpreterImplementation.for_value(requirement.name),
+            )
         except RequirementParseError:
-            if default_interpreter is not None:
-                return cls.parse(
-                    constraint="{interpreter}{specifier}".format(
-                        interpreter=default_interpreter, specifier=constraint
-                    ),
-                    default_interpreter=None,
-                )
             try:
-                return cls(specifier=SpecifierSet(constraint))
-            except RequirementParseError as e:
+                return cls(specifier=SpecifierSet(constraint), implementation=default_interpreter)
+            except InvalidSpecifier as e:
                 raise ValueError(
                     "Unparseable interpreter constraint {constraint}: {err}".format(
                         constraint=constraint, err=e
@@ -74,13 +71,13 @@ class InterpreterConstraint(object):
         # type: (Optional[PythonInterpreter]) -> InterpreterConstraint
         python_identity = (interpreter or PythonInterpreter.get()).identity
         return cls.parse(
-            "{interpreter}=={version}".format(
-                interpreter=python_identity.interpreter, version=python_identity.version_str
+            "{implementation}=={version}".format(
+                implementation=python_identity.implementation, version=python_identity.version_str
             )
         )
 
     specifier = attr.ib()  # type: SpecifierSet
-    name = attr.ib(default=None)  # type: Optional[str]
+    implementation = attr.ib(default=None)  # type: Optional[InterpreterImplementation.Value]
 
     @specifier.validator
     def _validate_specifier(
@@ -107,12 +104,14 @@ class InterpreterConstraint(object):
 
     def __str__(self):
         # type: () -> str
-        return "{name}{specifier}".format(name=self.name or "", specifier=self.specifier)
+        return "{implementation}{specifier}".format(
+            implementation=self.implementation or "", specifier=self.specifier
+        )
 
     def __contains__(self, interpreter):
         # type: (PythonInterpreter) -> bool
         python_identity = interpreter.identity
-        if self.name and self.name != python_identity.interpreter:
+        if self.implementation and self.implementation is not python_identity.implementation:
             return False
         return python_identity.version_str in self.specifier
 

--- a/pex/interpreter_constraints.py
+++ b/pex/interpreter_constraints.py
@@ -385,12 +385,12 @@ COMPATIBLE_PYTHON_VERSIONS = (
 
 
 def iter_compatible_versions(
-    requires_python,  # type: Iterable[str]
+    requires_python,  # type: Iterable[SpecifierSet]
     max_patch=DEFAULT_MAX_PATCH,  # type: int
 ):
     # type: (...) -> Iterator[Tuple[int, int, int]]
 
-    specifier_sets = OrderedSet(SpecifierSet(req) for req in requires_python)
+    specifier_sets = OrderedSet(requires_python)
     return itertools.chain.from_iterable(
         python_version.iter_compatible_versions(specifier_sets, max_patch=max_patch)
         for python_version in COMPATIBLE_PYTHON_VERSIONS

--- a/pex/interpreter_implementation.py
+++ b/pex/interpreter_implementation.py
@@ -1,0 +1,52 @@
+# Copyright 2025 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from pex.enum import Enum
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Optional, Tuple
+
+
+class _InterpreterImplementationValue(Enum.Value):
+    def __init__(
+        self,
+        value,  # type: str
+        abbr,  # type: str
+        binary_name,  # type: str
+    ):
+        # type: (...) -> None
+        super(_InterpreterImplementationValue, self).__init__(value)
+        self.abbr = abbr
+        self.binary_name = binary_name
+
+    def calculate_binary_name(self, version=None):
+        # type: (Optional[Tuple[int, ...]]) -> str
+        if not version:
+            return self.binary_name
+        return "{name}{version}".format(name=self.binary_name, version=".".join(map(str, version)))
+
+
+class InterpreterImplementation(Enum["InterpreterImplementation.Value"]):
+    class Value(_InterpreterImplementationValue):
+        pass
+
+    CPYTHON = Value("CPython", "cp", "python")
+    PYPY = Value("PyPy", "pp", "pypy")
+
+
+InterpreterImplementation.seal()
+
+
+def calculate_binary_name(
+    platform_python_implementation,  # type: str
+    python_version=None,  # type: Optional[Tuple[int, ...]]
+):
+    # type: (...) -> str
+
+    implementation = InterpreterImplementation.CPYTHON
+    if InterpreterImplementation.PYPY.value == platform_python_implementation:
+        implementation = InterpreterImplementation.PYPY
+    return implementation.calculate_binary_name(version=python_version)

--- a/pex/pep_508.py
+++ b/pex/pep_508.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import
 
+from pex.interpreter_implementation import InterpreterImplementation
 from pex.platforms import Platform
 from pex.third_party.packaging import markers
 from pex.typing import TYPE_CHECKING
@@ -117,11 +118,9 @@ class MarkerEnvironment(object):
             sys_platform = "win32"
 
         platform_python_implementation = None
-
-        if platform.impl == "cp":
-            platform_python_implementation = "CPython"
-        elif platform.impl == "pp":
-            platform_python_implementation = "PyPy"
+        for implementation in InterpreterImplementation.values():
+            if implementation.abbr == platform.impl:
+                platform_python_implementation = implementation.value
 
         python_version = ".".join(map(str, platform.version_info[:2]))
 

--- a/pex/pip/dependencies/__init__.py
+++ b/pex/pip/dependencies/__init__.py
@@ -9,9 +9,11 @@ import os
 from pex.common import safe_mkdtemp
 from pex.dependency_configuration import DependencyConfiguration
 from pex.exceptions import reportable_unexpected_error_msg
+from pex.interpreter_implementation import InterpreterImplementation
 from pex.pep_508 import MarkerEnvironment
 from pex.pip.download_observer import DownloadObserver, Patch, PatchSet
 from pex.resolve.target_system import TargetSystem, UniversalTarget
+from pex.third_party.packaging.specifiers import SpecifierSet
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
@@ -37,9 +39,14 @@ class PatchContext(object):
         universal_target = None  # type: Optional[UniversalTarget]
         universal_target_data = data["universal_target"]
         if universal_target_data:
+            implementation = universal_target_data["implementation"]
             universal_target = UniversalTarget(
+                implementation=InterpreterImplementation.for_value(implementation)
+                if implementation
+                else None,
                 requires_python=tuple(
-                    requires_python for requires_python in universal_target_data["requires_python"]
+                    SpecifierSet(requires_python)
+                    for requires_python in universal_target_data["requires_python"]
                 ),
                 systems=tuple(
                     TargetSystem.for_value(system) for system in universal_target_data["systems"]
@@ -88,7 +95,14 @@ class PatchContext(object):
                     ],
                     "universal_target": (
                         {
-                            "requires_python": extra_data.requires_python,
+                            "implementation": (
+                                str(extra_data.implementation)
+                                if extra_data.implementation
+                                else None
+                            ),
+                            "requires_python": [
+                                str(specifier_set) for specifier_set in extra_data.requires_python
+                            ],
                             "systems": [str(system) for system in extra_data.systems],
                         }
                         if isinstance(extra_data, UniversalTarget)

--- a/pex/pip/foreign_platform/__init__.py
+++ b/pex/pip/foreign_platform/__init__.py
@@ -12,6 +12,7 @@ from pex.pep_425 import CompatibilityTags
 from pex.pip.download_observer import DownloadObserver, Patch, PatchSet
 from pex.platforms import PlatformSpec
 from pex.targets import AbbreviatedPlatform, CompletePlatform, Target
+from pex.third_party.packaging.specifiers import SpecifierSet
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING
 
@@ -156,7 +157,7 @@ def patch(target):
         "environment markers defined and an abbreviated platform should always have at least the"
         "`python_version` environment marker defined. Given: {target}".format(target=target)
     )
-    requires_python = (
+    requires_python = SpecifierSet(
         "=={full_version}".format(full_version=target.marker_environment.python_full_version)
         if target.marker_environment.python_full_version
         else "=={version}.*".format(version=target.marker_environment.python_version)
@@ -179,7 +180,7 @@ def patch_tags(
 
 
 def patch_requires_python(
-    requires_python,  # type: Iterable[str]
+    requires_python,  # type: Iterable[SpecifierSet]
     patches_dir=None,  # type: Optional[str]
 ):
     # type: (...) -> Patch
@@ -193,7 +194,7 @@ def patch_requires_python(
     """
     with TRACER.timed(
         "Calculating compatible python versions for {requires_python}".format(
-            requires_python=requires_python
+            requires_python=" or ".join(map(str, requires_python))
         )
     ):
         python_full_versions = list(iter_compatible_versions(requires_python))

--- a/pex/pip/installation.py
+++ b/pex/pip/installation.py
@@ -384,7 +384,7 @@ class PipInstallation(object):
                 "{pip_version} requires Python {requires_python}.".format(
                     pip_requirement=self.version.requirement,
                     pip_version=self.version.value,
-                    python_impl=self.interpreter.identity.interpreter,
+                    python_impl=self.interpreter.identity.implementation,
                     python_version=self.interpreter.identity.version_str,
                     python_binary=self.interpreter.binary,
                     requires_python=self.version.requires_python,

--- a/pex/resolve/lock_resolver.py
+++ b/pex/resolve/lock_resolver.py
@@ -9,6 +9,7 @@ from pex.auth import PasswordDatabase, PasswordEntry
 from pex.dependency_configuration import DependencyConfiguration
 from pex.dist_metadata import Requirement, is_wheel
 from pex.exceptions import production_assert
+from pex.interpreter_constraints import InterpreterConstraint
 from pex.network_configuration import NetworkConfiguration
 from pex.pep_427 import InstallableType
 from pex.pep_503 import ProjectName
@@ -157,7 +158,11 @@ def resolve_from_pylock(
         # This ensures artifact downloads via Pip will not be rejected by Pip for mismatched
         # target interpreters, etc.
         lock_configuration=LockConfiguration.universal(
-            requires_python=[pylock.requires_python] if pylock.requires_python else []
+            interpreter_constraints=(
+                [InterpreterConstraint(specifier=pylock.requires_python)]
+                if pylock.requires_python
+                else []
+            )
         ),
         resolver=resolver,
         indexes=indexes,
@@ -241,7 +246,11 @@ def download_from_pylock(
         # This ensures artifact downloads via Pip will not be rejected by Pip for mismatched
         # target interpreters, etc.
         lock_configuration=LockConfiguration.universal(
-            requires_python=[pylock.requires_python] if pylock.requires_python else [],
+            interpreter_constraints=(
+                [InterpreterConstraint(specifier=pylock.requires_python)]
+                if pylock.requires_python
+                else []
+            ),
         ),
         resolver=resolver,
         indexes=indexes,
@@ -305,7 +314,7 @@ def resolve_from_pex_lock(
     )
     return _resolve_from_subset_result(
         subset_result,
-        lock_configuration=lock.lock_configuration(),
+        lock_configuration=lock.configuration,
         resolver=resolver,
         indexes=indexes,
         find_links=find_links,
@@ -366,7 +375,7 @@ def download_from_pex_lock(
     )
     downloaded_artifacts = _download_from_subset_result(
         subset_result,
-        lock_configuration=lock.lock_configuration(),
+        lock_configuration=lock.configuration,
         resolver=resolver,
         indexes=indexes,
         find_links=find_links,

--- a/pex/resolve/locked_resolve.py
+++ b/pex/resolve/locked_resolve.py
@@ -15,6 +15,7 @@ from pex.dependency_configuration import DependencyConfiguration
 from pex.dist_metadata import DistMetadata, Requirement, is_sdist, is_wheel
 from pex.enum import Enum
 from pex.exceptions import production_assert
+from pex.interpreter_constraints import InterpreterConstraint
 from pex.orderedset import OrderedSet
 from pex.pep_425 import CompatibilityTags, TagRank
 from pex.pep_503 import ProjectName
@@ -73,28 +74,48 @@ class LockConfiguration(object):
     @classmethod
     def universal(
         cls,
-        requires_python=(),  # type: Iterable[str]
+        interpreter_constraints=(),  # type: Iterable[InterpreterConstraint]
         systems=(),  # type: Iterable[TargetSystem.Value]
         elide_unused_requires_dist=False,  # type: bool
     ):
         # type: (...) -> LockConfiguration
+
+        implementations = {
+            interpreter_constraint.implementation
+            for interpreter_constraint in interpreter_constraints
+        }
+        if len(implementations) > 1:
+            raise ValueError(
+                "The interpreter constraints for a universal resolve cannot have mixed "
+                "implementations. Given: {constraints}".format(
+                    constraints=" or ".join(map(str, interpreter_constraints))
+                )
+            )
+
         return cls(
             style=LockStyle.UNIVERSAL,
-            target=UniversalTarget(requires_python=tuple(requires_python), systems=tuple(systems)),
+            universal_target=UniversalTarget(
+                implementation=implementations.pop() if implementations else None,
+                requires_python=tuple(
+                    interpreter_constraint.requires_python
+                    for interpreter_constraint in interpreter_constraints
+                ),
+                systems=tuple(systems),
+            ),
             elide_unused_requires_dist=elide_unused_requires_dist,
         )
 
     style = attr.ib()  # type: LockStyle.Value
-    target = attr.ib(default=None)  # type: Optional[UniversalTarget]
+    universal_target = attr.ib(default=None)  # type: Optional[UniversalTarget]
     elide_unused_requires_dist = attr.ib(default=False)  # type: bool
 
-    @target.validator
+    @universal_target.validator
     def _validate_only_set_for_universal(
         self,
         attribute,  # type: Any
         value,  # type: Any
     ):
-        if value and self.style != LockStyle.UNIVERSAL:
+        if value and self.style is not LockStyle.UNIVERSAL:
             raise ValueError(
                 "The {field_name} field should only be set for {universal} style locks; "
                 "this lock is {style} style and given {field_name} value of {value}".format(
@@ -104,16 +125,6 @@ class LockConfiguration(object):
                     value=value,
                 )
             )
-
-    @property
-    def requires_python(self):
-        # type: () -> Tuple[str, ...]
-        return self.target.requires_python if self.target else ()
-
-    @property
-    def target_systems(self):
-        # type: () -> Tuple[TargetSystem.Value, ...]
-        return self.target.systems if self.target else ()
 
 
 @total_ordering

--- a/pex/resolve/locker_patches.py
+++ b/pex/resolve/locker_patches.py
@@ -40,10 +40,20 @@ def patch_marker_evaluate():
     from pip._vendor.packaging import markers
 
     from pex.exceptions import production_assert
+    from pex.interpreter_implementation import InterpreterImplementation
     from pex.typing import TYPE_CHECKING
 
     if TYPE_CHECKING:
         from typing import Any, Callable, Dict, Iterable, List, Tuple, Type
+
+    interpreter_implementation = os.environ.get("_PEX_INTERPRETER_IMPLEMENTATION")
+    interpreter_implementations = []  # type: List[str]
+    if interpreter_implementation:
+        interpreter_implementations.append(str(interpreter_implementation))
+    else:
+        interpreter_implementations.extend(
+            str(implementation) for implementation in InterpreterImplementation.values()
+        )
 
     original_eval_op = markers._eval_op
 
@@ -118,6 +128,8 @@ def patch_marker_evaluate():
                         "'extra' does not exist in evaluation environment."
                     )
                 return original_extra
+            if name == "platform_python_implementation":
+                return interpreter_implementations
             if name == "python_version":
                 return python_versions_strings
             if name == "python_full_version":

--- a/pex/resolve/lockfile/create.py
+++ b/pex/resolve/lockfile/create.py
@@ -529,7 +529,7 @@ def create(
             extra_pip_requirements=pip_configuration.extra_requirements,
             keyring_provider=pip_configuration.keyring_provider,
             dependency_configuration=dependency_configuration,
-            universal_target=lock_configuration.target,
+            universal_target=lock_configuration.universal_target,
         )
     except resolvers.ResolveError as e:
         return Error(str(e))
@@ -560,9 +560,7 @@ def create(
 
     lock = Lockfile.create(
         pex_version=__version__,
-        style=lock_configuration.style,
-        requires_python=lock_configuration.requires_python,
-        target_systems=lock_configuration.target_systems,
+        lock_configuration=lock_configuration,
         pip_version=pip_configuration.version,
         resolver_version=pip_configuration.resolver_version,
         requirements=parsed_requirements,
@@ -573,7 +571,6 @@ def create(
         excluded=dependency_configuration.excluded,
         overridden=dependency_configuration.all_overrides(),
         locked_resolves=locked_resolves,
-        elide_unused_requires_dist=lock_configuration.elide_unused_requires_dist,
     )
 
     if lock_configuration.style is LockStyle.UNIVERSAL and (

--- a/pex/resolve/lockfile/updater.py
+++ b/pex/resolve/lockfile/updater.py
@@ -707,7 +707,7 @@ class LockUpdater(object):
         )
         return cls(
             lock_file=lock_file,
-            lock_configuration=lock_file.lock_configuration(),
+            lock_configuration=lock_file.configuration,
             pip_configuration=pip_configuration,
             dependency_configuration=dependency_configuration,
         )

--- a/pex/resolve/target_system.py
+++ b/pex/resolve/target_system.py
@@ -4,10 +4,13 @@
 from __future__ import absolute_import
 
 from pex.enum import Enum
+from pex.interpreter_constraints import InterpreterConstraint
+from pex.interpreter_implementation import InterpreterImplementation
+from pex.third_party.packaging.specifiers import SpecifierSet
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Tuple
+    from typing import Iterator, Optional, Tuple
 
     import attr  # vendor:skip
 else:
@@ -28,5 +31,11 @@ TargetSystem.seal()
 
 @attr.s(frozen=True)
 class UniversalTarget(object):
-    requires_python = attr.ib(default=())  # type: Tuple[str, ...]
+    implementation = attr.ib(default=None)  # type: Optional[InterpreterImplementation.Value]
+    requires_python = attr.ib(default=())  # type: Tuple[SpecifierSet, ...]
     systems = attr.ib(default=())  # type: Tuple[TargetSystem.Value, ...]
+
+    def iter_interpreter_constraints(self):
+        # type: () -> Iterator[InterpreterConstraint]
+        for specifier in self.requires_python:
+            yield InterpreterConstraint(specifier=specifier, implementation=self.implementation)

--- a/pex/sh_boot.py
+++ b/pex/sh_boot.py
@@ -20,6 +20,7 @@ from pex.os import WINDOWS
 from pex.pep_440 import Version
 from pex.pex_info import PexInfo
 from pex.targets import Targets
+from pex.third_party.packaging.specifiers import SpecifierSet
 from pex.typing import TYPE_CHECKING
 from pex.version import __version__
 
@@ -57,7 +58,7 @@ def _calculate_applicable_binary_names(
             PythonBinaryName(implementation=implementation, version=version)
             for interpreter_constraint in interpreter_constraints
             for version in iter_compatible_versions(
-                requires_python=[str(interpreter_constraint.requires_python)]
+                requires_python=[interpreter_constraint.specifier]
             )
             for implementation in (
                 (interpreter_constraint.implementation,)
@@ -86,10 +87,10 @@ def _calculate_applicable_binary_names(
     # more sophisticated detection and re-direction from these during its own bootstrap. When doing
     # so, select these interpreters from newest to oldest since it more likely any given machine
     # will have Python 3 at this point than it will Python 2.
-    pex_requires_python = ">=2.7"
+    pex_requires_python = SpecifierSet(">=2.7")
     dist = dist_metadata.find_distribution("pex")  # type: Optional[Distribution]
     if dist and dist.metadata.version == Version(__version__):
-        pex_requires_python = str(dist.metadata.requires_python)
+        pex_requires_python = dist.metadata.requires_python
     pex_supported_python_versions = tuple(
         reversed(list(iter_compatible_versions(requires_python=[pex_requires_python])))
     )

--- a/pex/venv/venv_pex.py
+++ b/pex/venv/venv_pex.py
@@ -179,8 +179,9 @@ def boot(
             "_PEX_USE_PIP_CONFIG",
             # This is used by Pex's Pip to inject runtime patches dynamically.
             "_PEX_PIP_RUNTIME_PATCHES_PACKAGE",
-            # These are used by Pex's Pip venv to provide foreign platform support and work
-            # around https://github.com/pypa/pip/issues/10050.
+            # These are used by Pex's Pip venv to provide foreign platform support, universal lock
+            # support and work around https://github.com/pypa/pip/issues/10050.
+            "_PEX_INTERPRETER_IMPLEMENTATION",
             "_PEX_PATCHED_MARKERS_FILE",
             "_PEX_PATCHED_TAGS_FILE",
             # These are used by Pex's Pip venv to implement universal locks.

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.55.0"
+__version__ = "2.55.1"

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -20,9 +20,9 @@ import pytest
 from pex.atomic_directory import atomic_directory
 from pex.common import open_zip, safe_mkdir, safe_mkdtemp, safe_rmtree, safe_sleep, temporary_dir
 from pex.dist_metadata import Distribution
-from pex.enum import Enum
 from pex.executor import Executor
 from pex.interpreter import PythonInterpreter
+from pex.interpreter_implementation import InterpreterImplementation
 from pex.os import LINUX, MAC, WINDOWS
 from pex.pep_427 import install_wheel_chroot
 from pex.pex import PEX
@@ -702,20 +702,9 @@ def ensure_python_interpreter(version):
     return ensure_python_distribution(version).binary
 
 
-class InterpreterImplementation(Enum["InterpreterImplementation.Value"]):
-    class Value(Enum.Value):
-        pass
-
-    CPython = Value("CPython")
-    PyPy = Value("PyPy")
-
-
-InterpreterImplementation.seal()
-
-
 def find_python_interpreter(
     version=(),  # type: Tuple[int, ...]
-    implementation=InterpreterImplementation.CPython,  # type: InterpreterImplementation.Value
+    implementation=InterpreterImplementation.CPYTHON,  # type: InterpreterImplementation.Value
 ):
     # type: (...) -> Optional[str]
     for pyenv_version, penv_version_info in _ALL_PY_VERSIONS_TO_VERSION_INFO.items():
@@ -725,7 +714,7 @@ def find_python_interpreter(
     for interpreter in PythonInterpreter.iter():
         if version != interpreter.version[: len(version)]:
             continue
-        if implementation != InterpreterImplementation.for_value(interpreter.identity.interpreter):
+        if implementation is not interpreter.identity.implementation:
             continue
         return interpreter.binary
 

--- a/testing/lock.py
+++ b/testing/lock.py
@@ -3,7 +3,6 @@
 
 from __future__ import absolute_import
 
-from pex.interpreter_constraints import InterpreterConstraint
 from pex.pep_503 import ProjectName
 from pex.resolve.locked_resolve import LockedRequirement
 from pex.resolve.lockfile import json_codec
@@ -36,12 +35,14 @@ def extract_lock_option_args(lock_file):
         "--resolver-version",
         str(lock.resolver_version),
         "--style",
-        str(lock.style),
+        str(lock.configuration.style),
     ]
-    for requires_python in lock.requires_python:
-        lock_args.append("--interpreter-constraint")
-        lock_args.append(str(InterpreterConstraint.parse(requires_python)))
-    for target_system in lock.target_systems:
-        lock_args.append("--target-system")
-        lock_args.append(str(target_system))
+    if lock.configuration.universal_target:
+        universal_target = lock.configuration.universal_target
+        for interpreter_constraint in universal_target.iter_interpreter_constraints():
+            lock_args.append("--interpreter-constraint")
+            lock_args.append(str(interpreter_constraint))
+        for target_system in universal_target.systems:
+            lock_args.append("--target-system")
+            lock_args.append(str(target_system))
     return lock_args

--- a/tests/bin/test_sh_boot.py
+++ b/tests/bin/test_sh_boot.py
@@ -9,6 +9,7 @@ from pex import sh_boot
 from pex.compatibility import ConfigParser
 from pex.interpreter import PythonInterpreter
 from pex.interpreter_constraints import InterpreterConstraints, iter_compatible_versions
+from pex.interpreter_implementation import InterpreterImplementation
 from pex.orderedset import OrderedSet
 from pex.pep_425 import CompatibilityTags
 from pex.pep_508 import MarkerEnvironment
@@ -112,8 +113,8 @@ def test_calculate_platforms_no_ics(requires_python):
 
     assert expected(
         requires_python,
-        PythonBinaryName(name="python", version=(3, 6)),
-        PythonBinaryName(name="pypy", version=(2, 7)),
+        PythonBinaryName(implementation=InterpreterImplementation.CPYTHON, version=(3, 6)),
+        PythonBinaryName(implementation=InterpreterImplementation.PYPY, version=(2, 7)),
     ) == calculate_binary_names(
         Targets(
             platforms=(
@@ -135,9 +136,9 @@ def test_calculate_interpreters_no_ics(
     assert (
         expected(
             requires_python,
-            PythonBinaryName(name="python", version=(2, 7)),
-            PythonBinaryName(name="python", version=(3, 11)),
-            PythonBinaryName(name="python", version=(3, 10)),
+            PythonBinaryName(implementation=InterpreterImplementation.CPYTHON, version=(2, 7)),
+            PythonBinaryName(implementation=InterpreterImplementation.CPYTHON, version=(3, 11)),
+            PythonBinaryName(implementation=InterpreterImplementation.CPYTHON, version=(3, 10)),
         )
         == calculate_binary_names(targets=Targets(interpreters=(py27, py311, py310)))
     )
@@ -149,13 +150,13 @@ def test_calculate_no_targets_ics(requires_python):
     assert (
         expected(
             requires_python,
-            PythonBinaryName(name="python", version=(3, 7)),
-            PythonBinaryName(name="pypy", version=(3, 7)),
-            PythonBinaryName(name="python", version=(3, 8)),
-            PythonBinaryName(name="pypy", version=(3, 8)),
-            PythonBinaryName(name="python", version=(3, 9)),
-            PythonBinaryName(name="pypy", version=(3, 9)),
-            PythonBinaryName(name="pypy", version=(3, 6)),
+            PythonBinaryName(implementation=InterpreterImplementation.CPYTHON, version=(3, 7)),
+            PythonBinaryName(implementation=InterpreterImplementation.PYPY, version=(3, 7)),
+            PythonBinaryName(implementation=InterpreterImplementation.CPYTHON, version=(3, 8)),
+            PythonBinaryName(implementation=InterpreterImplementation.PYPY, version=(3, 8)),
+            PythonBinaryName(implementation=InterpreterImplementation.CPYTHON, version=(3, 9)),
+            PythonBinaryName(implementation=InterpreterImplementation.PYPY, version=(3, 9)),
+            PythonBinaryName(implementation=InterpreterImplementation.PYPY, version=(3, 6)),
         )
         == calculate_binary_names(interpreter_constraints=[">=3.7,<3.10", "PyPy==3.6.*"])
     )
@@ -169,10 +170,10 @@ def test_calculate_mixed(
 
     assert expected(
         requires_python,
-        PythonBinaryName(name="python", version=(2, 7)),
-        PythonBinaryName(name="pypy", version=(3, 8)),
-        PythonBinaryName(name="python", version=(3, 6)),
-        PythonBinaryName(name="pypy", version=(3, 7)),
+        PythonBinaryName(implementation=InterpreterImplementation.CPYTHON, version=(2, 7)),
+        PythonBinaryName(implementation=InterpreterImplementation.PYPY, version=(3, 8)),
+        PythonBinaryName(implementation=InterpreterImplementation.CPYTHON, version=(3, 6)),
+        PythonBinaryName(implementation=InterpreterImplementation.PYPY, version=(3, 7)),
     ) == calculate_binary_names(
         targets=Targets(
             interpreters=(py27,),

--- a/tests/bin/test_sh_boot.py
+++ b/tests/bin/test_sh_boot.py
@@ -16,6 +16,7 @@ from pex.pep_508 import MarkerEnvironment
 from pex.resolve import abbreviated_platforms
 from pex.sh_boot import PythonBinaryName
 from pex.targets import CompletePlatform, Targets
+from pex.third_party.packaging.specifiers import SpecifierSet
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
@@ -66,7 +67,7 @@ def expected(
         all_names.add(current_interpreter_identity.binary_name(version_components=2))
 
     supported_versions = sorted(
-        (version[:2] for version in set(iter_compatible_versions([requires_python]))),
+        (version[:2] for version in set(iter_compatible_versions([SpecifierSet(requires_python)]))),
         reverse=True,  # Newest (highest) version 1st.
     )
     for exe_name in "python", "pypy":

--- a/tests/integration/cli/commands/test_export.py
+++ b/tests/integration/cli/commands/test_export.py
@@ -19,9 +19,9 @@ from pex.pip.version import PipVersion
 from pex.resolve.locked_resolve import (
     Artifact,
     LocalProjectArtifact,
+    LockConfiguration,
     LockedRequirement,
     LockedResolve,
-    LockStyle,
     VCSArtifact,
 )
 from pex.resolve.lockfile import json_codec
@@ -43,10 +43,7 @@ else:
 
 UNIVERSAL_ANSICOLORS = Lockfile(
     pex_version="42",
-    style=LockStyle.UNIVERSAL,
-    requires_python=SortedTuple(),
-    target_systems=SortedTuple(),
-    elide_unused_requires_dist=False,
+    configuration=LockConfiguration.universal(),
     pip_version=PipVersion.DEFAULT,
     resolver_version=ResolverVersion.PIP_2020,
     requirements=SortedTuple([Requirement.parse("ansicolors")]),

--- a/tests/integration/cli/commands/test_issue_1821.py
+++ b/tests/integration/cli/commands/test_issue_1821.py
@@ -222,7 +222,11 @@ def test_issue_1821(
     ) in result.error
 
     lockfile = lock(tmpdir, args, TargetSystem.LINUX, TargetSystem.MAC)
-    assert SortedTuple((TargetSystem.LINUX, TargetSystem.MAC)) == lockfile.target_systems
+    assert lockfile.configuration.universal_target is not None
+    assert (
+        SortedTuple((TargetSystem.LINUX, TargetSystem.MAC))
+        == lockfile.configuration.universal_target.systems
+    )
     assert lockfile.source is not None
     run_pex_command(
         args=["--lock", lockfile.source, "--", "-c", "import docker"], python=py310.binary

--- a/tests/integration/test_issue_2897.py
+++ b/tests/integration/test_issue_2897.py
@@ -1,0 +1,111 @@
+# Copyright 2025 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import re
+
+from pex.dist_metadata import Requirement
+from pex.interpreter import PythonInterpreter
+from pex.interpreter_constraints import InterpreterConstraint
+from pex.pep_440 import Version
+from pex.pep_503 import ProjectName
+from pex.resolve.locked_resolve import LockedRequirement
+from pex.resolve.lockfile import json_codec
+from testing import run_pex_command
+from testing.cli import run_pex3
+from testing.pytest_utils.tmp import Tempdir
+
+
+def test_ics_implementation_conflicting(tmpdir):
+    # type: (Tempdir) -> None
+
+    run_pex3(
+        "lock",
+        "create",
+        "--style",
+        "universal",
+        "--interpreter-constraint",
+        "CPython>=3.10,<3.12",
+        "--interpreter-constraint",
+        "PyPy>=3.9,<3.12",
+        "vcrpy==7.0.0",
+    ).assert_failure(
+        expected_error_re=re.escape(
+            "The interpreter constraints for a universal resolve cannot have mixed "
+            "implementations. Given: CPython<3.12,>=3.10 or PyPy<3.12,>=3.9"
+        )
+    )
+
+
+def test_ic_implementation_respected(
+    tmpdir,  # type: Tempdir
+    py311,  # type: PythonInterpreter
+):
+    # type: (...) -> None
+
+    lock_file = tmpdir.join("lock.json")
+    pex_root = tmpdir.join("pex-root")
+
+    def assert_vcr_lock(interpreter_constraint):
+        # type: (str) -> LockedRequirement
+
+        run_pex3(
+            "lock",
+            "create",
+            "--pex-root",
+            pex_root,
+            "--style",
+            "universal",
+            "--interpreter-constraint",
+            interpreter_constraint,
+            "--no-build",
+            "vcrpy==7.0.0",
+            "-o",
+            lock_file,
+            "--indent",
+            "2",
+        ).assert_success()
+
+        lock = json_codec.load(lock_file)
+        assert lock.configuration.universal_target is not None
+        expected_implementation = InterpreterConstraint.parse(interpreter_constraint).implementation
+        assert lock.configuration.universal_target.implementation is expected_implementation
+
+        assert len(lock.locked_resolves) == 1
+        locked_resolve = lock.locked_resolves[0]
+        locked_requirements_by_project_name = {
+            locked_requirement.pin.project_name: locked_requirement
+            for locked_requirement in locked_resolve.locked_requirements
+        }
+        vcrpy = locked_requirements_by_project_name.pop(ProjectName("vcrpy"))
+        assert {
+            Requirement.parse(req)
+            for req in (
+                "urllib3; platform_python_implementation != 'PyPy' and python_version >= '3.10'",
+                "urllib3<2; platform_python_implementation == 'PyPy'",
+                "urllib3<2; python_version < '3.10'",
+            )
+        }.issubset(vcrpy.requires_dists)
+        return locked_requirements_by_project_name.pop(ProjectName("urllib3"))
+
+    pypy_version_ceiling = Version("2")
+    urllib3 = assert_vcr_lock("CPython>=3.10,<3.12")
+    assert urllib3.pin.version >= pypy_version_ceiling
+    run_pex_command(
+        args=[
+            "--pex-root",
+            pex_root,
+            "--runtime-pex-root",
+            pex_root,
+            "--lock",
+            lock_file,
+            "--",
+            "-c",
+            "import vcr; print(vcr.__version__)",
+        ],
+        python=py311.binary,
+    ).assert_success(expected_output_re=r"^7\.0\.0$")
+
+    urllib3 = assert_vcr_lock("PyPy>=3.10,<3.12")
+    assert urllib3.pin.version < pypy_version_ceiling

--- a/tests/integration/test_pex_bootstrapper.py
+++ b/tests/integration/test_pex_bootstrapper.py
@@ -357,14 +357,14 @@ def test_boot_compatible_issue_1020_ic_min_compatible_build_time_hole(tmpdir):
             "--python-path",
             max_interpreter.binary,
             "--interpreter-constraint",
-            "{python}=={major}.{minor}.*".format(
-                python=max_interpreter.identity.interpreter,
+            "{implementation}=={major}.{minor}.*".format(
+                implementation=max_interpreter.identity.implementation,
                 major=min_interpreter.version[0],
                 minor=min_interpreter.version[1],
             ),
             "--interpreter-constraint",
-            "{python}=={major}.{minor}.*".format(
-                python=max_interpreter.identity.interpreter,
+            "{implementation}=={major}.{minor}.*".format(
+                implementation=max_interpreter.identity.implementation,
                 major=max_interpreter.version[0],
                 minor=max_interpreter.version[1],
             ),

--- a/tests/resolve/lockfile/test_json_codec.py
+++ b/tests/resolve/lockfile/test_json_codec.py
@@ -14,7 +14,13 @@ from pex.dist_metadata import Constraint, Requirement
 from pex.pep_440 import Version
 from pex.pep_503 import ProjectName
 from pex.pip.version import PipVersion
-from pex.resolve.locked_resolve import Artifact, LockedRequirement, LockedResolve, LockStyle
+from pex.resolve.locked_resolve import (
+    Artifact,
+    LockConfiguration,
+    LockedRequirement,
+    LockedResolve,
+    LockStyle,
+)
 from pex.resolve.lockfile import json_codec
 from pex.resolve.lockfile.json_codec import ParseError, PathMappingError
 from pex.resolve.lockfile.model import Lockfile
@@ -39,9 +45,7 @@ def test_roundtrip(tmpdir):
 
     lockfile = Lockfile.create(
         pex_version="1.2.3",
-        style=LockStyle.STRICT,
-        requires_python=(),
-        target_systems=(),
+        lock_configuration=LockConfiguration(style=LockStyle.STRICT),
         pip_version=PipVersion.VENDORED,
         resolver_version=ResolverVersion.PIP_2020,
         requirements=(

--- a/tests/test_interpreter_constraints.py
+++ b/tests/test_interpreter_constraints.py
@@ -5,6 +5,7 @@ import sys
 from textwrap import dedent
 
 import pytest
+from packaging.specifiers import SpecifierSet
 
 from pex import interpreter_constraints
 from pex.interpreter import PythonInterpreter
@@ -87,7 +88,9 @@ def test_parse():
 
 def iter_compatible_versions(*requires_python):
     # type: (*str) -> List[Tuple[int, int, int]]
-    return list(interpreter_constraints.iter_compatible_versions(list(requires_python)))
+    return list(
+        interpreter_constraints.iter_compatible_versions(map(SpecifierSet, requires_python))
+    )
 
 
 def test_iter_compatible_versions_none():
@@ -171,7 +174,11 @@ def test_iter_compatible_versions_non_eol():
     ) == list(
         interpreter_constraints.iter_compatible_versions(
             [
-                "=={major}.{minor}.*".format(major=python_version.major, minor=python_version.minor)
+                SpecifierSet(
+                    "=={major}.{minor}.*".format(
+                        major=python_version.major, minor=python_version.minor
+                    )
+                )
                 for python_version in (oldest_python_version, newest_python_version)
             ],
             max_patch=max_patch,

--- a/tests/test_interpreter_constraints.py
+++ b/tests/test_interpreter_constraints.py
@@ -15,6 +15,7 @@ from pex.interpreter_constraints import (
     Lifecycle,
     UnsatisfiableError,
 )
+from pex.interpreter_implementation import InterpreterImplementation
 from pex.pex_warnings import PEXWarning
 from pex.typing import TYPE_CHECKING
 from testing import PY39, ensure_python_interpreter
@@ -28,8 +29,12 @@ def test_parse():
 
     assert py39 in InterpreterConstraint.parse("==3.9.*")
     assert py39 in InterpreterConstraint.parse("CPython==3.9.*")
-    assert py39 in InterpreterConstraint.parse("==3.9.*", default_interpreter="CPython")
-    assert py39 not in InterpreterConstraint.parse("==3.9.*", default_interpreter="PyPy")
+    assert py39 in InterpreterConstraint.parse(
+        "==3.9.*", default_interpreter=InterpreterImplementation.CPYTHON
+    )
+    assert py39 not in InterpreterConstraint.parse(
+        "==3.9.*", default_interpreter=InterpreterImplementation.PYPY
+    )
     assert py39 not in InterpreterConstraint.parse("PyPy==3.9.*")
 
     with pytest.raises(


### PR DESCRIPTION
Previously, if an interpreter implementation was specified in a
`--style universal` lock `--interpreter-constraint`, that information
was discarded; so, for example, even with an `--interpreter-constraint` 
of `CPython==3.13.*` specified, the lock resolve would consider `PyPy`
wheels in-play.