### PR TITLE
Add `--derive-sources-from-requirements-files`.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## 2.58.0
+
+This release adds `--derive-sources-from-requirements-files` to allow for scoping requirement
+sources via the structure of requirements files. If any requirements files are specified that 
+contain `-f` / `--find-links`, `-i` / `--index-url`, or `--extra-index-url` options,
+`--derive-sources-from-requirements-files` will automatically map these repos as the `--source` for
+the requirements (if any) declared in the same requirements file.
+
+* Introduce `--derive-sources-from-requirements-files`. (#2909)
+
 ## 2.57.0
 
 This release adds support for project name regexes to `--source` scopes for repos. For example, the

--- a/pex/auth.py
+++ b/pex/auth.py
@@ -64,7 +64,7 @@ class Machine(object):
 class PasswordEntry(object):
     @classmethod
     def maybe_extract_from_url(cls, url):
-        # type: (str) -> Optional[PasswordEntry]
+        # type: (Text) -> Optional[PasswordEntry]
         url_info = urlparse.urlparse(url)
         if not url_info.username or not url_info.password:
             return None

--- a/pex/resolve/package_repository.py
+++ b/pex/resolve/package_repository.py
@@ -6,12 +6,22 @@ from __future__ import absolute_import
 import itertools
 import os
 import re
+from collections import OrderedDict, defaultdict
 
 from pex.auth import PasswordEntry
 from pex.compatibility import string
 from pex.dist_metadata import Requirement, RequirementParseError
 from pex.exceptions import production_assert, reportable_unexpected_error_msg
+from pex.orderedset import OrderedSet
 from pex.pep_503 import ProjectName
+from pex.requirements import (
+    FindLinks,
+    Index,
+    PyPIRequirement,
+    URLRequirement,
+    VCSRequirement,
+    parse_requirement_file,
+)
 from pex.resolve.target_system import MarkerEnv
 from pex.third_party.packaging.markers import InvalidMarker, Marker
 from pex.typing import TYPE_CHECKING, cast
@@ -19,7 +29,7 @@ from pex.typing import TYPE_CHECKING, cast
 if TYPE_CHECKING:
     # N.B.: The `re.Pattern` type is not available in all Python versions Pex supports.
     from re import Pattern  # type: ignore[attr-defined]
-    from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+    from typing import Any, DefaultDict, Dict, Iterable, List, Mapping, Optional, Text, Tuple, Union
 
     import attr  # vendor:skip
 
@@ -183,7 +193,7 @@ class Repo(object):
             location=data["location"], scopes=tuple(Scope.parse(scope) for scope in data["scopes"])
         )
 
-    location = attr.ib()  # type: str
+    location = attr.ib()  # type: Text
     scopes = attr.ib(default=())  # type: Tuple[Scope, ...]
 
     def as_dict(self):
@@ -240,8 +250,8 @@ class PackageRepositories(object):
     _target_env = attr.ib()  # type: Union[Dict[str, str], MarkerEnv]
     _scoped_indexes = attr.ib(default=())  # type: Tuple[Repo, ...]
     _scoped_find_links = attr.ib(default=())  # type: Tuple[Repo, ...]
-    global_indexes = attr.ib(default=(Repo(PYPI),))  # type: Tuple[str, ...]
-    global_find_links = attr.ib(default=())  # type: Tuple[str, ...]
+    global_indexes = attr.ib(default=(Repo(PYPI),))  # type: Tuple[Text, ...]
+    global_find_links = attr.ib(default=())  # type: Tuple[Text, ...]
 
     @property
     def has_scoped_repositories(self):
@@ -266,7 +276,7 @@ class PackageRepositories(object):
         scoped_repos,  # type: Iterable[Repo]
         project_name,  # type: ProjectName
     ):
-        # type: (...) -> List[str]
+        # type: (...) -> List[Text]
         return [
             repo.location
             for repo in scoped_repos
@@ -274,11 +284,11 @@ class PackageRepositories(object):
         ]
 
     def in_scope_indexes(self, project_name):
