### PR TITLE
Support regexes for `--source` project matching.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,27 @@
 # Release Notes
 
+## 2.57.0
+
+This release adds support for project name regexes to `--source` scopes for repos. For example, the
+PyTorch example given in the 2.56.0 release notes can now be shortened to:
+```console
+pex3 lock create \
+    --style universal \
+    --target-system linux \
+    --target-system mac \
+    --elide-unused-requires-dist \
+    --interpreter-constraint "CPython==3.13.*" \
+    --index pytorch=https://download.pytorch.org/whl/cu129 \
+    --source "pytorch=^torch(vision)?$; sys_platform != 'darwin'" \
+    --source "pytorch=^nvidia-.*; sys_platform != 'darwin'" \
+    --indent 2 \
+    -o lock.json \
+    torch \
+    torchvision
+```
+
+* Support regexes for `--source` project matching. (#2906)
+
 ## 2.56.0
 
 This release adds support for scoping `--index` and `--find-links` repos to only be used to resolve

--- a/pex/resolve/package_repository.py
+++ b/pex/resolve/package_repository.py
@@ -99,7 +99,8 @@ class Scope(object):
             return cls(project=requirement.project_name, marker=requirement.marker)
 
     project = attr.ib(default=None)  # type: Optional[Union[ProjectName, Pattern[str]]]
-    marker = attr.ib(default=None)  # type: Optional[Marker]
+    # N.B.: Older versions of Marker do not implement __eq__; so we use str(...) as a proxy.
+    marker = attr.ib(eq=str, default=None)  # type: Optional[Marker]
 
     def in_scope(
         self,

--- a/pex/resolve/package_repository.py
+++ b/pex/resolve/package_repository.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import itertools
 import os
+import re
 
 from pex.auth import PasswordEntry
 from pex.compatibility import string
@@ -13,9 +14,11 @@ from pex.exceptions import production_assert, reportable_unexpected_error_msg
 from pex.pep_503 import ProjectName
 from pex.resolve.target_system import MarkerEnv
 from pex.third_party.packaging.markers import InvalidMarker, Marker
-from pex.typing import TYPE_CHECKING
+from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
+    # N.B.: The `re.Pattern` type is not available in all Python versions Pex supports.
+    from re import Pattern  # type: ignore[attr-defined]
     from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
     import attr  # vendor:skip
@@ -27,6 +30,29 @@ else:
 @attr.s(frozen=True)
 class Scope(object):
     @classmethod
+    def _parse_regex_forms(cls, value):
+        # type: (str) -> Optional[Scope]
+
+        project_spec, sep, marker_value = value.partition(";")
+        try:
+            project = ProjectName(
+                project_spec, validated=True
+            )  # type: Union[ProjectName, Pattern[str]]
+        except ProjectName.InvalidError:
+            try:
+                project = re.compile(project_spec)
+            except re.error:
+                return None
+
+        marker = None  # type: Optional[Marker]
+        if marker_value:
+            try:
+                marker = Marker(marker_value)
+            except InvalidMarker:
+                return None
+        return cls(project=project, marker=marker)
+
+    @classmethod
     def parse(cls, value):
         # type: (str) -> Scope
 
@@ -37,8 +63,8 @@ class Scope(object):
             # type: (Optional[str]) -> Exception
             error_msg_lines = [
                 "The given scope is invalid: {scope}".format(scope=value),
-                "Expected a bare project name, a bare marker or a project name and marker; "
-                "e.g.: `torch; sys_platform != 'darwin'`.",
+                "Expected a bare project name-or-regex, a bare marker or a project name-or-regex "
+                "and marker; e.g.: `torch; sys_platform != 'darwin'`.",
             ]
             if footer:
                 error_msg_lines.append(footer)
@@ -47,6 +73,10 @@ class Scope(object):
         try:
             return cls(marker=Marker(value))
         except InvalidMarker:
+            scope = cls._parse_regex_forms(value)
+            if scope:
+                return scope
+
             try:
                 requirement = Requirement.parse(value)
             except RequirementParseError:
@@ -68,7 +98,7 @@ class Scope(object):
                 )
             return cls(project=requirement.project_name, marker=requirement.marker)
 
-    project = attr.ib(default=None)  # type: Optional[ProjectName]
+    project = attr.ib(default=None)  # type: Optional[Union[ProjectName, Pattern[str]]]
     marker = attr.ib(default=None)  # type: Optional[Marker]
 
     def in_scope(
@@ -84,31 +114,30 @@ class Scope(object):
             elif isinstance(target_env, MarkerEnv) and not target_env.evaluate(self.marker):
                 return False
 
-        if self.project and project_name and self.project != project_name:
-            return False
+        if not self.project or not project_name:
+            return True
 
-        return True
+        if isinstance(self.project, ProjectName):
+            return self.project == project_name
+
+        return cast("Pattern", self.project).match(project_name.normalized) is not None
 
     def __str__(self):
         # type: () -> str
-        if self.project and self.marker:
-            return "{project}; {marker}".format(project=self.project, marker=self.marker)
-        if self.project:
-            return str(self.project)
+
+        project_as_str = None  # type: Optional[str]
+        if isinstance(self.project, ProjectName):
+            project_as_str = self.project.raw
+        elif self.project:
+            project_as_str = self.project.pattern
+
+        if project_as_str and self.marker:
+            return "{project}; {marker}".format(project=project_as_str, marker=self.marker)
+        if project_as_str:
+            return project_as_str
         if self.marker:
             return str(self.marker)
         return ""
-
-
-# Indexes that only contain certain non-public projects or else projects you wish to override:
-# Scope(project=ProjectName("my-company-project1")) for https://my.company/simple
-
-# Platform-specific indexes that have native wheels built for just that platform:
-# Scope(marker=Marker("platform_machine == 'armv7l'")) for https://www.piwheels.org/simple
-
-# Complex cases, like PyTorch:
-# Scope(project=ProjectName("torch"), marker=Marker("sys_platform != 'darwin'")) for
-# https://download.pytorch.org/whl/cu129
 
 
 @attr.s(frozen=True)

--- a/pex/resolve/resolver_options.py
+++ b/pex/resolve/resolver_options.py
@@ -570,7 +570,8 @@ def register_repos_options(parser):
             "name and marker; e.g.: `internal=torch; sys_platform != 'darwin'` to resolve the "
             "`torch` project from the `internal` repo unless targeting macOS, or just a marker; "
             "e.g.: `piwheels=platform_machine == 'armv7l' to resolve from the `piwheels` repo "
-            "whenever 32bit arm machines are being targeted."
+            "whenever 32bit arm machines are being targeted. N.B. wherever you use a project name "
+            "in a scope, you can use a regex instead."
         ),
     )
 

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.56.0"
+__version__ = "2.57.0"

