### PR TITLE
Restore `-n auto` default for py27 ITs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,9 +107,9 @@ jobs:
           # N.B.: We use @ instead of / for the shard spec delimiter to play well with the
           # build-cache-image.yml job
 
-          - test-cmd: test-py27-pip20.3.4--patched-integration-n0-shard1@2
+          - test-cmd: test-py27-pip20.3.4--patched-integration-shard1@2
             base-pythons: old
-          - test-cmd: test-py27-pip20.3.4--patched-integration-n0-shard2@2
+          - test-cmd: test-py27-pip20.3.4--patched-integration-shard2@2
             base-pythons: old
 
           - test-cmd: test-py38-pip22.3.1-integration-shard1@2

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -15,7 +15,6 @@ RUN apt update && \
     cargo \
     clang \
     curl \
-    git \
     gpg-agent \
     libbz2-dev \
     libffi-dev \
@@ -32,6 +31,12 @@ RUN apt update && \
     wget \
     xz-utils \
     zlib1g-dev
+
+# Setup a modern git:
+RUN add-apt-repository --yes ppa:git-core/ppa && \
+    apt update && \
+    DEBIAN_FRONTEND=noninteractive apt install --yes --no-install-recommends git && \
+    add-apt-repository --yes --remove ppa:git-core/ppa
 
 # Setup a modern uv:
 RUN curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=/usr/bin sh

--- a/docker/base/install-pythons.py
+++ b/docker/base/install-pythons.py
@@ -80,14 +80,14 @@ def install_deadsnakes_versions(
     env = {**os.environ, "DEBIAN_FRONTEND": "noninteractive"}
     if versions:
         subprocess.run(
-            args=["add-apt-repository", "--yes", "--ppa", "deadsnakes"], env=env, check=True
+            args=["add-apt-repository", "--yes", "ppa:deadsnakes/ppa"], env=env, check=True
         )
 
         packages = [package for dead_snake in versions for package in dead_snake.iter_packages()]
         subprocess.run(args=["apt", "install", "--yes", *packages], env=env, check=True)
 
         subprocess.run(
-            args=["add-apt-repository", "--yes", "--remove", "--ppa", "deadsnakes"],
+            args=["add-apt-repository", "--yes", "--remove", "ppa:deadsnakes/ppa"],
             env=env,
             check=True,
         )

--- a/duvrc.sh
+++ b/duvrc.sh
@@ -6,13 +6,22 @@ ROOT="$(git rev-parse --show-toplevel)"
 
 if echo $0 | grep -E '\-old.sh$' >/dev/null; then
   BASE_PYTHONS=old
-  UBUNTU_VERSION=20.04
-  CACHE_TAG="${CACHE_TAG:-latest-old}"
 else
   BASE_PYTHONS="${BASE_PYTHONS:-new}"
-  UBUNTU_VERSION=24.04
-  CACHE_TAG="${CACHE_TAG:-latest-${BASE_PYTHONS}}"
 fi
+
+if [[ "${BASE_PYTHONS}" == "new" ]]; then
+  UBUNTU_VERSION=24.04
+else
+  UBUNTU_VERSION=20.04
+fi
+
+CACHE_TAG="${CACHE_TAG:-latest-${BASE_PYTHONS}}"
+VOLUME_DEV_CACHES="pex-dev-caches-${BASE_PYTHONS}"
+VOLUME_XDG_CACHES="pex-xdg-caches-${BASE_PYTHONS}"
+VOLUME_TMP_CACHES="pex-tmp-${BASE_PYTHONS}"
+VOLUME_VENV="pex-venv-${BASE_PYTHONS}"
+VOLUME_DEV_CMD="pex-dev-cmd-${BASE_PYTHONS}"
 
 BASE_MODE="${BASE_MODE:-build}"
 CACHE_MODE="${CACHE_MODE:-}"
@@ -65,11 +74,11 @@ if [[ -z "$(user_image_id)" ]]; then
 
   docker run \
     --rm \
-    --volume pex-dev-caches:/development/pex_dev \
-    --volume pex-xdg-caches:/var/cache \
-    --volume pex-tmp:/tmp \
-    --volume pex-venv:/development/pex/.venv \
-    --volume pex-dev-cmd:/development/pex/.dev-cmd \
+    --volume "${VOLUME_DEV_CACHES}:/development/pex_dev" \
+    --volume "${VOLUME_XDG_CACHES}:/var/cache" \
+    --volume "${VOLUME_TMP_CACHES}:/tmp" \
+    --volume "${VOLUME_VENV}:/development/pex/.venv" \
+    --volume "${VOLUME_DEV_CMD}:/development/pex/.dev-cmd" \
     --entrypoint bash \
     --user root \
     "pex-tool/pex/user:${BASE_PYTHONS}-${user_hash}" \
@@ -92,12 +101,12 @@ if [[ "${CACHE_MODE}" == "pull" ]]; then
   docker volume create pex-dev-caches
   docker run \
     --rm \
-    --volume pex-dev-caches:/development/pex_dev \
+    --volume "${VOLUME_DEV_CACHES}:/development/pex_dev" \
     --pull always \
     "ghcr.io/pex-tool/pex/cache:${CACHE_TAG}" true || true
   docker run \
     --rm \
-    --volume pex-dev-caches:/development/pex_dev \
+    --volume "${VOLUME_DEV_CACHES}:/development/pex_dev" \
     --entrypoint bash \
     --user root \
     "pex-tool/pex/user:${BASE_PYTHONS}-${user_hash}" \
@@ -170,14 +179,15 @@ if [[ -d "${HOME}/.ssh" ]]; then
   )
 fi
 
