### PR TITLE
Use `os.linesep` when testing output

### DIFF
--- a/tests/tools/commands/test_venv.py
+++ b/tests/tools/commands/test_venv.py
@@ -694,7 +694,7 @@ def test_warn_unused_pex_env_vars():
         stdout, stderr = process.communicate()
         assert 0 == process.returncode
         assert not stdout
-        expected = expected_stderr.strip()
+        expected = os.linesep.join(expected_stderr.strip().splitlines())
         error = stderr.decode("utf-8").strip()
         if expected:
             assert error.endswith(expected), error


### PR DESCRIPTION
Production code output should be consistent since #2691. So, tests need to use `os.linesep` whenever checking stdout/stderr strings.

More work towards #1658.

_note: I use CI to run windows tests. This PR's purpose is to find a process I can use to work on ameliorating some of the windows test failures. I have only sporadic chunks of time available to work on this, so don't expect fast or significant progress from me any time soon._