### PR TITLE
[codex] Fix sdist build cache reuse

### DIFF
--- a/pex/atomic_directory.py
+++ b/pex/atomic_directory.py
@@ -147,11 +147,11 @@ class AtomicDirectory(object):
         If a race is lost and `target_dir` already exists, the `target_dir` dir is left unchanged and
         the `work_dir` directory will simply be removed.
         """
-        if self.is_finalized():
-            return
-
-        source = os.path.join(self._work_dir, source) if source else self._work_dir
         try:
+            if self.is_finalized():
+                return
+
+            source = os.path.join(self._work_dir, source) if source else self._work_dir
             # Perform an atomic rename.
             #
             # Per the docs: https://docs.python.org/2.7/library/os.html#os.rename

--- a/pex/resolver.py
+++ b/pex/resolver.py
@@ -1083,8 +1083,12 @@ class WheelBuilder(object):
     def _spawn_wheel_build(self, build_request):
         # type: (BuildRequest) -> SpawnedJob[BuildResult]
         source_path, editable = build_request.prepare()
+        # Use the original sdist path as the build cache key even if the sdist was prepared as an
+        # extracted project directory. Archives with subdirectories need the prepared path to keep the
+        # sub-project identity in the cache key.
         build_result = build_request.result(
-            source_path, honor_editable=self._build_configuration.honor_editable
+            source_path if build_request.subdirectory else None,
+            honor_editable=self._build_configuration.honor_editable,
         )
         if build_result.is_built:
             TRACER.log(

--- a/tests/test_atomic_directory.py
+++ b/tests/test_atomic_directory.py
@@ -132,6 +132,22 @@ def test_atomic_directory_empty_workdir_finalized():
             ), "When the target_dir exists no work_dir should be created."
 
 
+def test_atomic_directory_finalize_cleans_work_dir_when_already_finalized():
+    # type: () -> None
+    with temporary_dir() as sandbox:
+        target_dir = os.path.join(sandbox, "target_dir")
+        os.mkdir(target_dir)
+
+        atomic_dir = AtomicDirectory(target_dir)
+        os.mkdir(atomic_dir.work_dir)
+        touch(os.path.join(atomic_dir.work_dir, "created"))
+
+        atomic_dir.finalize()
+
+        assert not os.path.exists(atomic_dir.work_dir)
+        assert not os.path.exists(os.path.join(target_dir, "created"))
+
+
 def test_atomic_directory_locked_mode():
     # type: () -> None
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -26,7 +26,7 @@ from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.package_repository import PYPI, Repo, ReposConfiguration
 from pex.resolve.resolver_configuration import BuildConfiguration, ResolverVersion
 from pex.resolve.resolvers import ResolvedDistribution, ResolveResult, Unsatisfiable
-from pex.resolver import download
+from pex.resolver import BuildRequest, WheelBuilder, download
 from pex.resolver import resolve as resolve_under_test
 from pex.targets import Target, Targets
 from pex.typing import TYPE_CHECKING
@@ -48,7 +48,7 @@ from testing import (
 from testing.pytest_utils.tmp import Tempdir
 
 if TYPE_CHECKING:
-    from typing import Any, DefaultDict, Iterable, Iterator, List, Union
+    from typing import Any, DefaultDict, Iterable, Iterator, List, Tuple, Union
 
     import attr  # vendor:skip
 else:
@@ -107,6 +107,35 @@ def disabled_cache():
     # from default PEX_ROOT to a temporary directory. We do the same here.
     with temporary_dir() as td, cache(td):
         yield
+
+
+def test_sdist_build_cache_key_is_original_archive(tmpdir, monkeypatch):
+    # type: (Any, Any) -> None
+    sdist_path = os.path.join(str(tmpdir), "project-1.0.tar.gz")
+    with open(sdist_path, "wb") as fp:
+        fp.write(b"Not really an sdist; just enough to fingerprint for this cache key test.")
+
+    build_request = BuildRequest.for_file(target=targets.current(), source_path=sdist_path)
+    cached_build = build_request.result()
+    os.makedirs(cached_build.dist_dir)
+
+    prepared_project = os.path.join(str(tmpdir), "prepared", "project-1.0")
+    os.makedirs(prepared_project)
+
+    def prepare(_build_request):
+        # type: (BuildRequest) -> Tuple[str, bool]
+        return prepared_project, False
+
+    def get_pip(*_args, **_kwargs):
+        # type: (*Any, **Any) -> Any
+        raise AssertionError("Expected the cached sdist build to be re-used.")
+
+    monkeypatch.setattr(BuildRequest, "prepare", prepare)
+    monkeypatch.setattr("pex.resolver.get_pip", get_pip)
+
+    build_result = WheelBuilder()._spawn_wheel_build(build_request).await_result()
+
+    assert cached_build.dist_dir == build_result.dist_dir
 
 
 def test_empty_resolve():


### PR DESCRIPTION
## Summary

- Keep normal sdist build cache identity tied to the original sdist artifact when spawning a wheel build, while preserving prepared-path cache identity for archive `#subdirectory=` builds.
- Ensure `AtomicDirectory.finalize()` always cleans its work directory when the target directory already exists.
- Add regression coverage for both the sdist cache-key path and the already-finalized atomic directory cleanup path.

Refs #3187.

## Validation

- `uv run dev-cmd test -- tests/test_atomic_directory.py::test_atomic_directory_finalize_cleans_work_dir_when_already_finalized tests/test_resolver.py::test_sdist_build_cache_key_is_original_archive`
- Real repro smoke test: three sequential `PEX_ROOT=... uv run python -m pex ansicolors==1.1.8 --no-binary ...` invocations left one built ansicolors wheel, one pip-cache ansicolors wheel, and zero `built_wheels` `.work` dirs; runs 2 and 3 reported `Using cached build`.
- `uv run dev-cmd lint-check`
- `uv run dev-cmd format-check`
- `uv run dev-cmd typecheck`

## Disclosure

This PR was written with AI assistance from OpenAI Codex/GPT-5, based on local investigation and reproduction.
