### PR TITLE
Add support for `--venv-repository` resolver.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## 2.59.0
+
+This release adds support for a `--venv-repository` resolution source. This allows creating a PEX
+from a pre-existing venv. By default, all installed venv distributions are included in the PEX, but
+by specifying requirements, the venv can be subset. The `--venv-repository` source is also supported
+by `pex3 venv create` allowing subsetting an existing venv directly into a new venv as well.
+
+* Add support for `--venv-repository` resolver. (#2916)
+
 ## 2.58.1
 
 This release fixes a bug building source distributions from locks of local project directories when

--- a/pex/bin/pex.py
+++ b/pex/bin/pex.py
@@ -144,6 +144,7 @@ def configure_clp_pex_resolution(parser):
         include_pex_lock=True,
         include_pylock=True,
         include_pre_resolved=True,
+        include_venv_repository=True,
     )
 
     group.add_argument(

--- a/pex/cli/commands/venv.py
+++ b/pex/cli/commands/venv.py
@@ -8,7 +8,7 @@ import logging
 import os.path
 from argparse import ArgumentParser, _ActionsContainer
 
-from pex import pex_warnings
+from pex import dependency_configuration, pex_warnings
 from pex.cli.command import BuildTimeCommand
 from pex.commands.command import JsonMixin, OutputMixin
 from pex.common import CopyMode, open_zip, pluralize
@@ -123,8 +123,10 @@ class Venv(OutputMixin, JsonMixin, BuildTimeCommand):
             include_pex_lock=True,
             include_pylock=True,
             include_pre_resolved=True,
+            include_venv_repository=True,
         )
         requirement_options.register(parser)
+        dependency_configuration.register(parser)
 
     @classmethod
     def add_extra_arguments(
@@ -285,11 +287,13 @@ class Venv(OutputMixin, JsonMixin, BuildTimeCommand):
                 )
 
         requirement_configuration = requirement_options.configure(self.options)
+        dependency_config = dependency_configuration.configure(self.options)
         with TRACER.timed("Resolving distributions"):
             resolved = configured_resolve.resolve(
                 targets=targets,
                 requirement_configuration=requirement_configuration,
                 resolver_configuration=resolver_configuration,
+                dependency_configuration=dependency_config,
             )
 
         pex = None  # type: Optional[PEX]

--- a/pex/dependency_configuration.py
+++ b/pex/dependency_configuration.py
@@ -141,8 +141,12 @@ class DependencyConfiguration(object):
         # type: (Requirement) -> Tuple[Requirement, ...]
         return self.overridden.get(requirement.project_name, ())
 