-        # type: (ProjectName) -> List[str]
+        # type: (ProjectName) -> List[Text]
         return self._in_scope_repos(scoped_repos=self._scoped_indexes, project_name=project_name)
 
     def in_scope_find_links(self, project_name):
-        # type: (ProjectName) -> List[str]
+        # type: (ProjectName) -> List[Text]
         return self._in_scope_repos(scoped_repos=self._scoped_find_links, project_name=project_name)
 
 
@@ -289,6 +299,7 @@ class ReposConfiguration(object):
         cls,
         indexes=(),  # type: Iterable[Repo]
         find_links=(),  # type: Iterable[Repo]
+        derive_scopes_from_requirements_files=False,  # type: bool
     ):
         # type: (...) -> ReposConfiguration
         password_entries = []
@@ -301,20 +312,73 @@ class ReposConfiguration(object):
             index_repos=tuple(indexes),
             find_links_repos=tuple(find_links),
             password_entries=tuple(password_entries),
+            derive_scopes_from_requirements_files=derive_scopes_from_requirements_files,
         )
 
     index_repos = attr.ib(default=(Repo(PYPI),))  # type: Tuple[Repo, ...]
     find_links_repos = attr.ib(default=())  # type: Tuple[Repo, ...]
     password_entries = attr.ib(default=())  # type: Tuple[PasswordEntry, ...]
+    derive_scopes_from_requirements_files = attr.ib(default=False)  # type: bool
+
+    def with_contained_repos(self, requirement_files=None):
+        # type: (Optional[Iterable[Text]]) -> ReposConfiguration
+
+        if not requirement_files:
+            return self
+
+        indexes_by_source = OrderedDict()  # type: OrderedDict[Text, OrderedSet[Text]]
+        find_links_by_source = OrderedDict()  # type: OrderedDict[Text, OrderedSet[Text]]
+        scopes_by_source = defaultdict(OrderedSet)  # type: DefaultDict[Text, OrderedSet[Scope]]
+        for item in itertools.chain.from_iterable(
+            parse_requirement_file(requirement_file) for requirement_file in requirement_files
+        ):
+            if self.derive_scopes_from_requirements_files and isinstance(
+                item, (PyPIRequirement, URLRequirement, VCSRequirement)
+            ):
+                scopes_by_source[item.line.source].add(
+                    Scope(project=item.requirement.project_name, marker=item.requirement.marker)
+                )
+            elif isinstance(item, FindLinks):
+                find_links_by_source.setdefault(item.line.source, OrderedSet()).add(item.location)
+            elif isinstance(item, Index):
+                indexes_by_source.setdefault(item.line.source, OrderedSet()).add(item.location)
+
+        if not indexes_by_source and not find_links_by_source:
+            return self
+
+        def merge_scopes(
+            repos,  # type: Iterable[Repo]
+            locations_by_source,  # type: Mapping[Text, Iterable[Text]]
+        ):
+            scopes_by_location = OrderedDict(
+                (repo.location, OrderedSet(repo.scopes)) for repo in repos
+            )
+            for source, locations in locations_by_source.items():
+                for location in locations:
+                    scopes_by_location.setdefault(location, OrderedSet()).update(
+                        scopes_by_source[source]
+                    )
+            return tuple(
+                Repo(location=location, scopes=tuple(scopes))
+                for location, scopes in scopes_by_location.items()
+            )
+
+        return attr.evolve(
+            self,
+            index_repos=merge_scopes(repos=self.index_repos, locations_by_source=indexes_by_source),
+            find_links_repos=merge_scopes(
+                repos=self.find_links_repos, locations_by_source=find_links_by_source
+            ),
+        )
 
     @property
     def indexes(self):
-        # type: () -> Tuple[str, ...]
+        # type: () -> Tuple[Text, ...]
         return tuple(repo.location for repo in self.index_repos if not repo.scopes)
 
     @property
     def find_links(self):
-        # type: () -> Tuple[str, ...]
+        # type: () -> Tuple[Text, ...]
         return tuple(repo.location for repo in self.find_links_repos if not repo.scopes)
 
     def scoped(self, target_env):