+
 exec docker run \
   --rm \
-  --volume pex-tmp:/tmp \
-  --volume pex-xdg-caches:/var/cache \
-  --volume pex-dev-caches:/development/pex_dev \
   --volume "${ROOT}:/development/pex" \
-  --volume pex-venv:/development/pex/.venv \
-  --volume pex-dev-cmd:/development/pex/.dev-cmd \
+  --volume "${VOLUME_DEV_CACHES}:/development/pex_dev" \
+  --volume "${VOLUME_XDG_CACHES}:/var/cache" \
+  --volume "${VOLUME_TMP_CACHES}:/tmp" \
+  --volume "${VOLUME_VENV}:/development/pex/.venv" \
+  --volume "${VOLUME_DEV_CMD}:/development/pex/.dev-cmd" \
   "${DOCKER_ARGS[@]}" \
   "pex-tool/pex/user:${BASE_PYTHONS}-${user_hash}" \
   "$@"

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -75,6 +75,7 @@ IS_PYPY3 = IS_PYPY and sys.version_info[0] == 3
 NOT_CPYTHON27 = IS_PYPY or PY_VER != (2, 7)
 IS_LINUX = LINUX
 IS_MAC = MAC
+IS_WINDOWS = WINDOWS
 IS_X86_64 = platform.machine().lower() in ("amd64", "x86_64")
 IS_ARM_64 = platform.machine().lower() in ("arm64", "aarch64")
 IS_LINUX_X86_64 = IS_LINUX and IS_X86_64