--- a/tests/integration/test_scoped_repos.py
+++ b/tests/integration/test_scoped_repos.py
@@ -321,9 +321,7 @@ class Expectations(object):
                     "--index",
                     "index={index}",
                     "--source",
-                    "index=cowsay",
-                    "--source",
-                    "index=ansicolors",
+                    "index=^(cowsay|ansicolors)$",
                 ],
             ),
             Expectations(
@@ -341,9 +339,7 @@ class Expectations(object):
                     "--find-links",
                     "fl={find_links}",
                     "--source",
-                    "fl=cowsay",
-                    "--source",
-                    "fl=ansicolors",
+                    "fl=.*co[lw].*",
                 ],
             ),
             Expectations(
@@ -496,11 +492,20 @@ def test_scoped_marker(
     )
 
 
-SCOPED_PROJECT_AND_MARKER_ARGS = [
+SCOPED_PROJECT_NAME_AND_MARKER_ARGS = [
     "--find-links",
     "fl={find_links}",
     "--source",
     "fl=cowsay; python_version == '{major}.{minor}'".format(
+        major=sys.version_info[0], minor=sys.version_info[1]
+    ),
+]
+
+SCOPED_PROJECT_RE_AND_MARKER_ARGS = [
+    "--find-links",
+    "fl={find_links}",
+    "--source",
+    "fl=^cow.*; python_version == '{major}.{minor}'".format(
         major=sys.version_info[0], minor=sys.version_info[1]
     ),
 ]
@@ -511,15 +516,27 @@ SCOPED_PROJECT_AND_MARKER_ARGS = [
     [
         pytest.param(
             Expectations(
-                cowsay_source=Source.FIND_LINKS, extra_args=SCOPED_PROJECT_AND_MARKER_ARGS
+                cowsay_source=Source.FIND_LINKS, extra_args=SCOPED_PROJECT_NAME_AND_MARKER_ARGS
             ),
             sys.executable,
-            id="marker-match",
+            id="name-marker-match",
         ),
         pytest.param(
-            Expectations(extra_args=SCOPED_PROJECT_AND_MARKER_ARGS),
+            Expectations(extra_args=SCOPED_PROJECT_NAME_AND_MARKER_ARGS),
             OTHER_INTERPRETER,
-            id="marker-miss",
+            id="name-marker-miss",
+        ),
+        pytest.param(
+            Expectations(
+                cowsay_source=Source.FIND_LINKS, extra_args=SCOPED_PROJECT_RE_AND_MARKER_ARGS
+            ),
+            sys.executable,
+            id="re-marker-match",
+        ),
+        pytest.param(
+            Expectations(extra_args=SCOPED_PROJECT_RE_AND_MARKER_ARGS),
+            OTHER_INTERPRETER,
+            id="re-marker-miss",
         ),
     ],
 )

--- a/tests/resolve/test_package_repository.py
+++ b/tests/resolve/test_package_repository.py
@@ -1,0 +1,90 @@
+# Copyright 2021 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import pytest
+
+from pex.pep_503 import ProjectName
+from pex.resolve.package_repository import Scope
+from pex.third_party.packaging.markers import Marker
+
+
+def assert_project_name(value):
+    # type: (str) -> Scope
+    scope = Scope.parse(value)
+    assert isinstance(scope.project, ProjectName)
+    return scope
+
+
+def assert_project_re(value):
+    # type: (str) -> Scope
+    scope = Scope.parse(value)
+    assert (
+        scope.project
+        and not isinstance(scope.project, ProjectName)
+        and hasattr(scope.project, "match")
+    )
+    return scope
+
+
+def test_parse():
+    # type: () -> None
+
+    scope = assert_project_name("foo")
+    assert scope.marker is None
+
+    scope = assert_project_name("foo; python_version == '3.9'")
+    assert Marker("python_version == '3.9'") == scope.marker
+
+    scope = assert_project_re("^(foo|bar|baz)$")
+    assert scope.marker is None
+
+    scope = assert_project_re("^(foo|bar|baz)$; python_version == '3.9'")
+    assert Marker("python_version == '3.9'") == scope.marker
+
+    scope = Scope.parse("python_version == '3.9'")
+    assert scope.project is None
+    assert Marker("python_version == '3.9'") == scope.marker
+
+
+@pytest.mark.parametrize(
+    "scope",
+    [
+        pytest.param(Scope.parse(scope), id=scope)
+        for scope in (
+            "foo",
+            "foo; python_version == '3.9'",
+            "^(foo|bar|baz)$",
+            "^(foo|bar|baz)$; python_version == '3.9'",
+            "python_version == '3.9'",
+        )
+    ],
+)
+def test_parse_str_round_trip(scope):
+    # type: (Scope) -> None
+
+    assert scope == Scope.parse(str(scope))
+
+
+def test_in_scope():
+    # type: () -> None
+
+    assert Scope.parse("foo").in_scope({})
+    assert Scope.parse("foo").in_scope({"python_version": "3.9"})
+    assert Scope.parse("foo").in_scope({}, project_name=ProjectName("Foo"))
+    assert Scope.parse("foo").in_scope({"python_version": "3.9"}, project_name=ProjectName("Foo"))
+
+    assert Scope.parse("^f.*").in_scope({}, project_name=ProjectName("Foo"))
+    assert Scope.parse("^f.*").in_scope({"python_version": "3.9"}, project_name=ProjectName("Foo"))
+
+    assert Scope.parse("^f.*; python_version == '3.9'").in_scope(
+        {"python_version": "3.9"}, project_name=ProjectName("Foo")
+    )
+    assert not Scope.parse("^f.*; python_version == '3.9'").in_scope(
+        {"python_version": "3.10"}, project_name=ProjectName("Foo")
+    )
+
+    assert Scope.parse("python_version == '3.9'").in_scope(
+        {"python_version": "3.9"}, project_name=ProjectName("foo")
+    )

--- a/tests/resolve/test_package_repository.py
+++ b/tests/resolve/test_package_repository.py
@@ -28,6 +28,15 @@ def assert_project_re(value):
     return scope
 
 
+def assert_marker(
+    expected,  # type: str
+    actual,  # type: Marker
+):
+    # type: (...) -> None
+    # N.B.: Older versions of Marker do not implement __eq__; so we use str(...) as a proxy.
+    assert str(Marker(expected)) == str(actual)
+
+
 def test_parse():
     # type: () -> None
 
@@ -35,17 +44,17 @@ def test_parse():
     assert scope.marker is None
 
     scope = assert_project_name("foo; python_version == '3.9'")
-    assert Marker("python_version == '3.9'") == scope.marker
+    assert_marker("python_version == '3.9'", scope.marker)
 
     scope = assert_project_re("^(foo|bar|baz)$")
     assert scope.marker is None
 
     scope = assert_project_re("^(foo|bar|baz)$; python_version == '3.9'")
-    assert Marker("python_version == '3.9'") == scope.marker
+    assert_marker("python_version == '3.9'", scope.marker)
 
     scope = Scope.parse("python_version == '3.9'")
     assert scope.project is None
-    assert Marker("python_version == '3.9'") == scope.marker
+    assert_marker("python_version == '3.9'", scope.marker)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This should help make common case command lines smaller and easier to
grok and maintain.