--- a/pex/resolve/requirement_configuration.py
+++ b/pex/resolve/requirement_configuration.py
@@ -5,7 +5,15 @@ from __future__ import absolute_import
 
 from pex.fetcher import URLFetcher
 from pex.network_configuration import NetworkConfiguration
-from pex.requirements import Constraint, parse_requirement_file, parse_requirement_strings
+from pex.requirements import (
+    Constraint,
+    LocalProjectRequirement,
+    PyPIRequirement,
+    URLRequirement,
+    VCSRequirement,
+    parse_requirement_file,
+    parse_requirement_strings,
+)
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -37,7 +45,10 @@ class RequirementConfiguration(object):
                     for requirement_or_constraint in parse_requirement_file(
                         requirement_file, is_constraints=False, fetcher=fetcher
                     )
-                    if not isinstance(requirement_or_constraint, Constraint)
+                    if isinstance(
+                        requirement_or_constraint,
+                        (PyPIRequirement, URLRequirement, VCSRequirement, LocalProjectRequirement),
+                    )
                 )
         return parsed_requirements
 

--- a/pex/resolve/resolver_options.py
+++ b/pex/resolve/resolver_options.py
@@ -574,6 +574,17 @@ def register_repos_options(parser):
             "in a scope, you can use a regex instead."
         ),
     )
+    parser.add_argument(
+        "--derive-sources-from-requirements-files",
+        dest="derive_scopes_from_requirements_files",
+        action=HandleBoolAction,
+        default=False,
+        help=(
+            "If any requirements files are specified that contain `-f` / `--find-links`, `-i` / "
+            "`--index-url`, or `--extra-index-url` options, automatically map these repos as the "
+            "`--source` for the requirements (if any) declared in that same requirements file."
+        ),
+    )
 
 
 def register_network_options(parser):
@@ -871,6 +882,7 @@ def create_repos_configuration(options):
         return ReposConfiguration.create(
             indexes=tuple(indexes),
             find_links=tuple(Repo(find_links_repo) for find_links_repo in options.find_links),
+            derive_scopes_from_requirements_files=options.derive_scopes_from_requirements_files,
         )
 
     parsed_indexes = _parse_package_repositories("index", scopes_by_name, options.indexes)
@@ -890,7 +902,9 @@ def create_repos_configuration(options):
 
     indexes.update(parsed_indexes.values())
     return ReposConfiguration.create(
-        indexes=tuple(indexes), find_links=tuple(parsed_find_links.values())
+        indexes=tuple(indexes),
+        find_links=tuple(parsed_find_links.values()),
+        derive_scopes_from_requirements_files=options.derive_scopes_from_requirements_files,
     )
 
 

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.57.0"
+__version__ = "2.58.0"

--- a/tests/integration/cli/commands/test_export_subset.py
+++ b/tests/integration/cli/commands/test_export_subset.py
@@ -10,7 +10,7 @@ import pytest
 from pex import requirements
 from pex.compatibility import to_unicode
 from pex.dist_metadata import Requirement
-from pex.requirements import LocalProjectRequirement, Source
+from pex.requirements import FindLinks, Index, LocalProjectRequirement, Source
 from pex.typing import TYPE_CHECKING
 from testing.cli import run_pex3
 
@@ -44,7 +44,7 @@ def test_full(
 
     actual_requirements = []
     for parsed_requirement in requirements.parse_requirements(Source.from_text(export_subset)):
-        assert not isinstance(parsed_requirement, LocalProjectRequirement)
+        assert not isinstance(parsed_requirement, (LocalProjectRequirement, FindLinks, Index))
         actual_requirements.append(parsed_requirement.requirement)
 
     expected_requirements = [


### PR DESCRIPTION
This allows scoping requirement sources via the structure of
requirements files. If any requirements files are specified that contain
`-f` / `--find-links`, `-i` / `--index-url`, or `--extra-index-url`
options, `--derive-sources-from-requirements-files` will automatically
map these repos as the `--source` for the requirements (if any) declared
in the same requirements file.

This may help with issues like:
  https://github.com/pantsbuild/pants/issues/22581