@@ -486,10 +487,91 @@ def create_pex_command(
     return cmd
 
 
+@attr.s(frozen=True)
+class UvPython(object):
+    @staticmethod
+    def _get_os():
+        # type: () -> str
+
+        if IS_WINDOWS:
+            return "windows"
+        elif IS_MAC:
+            return "macos"
+        else:
+            return "linux"
+
+    @staticmethod
+    def _get_arch():
+        # type: () -> str
+
+        if IS_WINDOWS:
+            arch = os.environ.get("PROCESSOR_ARCHITECTURE", platform.machine()).lower()
+        else:
+            arch = platform.machine().lower()
+
+        if arch in ("aarch64", "arm64"):
+            return "aarch64"
+        elif arch in ("x86_64", "amd64"):
+            return "x86_64"
+        else:
+            return arch
+
+    major = attr.ib()  # type: int
+    minor = attr.ib()  # type: int
+    implementation = attr.ib(
+        default=InterpreterImplementation.CPYTHON
+    )  # type: InterpreterImplementation.Value
+
+    def spec(self):
+        # type: () -> str
+
+        if self.implementation is InterpreterImplementation.PYPY:
+            return "pypy-{major}.{minor}-{os}-{arch}".format(
+                major=self.major, minor=self.minor, os=self._get_os(), arch=self._get_arch()
+            )
+
+        # N.B.: We force arch to get arm64 PBS builds for Windows arm64 machines.
+        # See: https://github.com/astral-sh/uv/issues/12906
+        return "cpython-{major}.{minor}{suffix}-{os}-{arch}".format(
+            major=self.major,
+            minor=self.minor,
+            suffix="t"
+            if self.implementation is InterpreterImplementation.CPYTHON_FREE_THREADED
+            else "",
+            os=self._get_os(),
+            arch=self._get_arch(),
+        )
+
+
+def ensure_uv_python(
+    python,  # type: Union[UvPython, str]
+    install_if_missing=True,  # type: bool
+):
+    # type: (...) -> str
+
+    python_spec = python.spec() if isinstance(python, UvPython) else python
+
+    env = make_env(UV_PYTHON_INSTALL_DIR=os.path.join(PEX_TEST_DEV_ROOT, "uv-pythons"))
+    process = subprocess.Popen(
+        args=["uv", "python", "find", python_spec], env=env, stdout=subprocess.PIPE
+    )
+    stdout, _ = process.communicate()
+    if process.returncode == 0:
+        return cast(str, stdout.decode("utf-8").strip())
+
+    assert install_if_missing, "The {python} interpreter was not found by uv on the system.".format(
+        python=python
+    )
+    subprocess.check_call(
+        args=["uv", "python", "install", "--managed-python", "--force", python_spec], env=env
+    )
+    return ensure_uv_python(python_spec, install_if_missing=False)
+
+
 def run_pex_command(
     args,  # type: Iterable[str]
     env=None,  # type: Optional[Dict[str, str]]
-    python=None,  # type: Optional[str]
+    python=None,  # type: Optional[Union[str, UvPython]]
     quiet=None,  # type: Optional[bool]
     cwd=None,  # type: Optional[str]
     pex_module="pex",  # type: str
@@ -502,6 +584,8 @@ def run_pex_command(
     generated pex.  This is useful for testing end to end runs with specific command line arguments
     or env options.
     """
+    if isinstance(python, UvPython):
+        python = ensure_uv_python(python)
     cmd = create_pex_command(
         args, python=python, quiet=quiet, pex_module=pex_module, use_pex_whl_venv=use_pex_whl_venv
     )

--- a/testing/cli.py
+++ b/testing/cli.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 
 from pex.typing import TYPE_CHECKING
-from testing import IntegResults, installed_pex_wheel_venv_python
+from testing import IntegResults, UvPython, ensure_uv_python, installed_pex_wheel_venv_python
 
 if TYPE_CHECKING:
     from typing import Any, Text
@@ -19,13 +19,18 @@ def run_pex3(
 ):
     # type: (...) -> IntegResults
 
-    python_exe = kwargs.pop("python", None) or sys.executable
+    python_exe = kwargs.pop("python", None)
+    if isinstance(python_exe, UvPython):
+        python = ensure_uv_python(python_exe)
+    elif python_exe:
+        python = python_exe
+    else:
+        python = sys.executable
+
     python = (
-        installed_pex_wheel_venv_python(python_exe)
-        if kwargs.pop("use_pex_whl_venv", True)
-        else python_exe
+        installed_pex_wheel_venv_python(python) if kwargs.pop("use_pex_whl_venv", True) else python
     )
-    cmd = [python, "-mpex.cli"] + list(args)
+    cmd = [python, "-mpex.cli"] + list(map(str, args))
     process = subprocess.Popen(args=cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs)
     stdout, stderr = process.communicate()
     return IntegResults(

--- a/tests/integration/cli/commands/test_lock_script_metadata.py
+++ b/tests/integration/cli/commands/test_lock_script_metadata.py
@@ -11,7 +11,7 @@ import pytest
 
 from pex.interpreter import PythonInterpreter
 from pex.typing import TYPE_CHECKING
-from testing import run_pex_command
+from testing import UvPython, run_pex_command
 from testing.cli import run_pex3
 from testing.pytest_utils.tmp import Tempdir
 
@@ -207,7 +207,14 @@ def assert_lock_script_conflict(
     # type: (...) -> None
 
     run_pex3(
-        "lock", verb, "--platform", "linux-aarch64-cp-39-cp39", "--script", script, *extra_args
+        "lock",
+        verb,
+        "--platform",
+        "linux-aarch64-cp-39-cp39",
+        "--script",
+        script,
+        *extra_args,
+        python=UvPython(3, 13)
     ).assert_failure(
         expected_error_re=re.escape(
             dedent(

--- a/tests/integration/test_interpreter_selection.py
+++ b/tests/integration/test_interpreter_selection.py
@@ -11,12 +11,14 @@ import pytest
 from pex.common import safe_open, temporary_dir
 from pex.interpreter import PythonInterpreter
 from pex.interpreter_constraints import InterpreterConstraint, InterpreterConstraints
+from pex.interpreter_implementation import InterpreterImplementation
 from pex.pex_info import PexInfo
 from pex.pip.version import PipVersion
 from testing import (
     PY39,
     PY310,
     PY311,
+    UvPython,
     ensure_python_interpreter,
     make_env,
     run_pex_command,
@@ -514,15 +516,14 @@ def test_free_threaded_cpython_selection(
     py314t_scie = tmpdir.join("py314t")
     run_pex_command(
         args=[
-            "--interpreter-constraint",
-            "CPython==3.14.*",
             "--scie-pbs-free-threaded",
             "--scie",
             "eager",
             "--scie-only",
             "-o",
             py314t_scie,
-        ]
+        ],
+        python=UvPython(implementation=InterpreterImplementation.CPYTHON_GIL, major=3, minor=14),
     ).assert_success()
     py314t = PythonInterpreter.from_binary(
         str(

--- a/tests/tools/commands/test_venv.py
+++ b/tests/tools/commands/test_venv.py
@@ -168,7 +168,7 @@ def parse_fabric_version_output(output):
 
 
 @pytest.mark.skipif(
-    sys.version_info[:2] >= (3, 12),
+    PY2 or sys.version_info[:2] >= (3, 12),
     reason=(
         "Fabric depends on invoke which embeds six which uses a meta path importer that only "
         "implements the PEP-302 finder spec and not the modern spec. Only the modern finder spec "
@@ -285,7 +285,7 @@ def test_binary_path(
 
 
 @pytest.mark.skipif(
-    sys.version_info[:2] >= (3, 12),
+    PY2 or sys.version_info[:2] >= (3, 12),
     reason=(
         "Fabric depends on invoke which embeds six which uses a meta path importer that only "
         "implements the PEP-302 finder spec and not the modern spec. Only the modern finder spec "

--- a/tests/tools/commands/test_venv.py
+++ b/tests/tools/commands/test_venv.py
@@ -168,7 +168,7 @@ def parse_fabric_version_output(output):
 
 
 @pytest.mark.skipif(
-    PY2 or sys.version_info[:2] >= (3, 12),
+    sys.version_info[:2] >= (3, 12),
     reason=(
         "Fabric depends on invoke which embeds six which uses a meta path importer that only "
         "implements the PEP-302 finder spec and not the modern spec. Only the modern finder spec "
@@ -285,7 +285,7 @@ def test_binary_path(
 
 
 @pytest.mark.skipif(
-    PY2 or sys.version_info[:2] >= (3, 12),
+    sys.version_info[:2] >= (3, 12),
     reason=(
         "Fabric depends on invoke which embeds six which uses a meta path importer that only "
         "implements the PEP-302 finder spec and not the modern spec. Only the modern finder spec "


### PR DESCRIPTION
The hang appears to have been in `test_setproctitle`, which is now
skipped for Python 2.7.