-    def overridden_by(self, requirement, target):
-        # type: (Requirement, Target) -> Optional[Requirement]
+    def overridden_by(
+        self,
+        requirement,  # type: Requirement
+        target,  # type: Target
+    ):
+        # type: (...) -> Optional[Requirement]
         overrides = self.overrides_for(requirement)
         applicable_overrides = [
             override for override in overrides if target.requirement_applies(override)

--- a/pex/dist_metadata.py
+++ b/pex/dist_metadata.py
@@ -210,6 +210,15 @@ class MetadataKey(object):
     location = attr.ib()  # type: Text
 
 
+def _read_function(
+    location,  # type: Text
+    rel_path,  # type: Text
+):
+    # type: (...) -> bytes
+    with open(os.path.join(location, rel_path), "rb") as fp:
+        return fp.read()
+
+
 def _find_installed_metadata_files(
     location,  # type: Text
     metadata_type,  # type: MetadataType.Value
@@ -218,17 +227,13 @@ def _find_installed_metadata_files(
 ):
     # type: (...) -> Iterator[MetadataFiles]
     metadata_files = glob.glob(os.path.join(location, metadata_dir_glob, metadata_file_name))
+    read_function = functools.partial(_read_function, location)
     for path in metadata_files:
         with open(path, "rb") as fp:
             metadata = parse_message(fp.read())
             project_name_and_version = ProjectNameAndVersion.from_parsed_pkg_info(
                 source=path, pkg_info=metadata
             )
-
-            def read_function(rel_path):
-                # type: (Text) -> bytes
-                with open(os.path.join(location, rel_path), "rb") as fp:
-                    return fp.read()
 
             yield MetadataFiles(
                 metadata=DistMetadataFile(

--- a/pex/dist_metadata.py
+++ b/pex/dist_metadata.py
@@ -152,14 +152,23 @@ class DistMetadataFile(object):
     version = attr.ib()  # type: Version
     pkg_info = attr.ib(eq=False)  # type: Message
 
-    def render_description(self):
-        # type: () -> str
+    def render_metadata_file_description(self, metadata_file_rel_path):
+        # type: (Text) -> str
         return "{project_name} {version} metadata from {rel_path} at {location}".format(
             project_name=self.project_name,
             version=self.version,
-            rel_path=self.rel_path,
+            rel_path=metadata_file_rel_path,
             location=self.location,
         )
+
+    def render_description(self):
+        # type: () -> str
+        return self.render_metadata_file_description(self.rel_path)
+
+    @property
+    def path(self):
+        # type: () -> Text
+        return os.path.join(self.location, self.rel_path)
 
 
 @attr.s(frozen=True)
@@ -181,6 +190,14 @@ class MetadataFiles(object):
         if rel_path is None or self._read_function is None:
             return None
         return self._read_function(rel_path)
+
+    def render_description(self, metadata_file_name):
+        # type: (Text) -> str
+        rel_path = self.metadata_file_rel_path(metadata_file_name)
+        return self.metadata.render_metadata_file_description(
+            rel_path
+            or "{metadata_file_name} not found".format(metadata_file_name=metadata_file_name)
+        )
 
 
 class MetadataType(Enum["MetadataType.Value"]):

--- a/pex/environment.py
+++ b/pex/environment.py
@@ -66,6 +66,22 @@ def _import_pkg_resources():
             return None, False
 
 
+def _fd_lt(
+    self,  # type: FingerprintedDistribution
+    other,  # type: FingerprintedDistribution
+):
+    # type: (...) -> bool
+    if self.project_name.normalized < other.project_name.normalized:
+        return True
+
+    # Since we want to rank higher versions higher (earlier) we need to reverse the natural
+    # ordering of Version in Distribution which is least to greatest.
+    if self.distribution.metadata.version >= other.distribution.metadata.version:
+        return True
+
+    return self.fingerprint < other.fingerprint
+
+
 @attr.s(frozen=True)
 class _RankedDistribution(object):
     # N.B.: A distribution implements rich comparison with the leading component being the
@@ -77,9 +93,7 @@ class _RankedDistribution(object):
     # The attr project type stub file simply misses this.
     _fd_cmp = attr.cmp_using(  # type: ignore[attr-defined]
         eq=FingerprintedDistribution.__eq__,
-        # Since we want to rank higher versions higher (earlier) we need to reverse the natural
-        # ordering of Version in Distribution which is least to greatest.
-        lt=FingerprintedDistribution.__ge__,
+        lt=_fd_lt,
     )
 
     @classmethod

--- a/pex/pep_425.py
+++ b/pex/pep_425.py
@@ -70,9 +70,11 @@ class CompatibilityTags(object):
         # type: (Union[Text, Distribution]) -> CompatibilityTags
 
         if isinstance(wheel, Distribution):
-            return cls(tags=WHEEL.from_distribution(wheel).tags)
+            if not is_wheel(wheel.location):
+                return cls(tags=WHEEL.from_distribution(wheel).tags)
+            wheel = wheel.location
 
-        elif not is_wheel(wheel):
+        if not is_wheel(wheel):
             raise ValueError(
                 "Can only calculate wheel tags from a filename that ends in .whl per "
                 "https://peps.python.org/pep-0427/#file-name-convention, given: {wheel!r}".format(

--- a/pex/pep_427.py
+++ b/pex/pep_427.py
@@ -9,20 +9,23 @@ import re
 import shutil
 import subprocess
 import sys
+import zipfile
 from contextlib import closing
 from fileinput import FileInput
 from textwrap import dedent
 
 from pex import pex_warnings, windows
-from pex.common import is_pyc_file, iter_copytree, open_zip, safe_open, touch
+from pex.common import is_pyc_file, iter_copytree, open_zip, safe_mkdir, safe_open, touch
 from pex.compatibility import commonpath, get_stdout_bytes_buffer, safe_commonpath
 from pex.dist_metadata import (
     CallableEntryPoint,
+    DistMetadata,
     Distribution,
+    MetadataFiles,
     NamedEntryPoint,
-    ProjectNameAndVersion,
 )
 from pex.enum import Enum
+from pex.exceptions import reportable_unexpected_error_msg
 from pex.executables import chmod_plus_x
 from pex.interpreter import PythonInterpreter
 from pex.os import WINDOWS
@@ -43,6 +46,7 @@ if TYPE_CHECKING:
         Optional,
         Text,
         Tuple,
+        Union,
     )
 
     import attr  # vendor:skip
@@ -119,29 +123,106 @@ class InstallPaths(object):
         raise KeyError("Not a known install path: {item}".format(item=item))
 
 
+@attr.s(frozen=True)
+class InstallableWheel(object):
+    @classmethod
+    def from_installation(
+        cls,
+        interpreter,  # type: PythonInterpreter
+        distribution,  # type: Distribution
+    ):
+        # type: (...) -> InstallableWheel
+        return cls(
+            wheel=Wheel.from_distribution(distribution),
+            install_paths=InstallPaths.interpreter(interpreter),
+        )
+
+    @classmethod
+    def from_whl(cls, whl):
+        # type: (str) -> InstallableWheel
+        return cls(wheel=Wheel.load(whl))
+
+    wheel = attr.ib()  # type: Wheel
+    is_whl = attr.ib(init=False)  # type: bool
+    install_paths = attr.ib(default=None)  # type: Optional[InstallPaths]
+
+    def __attrs_post_init__(self):
+        is_whl = zipfile.is_zipfile(self.wheel.location)
+
+        if is_whl and self.install_paths:
+            # TODO: XXX
+            raise ValueError("TODO: XXX")
+
+        if not is_whl and not self.install_paths:
+            # TODO: XXX
+            raise ValueError("TODO: XXX")
+
+        object.__setattr__(self, "is_whl", is_whl)
+
+    @property
+    def location(self):
+        # type: () -> str
+        return self.wheel.location
+
+    @property
+    def source(self):
+        # type: () -> str
+        return self.wheel.source
+
+    @property
+    def metadata_files(self):
+        # type: () -> MetadataFiles
+        return self.wheel.metadata_files
+
+    @property
+    def root_is_purelib(self):
+        # type: () -> bool
+        return self.wheel.root_is_purelib
+
+    @property
+    def data_dir(self):
+        # type: () -> str
+        return self.wheel.data_dir
+
+    @property
+    def wheel_file_name(self):
+        # type: () -> str
+        return self.wheel.wheel_file_name
+
+    def dist_metadata(self):
+        # type: () -> DistMetadata
+        return self.wheel.dist_metadata()
+
+    def metadata_path(self, *components):
+        # type: (*str) -> str
+        return self.wheel.metadata_path(*components)
+
+
 class WheelInstallError(WheelError):
     """Indicates an error installing a `.whl` file."""
 
 
 def install_wheel_chroot(
-    wheel_path,  # type: str
+    wheel,  # type: Union[str, InstallableWheel]
     destination,  # type: str
     compile=False,  # type: bool
     requested=True,  # type: bool
 ):
     # type: (...) -> InstalledWheel
 
-    wheel = install_wheel(
-        wheel_path,
+    wheel_to_install = (
+        wheel if isinstance(wheel, InstallableWheel) else InstallableWheel.from_whl(wheel)
+    )
+    install_wheel(
+        wheel_to_install,
         InstallPaths.chroot(
-            destination,
-            project_name=ProjectNameAndVersion.from_filename(wheel_path).canonicalized_project_name,
+            destination, project_name=wheel_to_install.metadata_files.metadata.project_name
         ),
         compile=compile,
         requested=requested,
     )
 
-    record_relpath = wheel.metadata_files.metadata_file_rel_path("RECORD")
+    record_relpath = wheel_to_install.metadata_files.metadata_file_rel_path("RECORD")
     assert (
         record_relpath is not None
     ), "The {module}.install_wheel function should always create a RECORD.".format(module=__name__)
@@ -149,20 +230,23 @@ def install_wheel_chroot(
         prefix_dir=destination,
         stash_dir=InstallPaths.CHROOT_STASH,
         record_relpath=record_relpath,
-        root_is_purelib=wheel.root_is_purelib,
+        root_is_purelib=wheel_to_install.root_is_purelib,
     )
 
 
 def install_wheel_interpreter(
-    wheel_path,  # type: str
+    wheel,  # type: Union[str, InstallableWheel]
     interpreter,  # type: PythonInterpreter
     compile=True,  # type: bool
     requested=True,  # type: bool
 ):
-    # type: (...) -> Wheel
+    # type: (...) -> None
 
-    return install_wheel(
-        wheel_path,
+    wheel_to_install = (
+        wheel if isinstance(wheel, InstallableWheel) else InstallableWheel.from_whl(wheel)
+    )
+    install_wheel(
+        wheel_to_install,
         InstallPaths.interpreter(interpreter),
         interpreter=interpreter,
         compile=compile,
@@ -171,16 +255,15 @@ def install_wheel_interpreter(
 
 
 def install_wheel(
-    wheel_path,  # type: str
+    wheel,  # type: InstallableWheel
     install_paths,  # type: InstallPaths
     interpreter=None,  # type: Optional[PythonInterpreter]
     compile=False,  # type: bool
     requested=True,  # type: bool
 ):
-    # type: (...) -> Wheel
+    # type: (...) -> None
 
     # See: https://packaging.python.org/en/latest/specifications/binary-distribution-format/#installing-a-wheel-distribution-1-0-py32-none-any-whl
-    wheel = Wheel.load(wheel_path)
     dest = install_paths.purelib if wheel.root_is_purelib else install_paths.platlib
 
     record_relpath = wheel.metadata_path("RECORD")
@@ -203,68 +286,125 @@ def install_wheel(
                 continue
             file_abspath = os.path.join(root_dir, name)
             if record_relpath == name:
-                # We'll generate a new RECORD below.
+                # We'll generate a new RECORD below as needed.
                 os.unlink(file_abspath)
                 continue
             installed_files.append(
                 InstalledWheel.create_installed_file(path=file_abspath, dest_dir=dest)
             )
 
-    with open_zip(wheel_path) as zf:
-        zf.extractall(dest)
-        # TODO(John Sirois): Consider verifying signatures.
-        # N.B.: Pip does not and its also not clear what good this does. A zip can be easily poked
-        # on a per-entry basis allowing forging a RECORD entry and its associated file. Only an
-        # outer fingerprint of the whole wheel really solves this sort of tampering.
-        record_files(
-            root_dir=dest,
-            names=[
-                name
-                for name in zf.namelist()
-                if not name.endswith("/")
-                and data_rel_path != safe_commonpath((data_rel_path, name))
-            ],
-        )
-        if os.path.isdir(data_path):
-            for entry in sorted(os.listdir(data_path)):
-                try:
-                    dest_dir = install_paths[entry]
-                except KeyError as e:
-                    raise WheelInstallError(
-                        "The wheel at {wheel_path} is invalid and cannot be installed: "
-                        "{err}".format(wheel_path=wheel_path, err=e)
-                    )
-                entry_path = os.path.join(data_path, entry)
-                copied = [dst for _, dst in iter_copytree(entry_path, dest_dir)]
-                if copied and "scripts" == entry:
-                    for script in copied:
-                        chmod_plus_x(script)
-                    if interpreter:
-                        with closing(FileInput(files=copied, inplace=True, mode="rb")) as script_fi:
-                            for line in cast("Iterator[bytes]", script_fi):
-                                buffer = get_stdout_bytes_buffer()
-                                if script_fi.isfirstline() and re.match(br"^#!pythonw?", line):
-                                    _, _, shebang_args = line.partition(b" ")
-                                    buffer.write(
-                                        "{shebang}\n".format(
-                                            shebang=interpreter.shebang(
-                                                args=shebang_args.decode("utf-8")
-                                            )
-                                        ).encode("utf-8")
-                                    )
-                                else:
-                                    # N.B.: These lines include the newline already.
-                                    buffer.write(cast(bytes, line))
+    if wheel.is_whl:
+        with open_zip(wheel.location) as zf:
+            # 1. Unpack
+            zf.extractall(dest)
+            # TODO(John Sirois): Consider verifying signatures.
+            # N.B.: Pip does not and its also not clear what good this does. A zip can be easily
+            # poked on a per-entry basis allowing forging a RECORD entry and its associated file.
+            # Only an outer fingerprint of the whole wheel really solves this sort of tampering.
+            record_files(
+                root_dir=dest,
+                names=[
+                    name
+                    for name in zf.namelist()
+                    if not name.endswith("/")
+                    and data_rel_path != safe_commonpath((data_rel_path, name))
+                ],
+            )
+            if os.path.isdir(data_path):
+                # 2. Spread
+                for entry in sorted(os.listdir(data_path)):
+                    try:
+                        dest_dir = install_paths[entry]
+                    except KeyError as e:
+                        raise WheelInstallError(
+                            "The wheel at {wheel_path} is invalid and cannot be installed: "
+                            "{err}".format(wheel_path=wheel.source, err=e)
+                        )
+                    entry_path = os.path.join(data_path, entry)
+                    copied = [dst for _, dst in iter_copytree(entry_path, dest_dir)]
+                    if copied and "scripts" == entry:
+                        for script in copied:
+                            chmod_plus_x(script)
+                        if interpreter:
+                            with closing(
+                                FileInput(files=copied, inplace=True, mode="rb")
+                            ) as script_fi:
+                                for line in cast("Iterator[bytes]", script_fi):
+                                    buffer = get_stdout_bytes_buffer()
+                                    if script_fi.isfirstline() and re.match(br"^#!pythonw?", line):
+                                        _, _, shebang_args = line.partition(b" ")
+                                        buffer.write(
+                                            "{shebang}\n".format(
+                                                shebang=interpreter.shebang(
+                                                    args=shebang_args.decode("utf-8")
+                                                )
+                                            ).encode("utf-8")
+                                        )
+                                    else:
+                                        # N.B.: These lines include the newline already.
+                                        buffer.write(cast(bytes, line))
 
-                record_files(
-                    root_dir=dest_dir,
-                    names=[
-                        os.path.relpath(os.path.join(root, f), entry_path)
-                        for root, _, files in os.walk(entry_path)
-                        for f in files
-                    ],
+                    record_files(
+                        root_dir=dest_dir,
+                        names=[
+                            os.path.relpath(os.path.join(root, f), entry_path)
+                            for root, _, files in os.walk(entry_path)
+                            for f in files
+                        ],
+                    )
+                shutil.rmtree(data_path)
+    elif wheel.install_paths:
+        record_data = wheel.metadata_files.read("RECORD")
+        if not record_data:
+            # TODO: XXX
+            raise WheelInstallError("TODO: XXX")
+        for installed_file in Record.read(iter(record_data.decode("utf-8").splitlines())):
+            if installed_file.path == record_relpath:
+                # We'll generate a new RECORD below as needed.
+                continue
+            src_file = os.path.realpath(os.path.join(wheel.location, installed_file.path))
+            dst_file = os.path.realpath(os.path.join(dest, installed_file.path))
+            if dest == commonpath((dest, dst_file)):
+                safe_mkdir(os.path.dirname(dst_file))
+                shutil.copy(src_file, dst_file)
+                installed_files.append(installed_file)
+                continue
+
+            if wheel.install_paths.scripts == commonpath((wheel.install_paths.scripts, src_file)):
+                dst_file = os.path.join(
+                    install_paths.scripts, os.path.relpath(src_file, wheel.install_paths.scripts)
                 )
-            shutil.rmtree(data_path)
+            elif wheel.install_paths.platlib == commonpath((wheel.install_paths.platlib, src_file)):
+                dst_file = os.path.join(
+                    install_paths.platlib, os.path.relpath(src_file, wheel.install_paths.platlib)
+                )
+            elif wheel.install_paths.purelib == commonpath((wheel.install_paths.purelib, src_file)):
+                dst_file = os.path.join(
+                    install_paths.purelib, os.path.relpath(src_file, wheel.install_paths.purelib)
+                )
+            elif wheel.install_paths.headers == commonpath((wheel.install_paths.headers, src_file)):
+                dst_file = os.path.join(
+                    install_paths.headers, os.path.relpath(src_file, wheel.install_paths.headers)
+                )
+            elif wheel.install_paths.data == commonpath((wheel.install_paths.data, src_file)):
+                dst_file = os.path.join(
+                    install_paths.data, os.path.relpath(src_file, wheel.install_paths.data)
+                )
+            else:
+                # TODO: XXX
+                raise WheelInstallError("TODO: XXX")
+
+            safe_mkdir(os.path.dirname(dst_file))
+            shutil.copy(src_file, dst_file)
+            installed_files.append(
+                InstalledFile(
+                    path=os.path.relpath(dst_file, dest),
+                    hash=installed_file.hash,
+                    size=installed_file.size,
+                )
+            )
+    else:
+        raise AssertionError(reportable_unexpected_error_msg())
 
     if compile:
         args = [
@@ -285,7 +425,7 @@ def install_wheel(
         if process.returncode != 0:
             pex_warnings.warn(
                 "Failed to compile some .py files for install of {wheel} to {dest}:\n"
-                "{stderr}".format(wheel=wheel_path, dest=dest, stderr=stderr.decode("utf-8"))
+                "{stderr}".format(wheel=wheel.source, dest=dest, stderr=stderr.decode("utf-8"))
             )
         for root, _, files in os.walk(commonpath(py_files)):
             for f in files:
@@ -315,8 +455,6 @@ def install_wheel(
 
         installed_files.append(InstalledFile(path=record_relpath, hash=None, size=None))
         Record.write(dst=record_abspath, installed_files=installed_files)
-
-    return wheel
 
 
 def install_scripts(

--- a/pex/pip/installation.py
+++ b/pex/pip/installation.py
@@ -221,7 +221,7 @@ def _install_wheel(wheel_path):
     with atomic_directory(installed_wheel_dir) as atomic_dir:
         if not atomic_dir.is_finalized():
             installed_wheel = pep_427.install_wheel_chroot(
-                wheel_path=wheel_path, destination=atomic_dir.work_dir
+                wheel=wheel_path, destination=atomic_dir.work_dir
             )
             runtime_key_dir = InstalledWheelDir.create(
                 wheel_name=wheel_name,

--- a/pex/pip/tool.py
+++ b/pex/pip/tool.py
@@ -750,7 +750,7 @@ class Pip(object):
                     build_configuration=BuildConfiguration.create(allow_builds=False),
                 ).wait()
                 for wheel in glob.glob(os.path.join(atomic_dir.work_dir, "*.whl")):
-                    install_wheel_interpreter(wheel_path=wheel, interpreter=pip_interpreter)
+                    install_wheel_interpreter(wheel=wheel, interpreter=pip_interpreter)
 
     def spawn_build_wheels(
         self,

--- a/pex/resolve/configured_resolve.py
+++ b/pex/resolve/configured_resolve.py
@@ -17,8 +17,10 @@ from pex.resolve.resolver_configuration import (
     PexRepositoryConfiguration,
     PreResolvedConfiguration,
     PylockRepositoryConfiguration,
+    VenvRepositoryConfiguration,
 )
 from pex.resolve.resolvers import ResolveResult
+from pex.resolve.venv_resolver import resolve_from_venv
 from pex.resolver import resolve as resolve_via_pip
 from pex.result import try_
 from pex.targets import Targets
@@ -138,6 +140,24 @@ def resolve(
                 ignore_errors=ignore_errors,
                 result_type=result_type,
                 dependency_configuration=dependency_configuration,
+            )
+    elif isinstance(resolver_configuration, VenvRepositoryConfiguration):
+        with TRACER.timed(
+            "Resolving requirements from venv at {venv}.".format(
+                venv=resolver_configuration.venv.venv_dir
+            )
+        ):
+            return try_(
+                resolve_from_venv(
+                    targets=targets,
+                    venv=resolver_configuration.venv,
+                    requirement_configuration=requirement_configuration,
+                    pip_configuration=resolver_configuration.pip_configuration,
+                    compile=compile_pyc,
+                    ignore_errors=ignore_errors,
+                    result_type=result_type,
+                    dependency_configuration=dependency_configuration,
+                )
             )
     else:
         with TRACER.timed("Resolving requirements."):

--- a/pex/resolve/configured_resolver.py
+++ b/pex/resolve/configured_resolver.py
@@ -58,20 +58,24 @@ class ConfiguredResolver(Resolver):
         transitive=None,  # type: Optional[bool]
         extra_resolver_requirements=None,  # type: Optional[Tuple[Requirement, ...]]
         result_type=InstallableType.INSTALLED_WHEEL_CHROOT,  # type: InstallableType.Value
+        constraint_files=None,  # type: Optional[Iterable[str]]
+        compile=False,  # type: bool
+        ignore_errors=False,  # type: bool
     ):
         # type: (...) -> ResolveResult
         return resolver.resolve(
             targets=targets,
             requirements=requirements,
-            allow_prereleases=False,
+            constraint_files=constraint_files,
+            allow_prereleases=self.pip_configuration.allow_prereleases,
             transitive=transitive if transitive is not None else self.pip_configuration.transitive,
             repos_configuration=self.pip_configuration.repos_configuration,
             resolver_version=self.pip_configuration.resolver_version,
             network_configuration=self.pip_configuration.network_configuration,
             build_configuration=self.pip_configuration.build_configuration,
-            compile=False,
+            compile=compile,
             max_parallel_jobs=self.pip_configuration.max_jobs,
-            ignore_errors=False,
+            ignore_errors=ignore_errors,
             verify_wheels=True,
             pip_version=pip_version or self.pip_configuration.version,
             resolver=self,

--- a/pex/resolve/pex_repository_resolver.py
+++ b/pex/resolve/pex_repository_resolver.py
@@ -80,7 +80,7 @@ def resolve_from_pex(
     distributions = OrderedSet()  # type: OrderedSet[ResolvedDistribution]
     for target in targets.unique_targets():
         # TODO(John Sirois): Handling of result type should be centralized. As it stands, it's
-        #  currently critical to _not_ PEXEnvironment.mount(...) if you want to resolve whell files
+        #  currently critical to _not_ PEXEnvironment.mount(...) if you want to resolve wheel files
         #  instead of installed wheel chroots.
         pex_env = (
             PEXEnvironment(pex, target=target)

--- a/pex/resolve/resolver_configuration.py
+++ b/pex/resolve/resolver_configuration.py
@@ -12,6 +12,7 @@ from pex.pep_503 import ProjectName
 from pex.pip.version import PipVersion, PipVersionValue
 from pex.resolve.package_repository import ReposConfiguration
 from pex.typing import TYPE_CHECKING
+from pex.venv.virtualenv import Virtualenv
 
 if TYPE_CHECKING:
     from typing import Callable, FrozenSet, Iterable, Optional, Tuple, Union
@@ -235,6 +236,22 @@ class PylockRepositoryConfiguration(object):
 class PreResolvedConfiguration(object):
     sdists = attr.ib()  # type: Tuple[str, ...]
     wheels = attr.ib()  # type: Tuple[str, ...]
+    pip_configuration = attr.ib()  # type: PipConfiguration
+
+    @property
+    def repos_configuration(self):
+        # type: () -> ReposConfiguration
+        return self.pip_configuration.repos_configuration
+
+    @property
+    def network_configuration(self):
+        # type: () -> NetworkConfiguration
+        return self.pip_configuration.network_configuration
+
+
+@attr.s(frozen=True)
+class VenvRepositoryConfiguration(object):
+    venv = attr.ib()  # type: Virtualenv
     pip_configuration = attr.ib()  # type: PipConfiguration
 
     @property

--- a/pex/resolve/resolver_options.py
+++ b/pex/resolve/resolver_options.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import glob
 import os
+import sys
 import tempfile
 from argparse import Action, ArgumentError, ArgumentTypeError, Namespace, _ActionsContainer
 from collections import OrderedDict, defaultdict
@@ -16,6 +17,7 @@ from pex.dist_metadata import Requirement, is_sdist, is_wheel
 from pex.fetcher import initialize_ssl_context
 from pex.network_configuration import NetworkConfiguration
 from pex.orderedset import OrderedSet
+from pex.os import is_exe
 from pex.pep_503 import ProjectName
 from pex.pip.version import PipVersion, PipVersionValue
 from pex.resolve.lockfile import json_codec
@@ -31,30 +33,15 @@ from pex.resolve.resolver_configuration import (
     PreResolvedConfiguration,
     PylockRepositoryConfiguration,
     ResolverVersion,
+    VenvRepositoryConfiguration,
 )
 from pex.result import Error
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING, cast
+from pex.venv.virtualenv import Virtualenv
 
 if TYPE_CHECKING:
     from typing import DefaultDict, Iterable, List, Mapping, Optional, Tuple, Union
-
-
-class _ManylinuxAction(Action):
-    def __init__(self, *args, **kwargs):
-        kwargs["nargs"] = "?"
-        super(_ManylinuxAction, self).__init__(*args, **kwargs)
-
-    def __call__(self, parser, namespace, value, option_str=None):
-        if option_str.startswith("--no"):
-            setattr(namespace, self.dest, None)
-        elif value.startswith("manylinux"):
-            setattr(namespace, self.dest, value)
-        else:
-            raise ArgumentTypeError(
-                "Please specify a manylinux standard; ie: --manylinux=manylinux1. "
-                "Given {}".format(value)
-            )
 
 
 class _HandleTransitiveAction(Action):
@@ -66,12 +53,54 @@ class _HandleTransitiveAction(Action):
         setattr(namespace, self.dest, option_str == "--transitive")
 
 
+class _ResolveVenvAction(Action):
+    def __init__(self, *args, **kwargs):
+        kwargs["nargs"] = "?"
+        super(_ResolveVenvAction, self).__init__(*args, **kwargs)
+
+    def __call__(self, parser, namespace, value, option_str=None):
+        if value:
+            if not os.path.exists(value):
+                raise ArgumentError(
+                    argument=self,
+                    message=(
+                        "The {option} {value} does not point to an existing path.".format(
+                            option=option_str, value=value
+                        )
+                    ),
+                )
+            venv = Virtualenv.enclosing(value) if is_exe(value) else Virtualenv(value)
+            if not venv:
+                raise ArgumentError(
+                    argument=self,
+                    message=(
+                        "The {option} {value} is not a valid virtual environment interpreter "
+                        "path.".format(option=option_str, value=value)
+                    ),
+                )
+            setattr(namespace, self.dest, venv)
+        else:
+            current_venv = Virtualenv.enclosing(python=sys.executable)
+            if not current_venv:
+                raise ArgumentError(
+                    argument=self,
+                    message=(
+                        "The {option} option was requested but Pex is not currently running from a "
+                        "venv to use as the implicit {option}. You'll need to specify the path to "
+                        "a virtual environment directory or virtual environment interpreter as an "
+                        "argument.".format(option=option_str)
+                    ),
+                )
+            setattr(namespace, self.dest, current_venv)
+
+
 def register(
     parser,  # type: _ActionsContainer
     include_pex_repository=False,  # type: bool
     include_pex_lock=False,  # type: bool
     include_pylock=False,  # type: bool
     include_pre_resolved=False,  # type: bool
+    include_venv_repository=False,  # type: bool
 ):
     # type: (...) -> None
     """Register resolver configuration options with the given parser.
@@ -82,6 +111,7 @@ def register(
     :param include_pylock: Whether to include the `--pylock` / `--pep-751-lock` option.
     :param include_pre_resolved: Whether to include the `--pre-resolved-dist` and
                                  `--pre-resolved-dists` options.
+    :param include_venv_repository: Whether to include the `--venv-repository` option.
     """
 
     default_resolver_configuration = PipConfiguration()
@@ -192,6 +222,8 @@ def register(
         repository_types += 1
     if include_pre_resolved:
         repository_types += 1
+    if include_venv_repository:
+        repository_types += 1
 
     repository_choice = parser.add_mutually_exclusive_group() if repository_types > 1 else parser
     if include_pex_repository:
@@ -270,6 +302,14 @@ def register(
                 "This option can be used to add a pre-resolved dependency set to a PEX. By "
                 "default, Pex will ensure the dependencies added form a closure."
             ),
+        )
+    if include_venv_repository:
+        repository_choice.add_argument(
+            "--venv-repository",
+            dest="venv_repository",
+            action=_ResolveVenvAction,
+            # TODO: XXX
+            help="TODO: XXX",
         )
 
     parser.add_argument(
@@ -676,6 +716,7 @@ if TYPE_CHECKING:
         PipConfiguration,
         PreResolvedConfiguration,
         PylockRepositoryConfiguration,
+        VenvRepositoryConfiguration,
     ]
 
 
@@ -741,6 +782,18 @@ def configure(
                     sdists.append(dist)
         return PreResolvedConfiguration(
             sdists=tuple(sdists), wheels=tuple(wheels), pip_configuration=pip_configuration
+        )
+
+    venv = getattr(options, "venv_repository", None)
+    if venv:
+        return VenvRepositoryConfiguration(venv=venv, pip_configuration=pip_configuration)
+
+    if pylock:
+        return PylockRepositoryConfiguration(
+            lock_file_path=pylock,
+            extras=frozenset(options.pylock_extras),
+            dependency_groups=frozenset(options.pylock_dependency_groups),
+            pip_configuration=pip_configuration,
         )
 
     return pip_configuration

--- a/pex/resolve/resolvers.py
+++ b/pex/resolve/resolvers.py
@@ -255,6 +255,9 @@ class Resolver(object):
         transitive=None,  # type: Optional[bool]
         extra_resolver_requirements=None,  # type: Optional[Tuple[Requirement, ...]]
         result_type=InstallableType.INSTALLED_WHEEL_CHROOT,  # type: InstallableType.Value
+        constraint_files=None,  # type: Optional[Iterable[str]]
+        compile=False,  # type: bool
+        ignore_errors=False,  # type: bool
     ):
         # type: (...) -> ResolveResult
         raise NotImplementedError()

--- a/pex/resolve/target_options.py
+++ b/pex/resolve/target_options.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 import json
 import os.path
 import sys
-from argparse import ArgumentTypeError, Namespace, _ActionsContainer
+from argparse import Action, ArgumentTypeError, Namespace, _ActionsContainer
 
 from pex.argparse import HandleBoolAction
 from pex.interpreter_constraints import InterpreterConstraints
@@ -16,13 +16,29 @@ from pex.pep_508 import MarkerEnvironment
 from pex.platforms import Platform, PlatformSpec
 from pex.resolve import abbreviated_platforms
 from pex.resolve.resolver_configuration import PipConfiguration
-from pex.resolve.resolver_options import _ManylinuxAction
 from pex.resolve.target_configuration import InterpreterConfiguration, TargetConfiguration
 from pex.targets import CompletePlatform
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional
+
+
+class _ManylinuxAction(Action):
+    def __init__(self, *args, **kwargs):
+        kwargs["nargs"] = "?"
+        super(_ManylinuxAction, self).__init__(*args, **kwargs)
+
+    def __call__(self, parser, namespace, value, option_str=None):
+        if option_str.startswith("--no"):
+            setattr(namespace, self.dest, None)
+        elif value.startswith("manylinux"):
+            setattr(namespace, self.dest, value)
+        else:
+            raise ArgumentTypeError(
+                "Please specify a manylinux standard; ie: --manylinux=manylinux1. "
+                "Given {}".format(value)
+            )
 
 
 def register(

--- a/pex/resolve/venv_resolver.py
+++ b/pex/resolve/venv_resolver.py
@@ -1,0 +1,310 @@
+# Copyright 2025 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import functools
+import hashlib
+import itertools
+import os
+from collections import defaultdict, deque
+
+from pex import pex_warnings
+from pex.atomic_directory import atomic_directory
+from pex.cache.dirs import CacheDir, InstalledWheelDir
+from pex.common import safe_relative_symlink
+from pex.dependency_configuration import DependencyConfiguration
+from pex.dist_metadata import (
+    Distribution,
+    DistributionType,
+    MetadataType,
+    Requirement,
+    find_distribution,
+)
+from pex.exceptions import production_assert, reportable_unexpected_error_msg
+from pex.fingerprinted_distribution import FingerprintedDistribution
+from pex.jobs import DEFAULT_MAX_JOBS, iter_map_parallel
+from pex.orderedset import OrderedSet
+from pex.pep_376 import InstalledWheel
+from pex.pep_427 import InstallableType, InstallableWheel, InstallPaths, install_wheel_chroot
+from pex.pep_503 import ProjectName
+from pex.pip.version import PipVersion
+from pex.requirements import LocalProjectRequirement
+from pex.resolve.configured_resolver import ConfiguredResolver
+from pex.resolve.requirement_configuration import RequirementConfiguration
+from pex.resolve.resolver_configuration import PipConfiguration
+from pex.resolve.resolvers import ResolvedDistribution, Resolver, ResolveResult
+from pex.result import Error
+from pex.targets import LocalInterpreter, Target, Targets
+from pex.typing import TYPE_CHECKING
+from pex.venv.virtualenv import Virtualenv
+from pex.wheel import Wheel
+
+if TYPE_CHECKING:
+    from typing import DefaultDict, Deque, Iterable, Iterator, List, Set, Tuple, Union
+
+    import attr  # vendor:skip
+else:
+    import pex.third_party.attr as attr
+
+
+def _install_distribution(
+    venv_install_paths,  # type: InstallPaths
+    distribution,  # type: Distribution
+):
+    # type: (...) -> InstalledWheel
+
+    production_assert(distribution.type is DistributionType.INSTALLED)
+    production_assert(distribution.metadata.files.metadata.type is MetadataType.DIST_INFO)
+
+    wheel = InstallableWheel(
+        wheel=Wheel.from_distribution(distribution), install_paths=venv_install_paths
+    )
+    record_data = wheel.metadata_files.read("RECORD")
+    if not record_data:
+        raise AssertionError(
+            reportable_unexpected_error_msg(
+                "Distribution for {project_name} {version} installed at {location} "
+                "unexpectedly has no installation RECORD.",
+                project_name=distribution.project_name,
+                version=distribution.version,
+                location=distribution.location,
+            )
+        )
+
+    installed_wheel_dir = InstalledWheelDir.create(
+        wheel_name=wheel.wheel_file_name, install_hash=hashlib.sha256(record_data).hexdigest()
+    )
+    with atomic_directory(target_dir=installed_wheel_dir) as atomic_dir:
+        if not atomic_dir.is_finalized():
+            installed_wheel = install_wheel_chroot(
+                wheel,
+                atomic_dir.work_dir,
+            )
+            if not installed_wheel.fingerprint:
+                raise AssertionError(reportable_unexpected_error_msg())
+            runtime_key_dir = CacheDir.INSTALLED_WHEELS.path(installed_wheel.fingerprint)
+            with atomic_directory(runtime_key_dir) as symlink_atomic_dir:
+                if not atomic_dir.is_finalized():
+                    # Note: Create a relative path symlink between the two directories so that the
+                    # PEX_ROOT can be used within a chroot environment where the prefix of the path
+                    # may change between programs running inside and outside the chroot.
+                    safe_relative_symlink(
+                        installed_wheel_dir,
+                        os.path.join(symlink_atomic_dir.work_dir, wheel.wheel_file_name),
+                    )
+    return InstalledWheel.load(installed_wheel_dir)
+
+
+def _install_venv_distributions(
+    venv,  # type: Virtualenv
+    distributions,  # type: Iterable[Distribution]
+    compile=False,  # type: bool
+    ignore_errors=False,  # type: bool
+    max_install_jobs=DEFAULT_MAX_JOBS,  # type: int
+):
+    # type: (...) -> Iterator[FingerprintedDistribution]
+
+    venv_install_paths = InstallPaths.interpreter(venv.interpreter)
+    for installed_wheel in iter_map_parallel(
+        inputs=distributions,
+        function=functools.partial(_install_distribution, venv_install_paths),
+        max_jobs=max_install_jobs,
+    ):
+        if not installed_wheel.fingerprint:
+            raise AssertionError(reportable_unexpected_error_msg())
+        yield FingerprintedDistribution(
+            distribution=Distribution.load(installed_wheel.prefix_dir),
+            fingerprint=installed_wheel.fingerprint,
+        )
+
+
+def _resolve_distributions(
+    resolver,  # type: Resolver
+    target,  # type: Target
+    search_path,  # type: Iterable[str]
+    requirements,  # type: Iterable[Requirement]
+    allow_prereleases=False,  # type: bool
+    compile=False,  # type: bool
+    ignore_errors=False,  # type: bool
+):
+    # type: (...) -> Iterator[Union[Distribution, FingerprintedDistribution, Error]]
+
+    to_resolve = deque(
+        OrderedSet((requirement, ()) for requirement in requirements)
+    )  # type: Deque[Tuple[Requirement, Iterable[str]]]
+    resolved = set()  # type: Set[ProjectName]
+    while to_resolve:
+        requirement, extras = to_resolve.popleft()
+        if requirement.project_name in resolved:
+            continue
+
+        if not target.requirement_applies(requirement, extras=extras):
+            continue
+
+        distribution = find_distribution(requirement.project_name, search_path)
+        if not distribution:
+            # TODO: XXX
+            yield Error("TODO: XXX")
+        elif requirement.contains(distribution, prereleases=allow_prereleases):
+            production_assert(distribution.type is DistributionType.INSTALLED)
+            if distribution.metadata.files.metadata.type is not MetadataType.DIST_INFO:
+                result = resolver.resolve_requirements(
+                    requirements=[str(distribution.as_requirement())],
+                    targets=Targets.from_target(target),
+                    transitive=False,
+                )
+                resolved.add(requirement.project_name)
+                for dist in result.distributions:
+                    if not target.wheel_applies(dist.distribution):
+                        # TODO: XXX
+                        yield Error("TODO: XXX")
+                    to_resolve.extend(
+                        (dep, requirement.extras)
+                        for dep in dist.distribution.metadata.requires_dists
+                    )
+                    yield dist.fingerprinted_distribution
+                continue
+            if not target.wheel_applies(distribution):
+                # TODO: XXX
+                yield Error("TODO: XXX")
+
+            resolved.add(requirement.project_name)
+            to_resolve.extend(
+                (dep, requirement.extras) for dep in distribution.metadata.requires_dists
+            )
+            yield distribution
+        else:
+            # TODO: XXX
+            yield Error("TODO: XXX")
+
+
+def resolve_from_venv(
+    targets,  # type: Targets
+    venv,  # type: Virtualenv
+    requirement_configuration=RequirementConfiguration(),  # type: RequirementConfiguration
+    pip_configuration=PipConfiguration(),  # type: PipConfiguration
+    compile=False,  # type: bool
+    ignore_errors=False,  # type: bool
+    result_type=InstallableType.INSTALLED_WHEEL_CHROOT,  # type: InstallableType.Value
+    dependency_configuration=DependencyConfiguration(),  # type: DependencyConfiguration
+):
+    # type: (...) -> Union[ResolveResult, Error]
+
+    # TODO: XXX: How to handle targets?
+    target = LocalInterpreter.create(venv.interpreter)
+
+    # TODO: XXX: Mabe mix DEFAULT in here and che
+    compatible_pip_version = (
+        pip_configuration.version
+        if pip_configuration.version and pip_configuration.version.requires_python_applies(target)
+        else PipVersion.latest_compatible(target)
+    )
+    if pip_configuration.version and pip_configuration.version != compatible_pip_version:
+        # TODO: XXX: Or just warn we changed the version to match the venv?
+        pex_warnings.warn(
+            "Adjusted Pip version from {version} to {compatible_version} to work with the venv "
+            "interpreter.".format(
+                version=pip_configuration.version, compatible_version=compatible_pip_version
+            )
+        )
+
+    if result_type is InstallableType.WHEEL_FILE:
+        # TODO: XXX: Reference an issue to chime in on?
+        return Error(
+            "Cannot resolve .whl files from virtual environment at {venv_dir}; Pex does not "
+            "currently know how to turn an installed wheel back into a zipped wheel.".format(
+                venv_dir=venv.venv_dir
+            )
+        )
+
+    resolver = ConfiguredResolver(
+        pip_configuration=attr.evolve(pip_configuration, version=compatible_pip_version)
+    )
+    fingerprinted_distributions = []  # type: List[FingerprintedDistribution]
+    venv_distributions = []  # type: List[Distribution]
+    direct_requirements_by_project_name = defaultdict(
+        OrderedSet
+    )  # type: DefaultDict[ProjectName, OrderedSet[Requirement]]
+    if requirement_configuration.has_requirements:
+        parsed_requirements = requirement_configuration.parse_requirements(
+            network_configuration=pip_configuration.network_configuration
+        )
+        local_project_requirements = OrderedSet()  # type: OrderedSet[LocalProjectRequirement]
+        root_requirements = OrderedSet()  # type: OrderedSet[Requirement]
+        for parsed_requirement in parsed_requirements:
+            if isinstance(parsed_requirement, LocalProjectRequirement):
+                local_project_requirements.add(parsed_requirement)
+            else:
+                root_requirements.add(parsed_requirement.requirement)
+                direct_requirements_by_project_name[
+                    parsed_requirement.requirement.project_name
+                ].add(parsed_requirement.requirement)
+
+        if local_project_requirements:
+            # TODO: XXX
+            return Error("TODO: XXX")
+
+        if requirement_configuration.constraint_files:
+            # TODO: XXX
+            pex_warnings.warn("TODO: XXX")
+
+        for distribution_or_error in _resolve_distributions(
+            resolver=resolver,
+            target=target,
+            search_path=tuple(
+                site_packages_dir.path for site_packages_dir in venv.interpreter.site_packages
+            ),
+            requirements=root_requirements,
+            allow_prereleases=pip_configuration.allow_prereleases,
+            compile=compile,
+            ignore_errors=ignore_errors,
+        ):
+            if isinstance(distribution_or_error, Error):
+                return distribution_or_error
+            elif isinstance(distribution_or_error, FingerprintedDistribution):
+                fingerprinted_distributions.append(distribution_or_error)
+            else:
+                venv_distributions.append(distribution_or_error)
+    else:
+        sdists_to_resolve = []
+        for venv_distribution in venv.iter_distributions():
+            if venv_distribution.metadata.files.metadata.type is not MetadataType.DIST_INFO:
+                sdists_to_resolve.append(str(venv_distribution.as_requirement()))
+            else:
+                venv_distributions.append(venv_distribution)
+            direct_requirements_by_project_name[venv_distribution.metadata.project_name].add(
+                venv_distribution.as_requirement()
+            )
+        result = resolver.resolve_requirements(
+            sdists_to_resolve, targets=Targets.from_target(target), transitive=False
+        )
+        fingerprinted_distributions.extend(
+            dist.fingerprinted_distribution for dist in result.distributions
+        )
+
+    return ResolveResult(
+        dependency_configuration=dependency_configuration,
+        distributions=tuple(
+            ResolvedDistribution(
+                target=target,
+                fingerprinted_distribution=fingerprinted_distribution,
+                direct_requirements=direct_requirements_by_project_name[
+                    fingerprinted_distribution.project_name
+                ],
+            )
+            for fingerprinted_distribution in itertools.chain(
+                list(
+                    _install_venv_distributions(
+                        venv=venv,
+                        distributions=venv_distributions,
+                        compile=compile,
+                        ignore_errors=ignore_errors,
+                        max_install_jobs=pip_configuration.max_jobs,
+                    )
+                ),
+                fingerprinted_distributions,
+            )
+        ),
+        type=result_type,
+    )

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -987,9 +987,7 @@ def _perform_install(
 ):
     # type: (...) -> InstallResult
     install_result = install_request.result(installed_wheels_dir)
-    install_wheel_chroot(
-        wheel_path=install_request.wheel_path, destination=install_result.build_chroot
-    )
+    install_wheel_chroot(wheel=install_request.wheel_path, destination=install_result.build_chroot)
     return install_result
 
 

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -583,7 +583,7 @@ class BuildResult(object):
                     return frozenset(platforms), is_linux
 
                 wheel_platform_tags, is_linux_wheel = collect_platforms(
-                    CompatibilityTags.from_wheel(wheel.location)
+                    CompatibilityTags.from_wheel(wheel)
                 )
                 abbreviated_target_platform_tags, is_linux_abbreviated_target = collect_platforms(
                     self.request.target.supported_tags

--- a/pex/targets.py
+++ b/pex/targets.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 
 import os
 
-from pex.dist_metadata import Distribution, Requirement
+from pex.dist_metadata import Constraint, Distribution
 from pex.interpreter import PythonInterpreter
 from pex.interpreter_implementation import InterpreterImplementation
 from pex.orderedset import OrderedSet
@@ -157,7 +157,7 @@ class Target(object):
 
     def requirement_applies(
         self,
-        requirement,  # type: Requirement
+        requirement,  # type: Constraint
         extras=(),  # type: Iterable[str]
     ):
         # type: (...) -> bool
@@ -183,7 +183,7 @@ class Target(object):
 
     def wheel_applies(self, wheel):
         # type: (Distribution) -> WheelEvaluation
-        wheel_tags = CompatibilityTags.from_wheel(wheel.location)
+        wheel_tags = CompatibilityTags.from_wheel(wheel)
         ranked_tag = self.supported_tags.best_match(wheel_tags)
         return WheelEvaluation(
             tags=tuple(wheel_tags),
@@ -345,6 +345,11 @@ class Targets(object):
     interpreters = attr.ib(default=())  # type: Tuple[PythonInterpreter, ...]
     complete_platforms = attr.ib(default=())  # type: Tuple[CompletePlatform, ...]
     platforms = attr.ib(default=())  # type: Tuple[Optional[Platform], ...]
+
+    @property
+    def is_empty(self):
+        # type: () -> bool
+        return not self.interpreters and not self.complete_platforms and not self.platforms
 
     @property
     def interpreter(self):

--- a/pex/targets.py
+++ b/pex/targets.py
@@ -407,7 +407,7 @@ class Targets(object):
 
     def require_at_most_one_target(self, purpose):
         # type: (str) -> Union[Optional[Target], Error]
-        resolved_targets = self.unique_targets(only_explicit=False)
+        resolved_targets = self.unique_targets(only_explicit=True)
         if len(resolved_targets) > 1:
             return Error(
                 "At most a single target is required for {purpose}.\n"

--- a/pex/vendor/__main__.py
+++ b/pex/vendor/__main__.py
@@ -534,7 +534,7 @@ def vendorize(root_dir, vendor_specs, prefix, update):
                 count=len(wheel_files),
                 wheel_files="\n".join(os.path.basename(wheel_file) for wheel_file in wheel_files),
             )
-            install_wheel_chroot(wheel_path=wheel_files[0], destination=vendor_spec.target_dir)
+            install_wheel_chroot(wheel=wheel_files[0], destination=vendor_spec.target_dir)
 
 
 if __name__ == "__main__":

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.58.1"
+__version__ = "2.59.0"

--- a/pex/wheel.py
+++ b/pex/wheel.py
@@ -10,6 +10,7 @@ from email.message import Message
 
 from pex.dist_metadata import (
     DistMetadata,
+    Distribution,
     MetadataFiles,
     MetadataType,
     load_metadata,
@@ -20,7 +21,7 @@ from pex.third_party.packaging import tags
 from pex.typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
-    from typing import Dict, Text, Tuple
+    from typing import Dict, Optional, Text, Tuple
 
     import attr  # vendor:skip
 else:
@@ -84,26 +85,49 @@ class WHEEL(object):
 
 @attr.s(frozen=True)
 class Wheel(object):
+    @staticmethod
+    def _source(
+        location,  # type: str
+        metadata_files,  # type: MetadataFiles
+    ):
+        # type: (...) -> str
+        return "{project_name} {version} at {location}".format(
+            project_name=metadata_files.metadata.project_name,
+            version=metadata_files.metadata.version,
+            location=location,
+        )
+
     @classmethod
-    def load(cls, wheel_path):
-        # type: (str) -> Wheel
+    def _from_metadata_files(
+        cls,
+        location,  # type: str
+        metadata_files,  # type: MetadataFiles
+        wheel=None,  # type: Optional[WHEEL]
+    ):
+        # type: (...) -> Wheel
 
-        metadata = WHEEL.load(wheel_path)
+        if wheel:
+            metadata = wheel
+        else:
+            wheel_data = metadata_files.read("WHEEL")
+            if not wheel_data:
+                raise WheelMetadataLoadError(
+                    "Could not find WHEEL metadata in {source}.".format(
+                        source=cls._source(location, metadata_files)
+                    )
+                )
+            metadata = WHEEL(files=metadata_files, metadata=parse_message(wheel_data))
 
-        metadata_path = metadata.files.metadata_file_rel_path("WHEEL")
-        if not metadata_path:
-            raise WheelMetadataLoadError(
-                "Could not find WHEEL metadata in {wheel}.".format(wheel=wheel_path)
-            )
-
-        wheel_metadata_dir = os.path.dirname(metadata_path)
+        wheel_metadata_dir = os.path.dirname(metadata_files.metadata.rel_path)
         if not wheel_metadata_dir.endswith(".dist-info"):
             raise WheelMetadataLoadError(
-                "Expected WHEEL metadata for {wheel} to be housed in a .dist-info directory, but was "
-                "found at {wheel_metadata_path}.".format(
-                    wheel=wheel_path, wheel_metadata_path=metadata_path
+                "Expected METADATA file for {source} to be housed in a .dist-info directory, but "
+                "was found at {wheel_metadata_path}.".format(
+                    source=cls._source(location, metadata_files),
+                    wheel_metadata_path=metadata_files.metadata.rel_path,
                 )
             )
+
         # Although not crisply defined, all PEPs lead to PEP-508 which restricts project names
         # to ASCII: https://peps.python.org/pep-0508/#names. Likewise, version numbers are also
         # restricted to ASCII: https://peps.python.org/pep-0440/. Since the `.dist-info` dir
@@ -115,11 +139,27 @@ class Wheel(object):
         data_dir = re.sub(r"\.dist-info$", ".data", metadata_dir)
 
         return cls(
-            location=wheel_path,
+            location=location,
             metadata_dir=metadata_dir,
-            metadata_files=metadata.files,
+            metadata_files=metadata_files,
             metadata=metadata,
             data_dir=data_dir,
+        )
+
+    @classmethod
+    def load(cls, wheel_path):
+        # type: (str) -> Wheel
+
+        wheel = WHEEL.load(wheel_path)
+        return cls._from_metadata_files(
+            location=wheel_path, metadata_files=wheel.files, wheel=wheel
+        )
+
+    @classmethod
+    def from_distribution(cls, distribution):
+        # type: (Distribution) -> Wheel
+        return cls._from_metadata_files(
+            location=distribution.location, metadata_files=distribution.metadata.files
         )
 
     location = attr.ib()  # type: str
@@ -127,6 +167,11 @@ class Wheel(object):
     metadata_files = attr.ib()  # type: MetadataFiles
     metadata = attr.ib()  # type: WHEEL
     data_dir = attr.ib()  # type: str
+
+    @property
+    def source(self):
+        # type: () -> str
+        return self._source(self.location, self.metadata_files)
 
     @property
     def wheel_file_name(self):
@@ -159,9 +204,9 @@ class Wheel(object):
         return DistMetadata.from_metadata_files(self.metadata_files)
 
     def metadata_path(self, *components):
-        # typ: (*str) -> str
+        # type: (*str) -> str
         return os.path.join(self.metadata_dir, *components)
 
     def data_path(self, *components):
-        # typ: (*str) -> str
+        # type: (*str) -> str
         return os.path.join(self.data_dir, *components)

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -324,7 +324,7 @@ def make_bdist(
 def install_wheel(wheel):
     # type: (str) -> Distribution
     install_dir = os.path.join(safe_mkdtemp(), os.path.basename(wheel))
-    install_wheel_chroot(wheel_path=wheel, destination=install_dir)
+    install_wheel_chroot(wheel=wheel, destination=install_dir)
     return Distribution.load(install_dir)
 
 

--- a/tests/integration/resolve/test_issue_1361.py
+++ b/tests/integration/resolve/test_issue_1361.py
@@ -1,0 +1,120 @@
+# Copyright 2025 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import filecmp
+import subprocess
+
+import pytest
+
+from pex.dist_metadata import MetadataType
+from pex.pep_503 import ProjectName
+from pex.pex import PEX
+from pex.typing import TYPE_CHECKING
+from pex.venv.virtualenv import Virtualenv
+from testing import make_env, run_pex_command
+from testing.pytest_utils.tmp import Tempdir
+
+if TYPE_CHECKING:
+    from typing import List
+
+
+def test_round_trip(tmpdir):
+    # type: (Tempdir) -> None
+
+    pex_root = tmpdir.join("pex-root")
+
+    def create_cowsay_pex(
+        pex_file,  # type: str
+        *extra_args  # type: str
+    ):
+        # type: (...) -> str
+
+        pex = tmpdir.join(pex_file)
+        run_pex_command(
+            args=[
+                "--pex-root",
+                pex_root,
+                "--runtime-pex-root",
+                pex_root,
+                "cowsay<6",
+                "-c",
+                "cowsay",
+                "-o",
+                pex,
+                "--include-tools",
+            ]
+            + list(extra_args)
+        ).assert_success()
+        assert b"| Moo! |" in subprocess.check_output(args=[pex, "Moo!"])
+        return pex
+
+    from_requirements_pex = create_cowsay_pex("from-requirements.pex")
+
+    venv = tmpdir.join("venv")
+    subprocess.check_call(args=[from_requirements_pex, "venv", venv], env=make_env(PEX_TOOLS=1))
+
+    from_venv_pex = create_cowsay_pex("from-venv.pex", "--venv-repository", venv)
+    assert filecmp.cmp(from_requirements_pex, from_venv_pex, shallow=False)
+
+
+@pytest.fixture
+def non_dist_info_cowsay_venv(tmpdir):
+    # type: (Tempdir) -> Virtualenv
+
+    venv = Virtualenv.create(tmpdir.join("venv"))
+    venv.ensure_pip()
+
+    subprocess.check_call(
+        args=[venv.interpreter.binary, "-m", "pip", "install", "cowsay<6", "--no-binary", "cowsay"]
+    )
+    dists_by_project_name = {
+        dist.metadata.project_name: dist for dist in venv.iter_distributions(rescan=True)
+    }
+    cowsay_dist = dists_by_project_name[ProjectName("cowsay")]
+    if cowsay_dist.metadata.type is MetadataType.DIST_INFO:
+        pytest.skip(
+            "The cowsay installation is .dist-info but the test requires a non .dist-info "
+            "installation."
+        )
+    return venv
+
+
+@pytest.mark.parametrize(
+    "requirements",
+    (
+        pytest.param(["cowsay"], id="subset"),
+        pytest.param([], id="full"),
+    ),
+)
+def test_non_dist_info_handling(
+    tmpdir,  # type: Tempdir
+    non_dist_info_cowsay_venv,  # type: Virtualenv
+    requirements,  # type: List[str]
+):
+    # type: (...) -> None
+
+    pex = tmpdir.join("pex")
+    run_pex_command(
+        args=requirements
+        + ["--venv-repository", non_dist_info_cowsay_venv.venv_dir, "-c", "cowsay", "-o", pex]
+    ).assert_success()
+    assert b"| Moo! |" in subprocess.check_output(args=[pex, "Moo!"])
+    pex_project_names = {dist.metadata.project_name for dist in PEX(pex).resolve()}
+    assert ProjectName("cowsay") in pex_project_names
+    if requirements:
+        assert ProjectName("pip") not in pex_project_names
+    else:
+        assert ProjectName("pip") in pex_project_names
+
+    venv_dists_by_project_name = {
+        dist.metadata.project_name: dist for dist in non_dist_info_cowsay_venv.iter_distributions()
+    }
+    assert (
+        venv_dists_by_project_name[ProjectName("cowsay")].metadata.type
+        is not MetadataType.DIST_INFO
+    ), "Expected full resolve to handle mixed dist-info and non-dist-info"
+    assert (
+        venv_dists_by_project_name[ProjectName("pip")].metadata.type is MetadataType.DIST_INFO
+    ), "Expected full resolve to handle mixed dist-info and non-dist-info"

--- a/tests/integration/venv_ITs/test_install_wheel_multiple_site_packages_dirs.py
+++ b/tests/integration/venv_ITs/test_install_wheel_multiple_site_packages_dirs.py
@@ -92,7 +92,7 @@ def test_wheel_files(fedora39_virtualenv_runner):
 
                 interpreter = PythonInterpreter.get()
                 for wheel_path in glob.glob("/wheels/*.whl"):
-                    install_wheel_interpreter(wheel_path=wheel_path, interpreter=interpreter)
+                    install_wheel_interpreter(wheel=wheel_path, interpreter=interpreter)
 
                 venv = Virtualenv("/virtualenv.venv")
                 json.dump(

--- a/tests/test_dist_metadata.py
+++ b/tests/test_dist_metadata.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
 def installed_wheel(wheel_path):
     # type: (str) -> Iterator[Distribution]
     with temporary_dir() as install_dir:
-        install_wheel_chroot(wheel_path=wheel_path, destination=install_dir)
+        install_wheel_chroot(wheel=wheel_path, destination=install_dir)
         yield Distribution.load(install_dir)
 
 

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -429,7 +429,15 @@ def create_dist(
         # Some tests purposefully use bad wheel names; so we just construct in-memory metadata.
         pass
     else:
-        location = os.path.join(safe_mkdtemp(), location)
+        location = os.path.join(
+            safe_mkdtemp(
+                prefix="{location}.".format(location=location),
+                suffix=".{project_name}-{version}".format(
+                    project_name=project_name, version=version
+                ),
+            ),
+            location,
+        )
         pnav = ProjectNameAndVersion.from_filename(location)
         with safe_open(
             os.path.join(

--- a/tests/test_finders.py
+++ b/tests/test_finders.py
@@ -49,7 +49,7 @@ def test_get_script_from_distributions(tmpdir):
     assert "aws_cfn_bootstrap-1.4.data/scripts/cfn-signal" == dist_script.path
 
     install_dir = os.path.join(str(tmpdir), os.path.basename(whl_path))
-    install_wheel_chroot(wheel_path=whl_path, destination=install_dir)
+    install_wheel_chroot(wheel=whl_path, destination=install_dir)
     installed_wheel_dist, dist_script = assert_script(Distribution.load(install_dir))
     assert InstalledWheel.load(install_dir).stashed_path("bin/cfn-signal") == dist_script.path
 


### PR DESCRIPTION
Add a new `--venv-repository` resolution source. This allows creating a
PEX from a preexisting venv. By default, all installed venv 
distributions are included in the PEX, but by specifying requirements,
the venv can be subset.

The `--venv-repository` source is also supported by `pex3 venv create`, 
allowing sub-setting an existing venv directly into a new venv as well.

Closes #1361