### PR TITLE
Re-structure `duvrc.sh` / `install-pythons.py`.

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -59,6 +59,7 @@ RUN mkdir -p -m 755 /etc/apt/keyrings && \
     DEBIAN_FRONTEND=noninteractive apt install --yes --no-install-recommends gh -y
 
 ARG PYTHONS=new
-COPY install-pythons.py /root/
-RUN uv run /root/install-pythons.py --pythons $PYTHONS && \
+COPY install-pythons.py /root/install-pythons.py
+COPY ${PYTHONS}-versions.toml /root/versions.toml
+RUN uv run /root/install-pythons.py /root/versions.toml && \
     uv python uninstall --all

--- a/docker/base/install-pythons.py
+++ b/docker/base/install-pythons.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 # /// script
-# requires-python = ">=3.9"
+# requires-python = "==3.11.*"
 # ///
 
 from __future__ import annotations
@@ -10,18 +10,59 @@ import os
 import shutil
 import subprocess
 import sys
-from argparse import ArgumentParser
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Iterator
 
-# N.B.: 3.12 is the default system python for ubuntu 24.04 and software-properties-common uses it.
-# There may be a way to substitute the deadsnakes version but I have not found it; so we uninstall
-# via `apt autoremove` and let pyenv install a 3.12.
+import tomllib
+
+
+def parse_str_field(subject: str, name: str, data: dict[str, Any]) -> str:
+    try:
+        value = data.pop(name)
+    except KeyError:
+        raise InstallError(f"A {subject} must define a `{name}` field.")
+    if not isinstance(value, str):
+        raise InstallError(
+            f"The `{name}` field must be a string; given {value} of type {type(value)}."
+        )
+    return value
+
+
+def parse_list_field(subject: str, name: str, data: dict[str, Any]) -> list[Any]:
+    try:
+        values = data.pop(name)
+    except KeyError:
+        raise InstallError(f"A {subject} must define a `{name}` field.")
+    if not isinstance(values, list):
+        raise InstallError(
+            f"The `{name}` field must be a list; given {values} of type {type(values)}."
+        )
+    return values
+
+
+def parse_str_list_field(subject: str, name: str, data: dict[str, Any]) -> list[str]:
+    values = parse_list_field(subject, name, data)
+    if not all(isinstance(value, str) for value in values):
+        raise InstallError(
+            f"The `{name}` field must be a list of strings; given {values} which contains "
+            f"non-strings."
+        )
+    return values
+
 
 # See: https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa
 @dataclass(frozen=True)
 class DeadSnake:
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DeadSnake:
+        subject = "Dead Snakes version"
+        version = parse_str_field(subject=subject, name="version", data=data)
+        packages = parse_str_list_field(subject=subject, name="packages", data=data)
+        if data:
+            raise InstallError(f"Unrecognized Dead Snakes fields: {', '.join(data.keys())}")
+        return cls(precise_version=version, packages=packages)
+
     precise_version: str
     packages: list[str]
 
@@ -31,59 +72,16 @@ class DeadSnake:
             yield f"python{version}-{package}={self.precise_version}*"
 
 
-# N.B.: 2.7, 3.9 and 3.11 are needed in both version sets to run certain dev-cmd commands.
-
-NEW_DEFAULT_PYTHON = "python3.14"
-NEW_VERSIONS = (
-    # N.B.: Old, but needed for some dev-cmd commands.
-    "2.7.18",
-    DeadSnake("3.9.25", ["dev", "venv", "distutils"]),
-    # New:
-    DeadSnake("3.10.20", ["dev", "venv", "distutils"]),
-    DeadSnake("3.11.15", ["dev", "venv"]),
-    "3.12.13",
-    DeadSnake("3.13.14", ["dev", "venv"]),
-    DeadSnake("3.14.6", ["dev", "venv"]),
-    DeadSnake("3.15.0~b2", ["dev", "venv"]),
-    "pypy3.11-7.3.22",
-)
-
-OLD_DEFAULT_PYTHON = "python3.9"
-OLD_VERSIONS = (
-    # N.B.: New, but needed for some dev-cmd commands.
-    "3.11.15",
-    # Old:
-    "2.7.18",
-    "3.5.10",
-    "3.6.15",
-    "3.7.17",
-    "3.8.20",
-    "3.9.25",
-    "pypy2.7-7.3.22",
-    # This is served from:
-    #   https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-7.0.0-linux_x86_64-portable.tar.bz2
-    # which has begun to prove flaky; so we comment out for now and perhaps need to drop or
-    # self-host:
-    # pypy3.5-7.0.0
-    # This is failing install for unknown reasons:
-    # pypy3.6-7.3.3
-    "pypy3.7-7.3.9",
-    "pypy3.8-7.3.11",
-    "pypy3.9-7.3.16",
-    "pypy3.10-7.3.19",
-)
-
-
 def install_deadsnakes_versions(
-    versions: Iterable[DeadSnake], uninstall: Iterable[str] = ()
+    dead_snakes: Iterable[DeadSnake], uninstall: Iterable[str] = ()
 ) -> None:
     env = {**os.environ, "DEBIAN_FRONTEND": "noninteractive"}
-    if versions:
+    if dead_snakes:
         subprocess.run(
             args=["add-apt-repository", "--yes", "ppa:deadsnakes/ppa"], env=env, check=True
         )
 
-        packages = [package for dead_snake in versions for package in dead_snake.iter_packages()]
+        packages = [package for dead_snake in dead_snakes for package in dead_snake.iter_packages()]
         subprocess.run(args=["apt", "install", "--yes", *packages], env=env, check=True)
 
         subprocess.run(
@@ -100,10 +98,34 @@ def install_deadsnakes_versions(
     subprocess.run(args=["apt", "autoremove", "--yes"], env=env, check=True)
 
 
+# See: https://github.com/pyenv/pyenv
 PYENV_ROOT = Path("/pyenv")
 PYENV_REPO = os.environ.get("PYENV_REPO", "https://github.com/pyenv/pyenv")
 PYENV_SHA = os.environ.get("PYENV_SHA", "HEAD")
 PYENV_ENV = {**os.environ, "PYENV_ROOT": str(PYENV_ROOT)}
+
+
+@dataclass(frozen=True)
+class Pyenv:
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Pyenv:
+        version = parse_str_field(subject="Pyenv version", name="version", data=data)
+        if data:
+            raise InstallError(f"Unrecognized pyenv fields: {', '.join(data.keys())}")
+        return cls(version=version)
+
+    version: str
+    exe: str = field(init=False)
+    exe_path: Path = field(init=False)
+
+    def __post_init__(self):
+        if self.version.startswith("pypy"):
+            exe = self.version.split("-")[0]
+        else:
+            major, minor = self.version.split(".")[:2]
+            exe = f"python{major}.{minor}"
+        object.__setattr__(self, "exe", exe)
+        object.__setattr__(self, "exe_path", PYENV_ROOT / "versions" / self.version / "bin" / exe)
 
 
 def install_pyenv() -> None:
@@ -113,54 +135,96 @@ def install_pyenv() -> None:
     subprocess.run(args=["make", "-C", "src"], env=PYENV_ENV, cwd=PYENV_ROOT, check=True)
 
 
-def install_pyenv_versions(versions: Iterable[str]) -> None:
-    if not versions:
+def install_pyenv_versions(pyenvs: Iterable[Pyenv]) -> None:
+    if not pyenvs:
         return
 
     install_pyenv()
     subprocess.run(
-        args=[PYENV_ROOT / "bin" / "pyenv", "install", "--force", *versions],
+        args=[
+            PYENV_ROOT / "bin" / "pyenv",
+            "install",
+            "--force",
+            *(pyenv.version for pyenv in pyenvs),
+        ],
         env=PYENV_ENV,
         check=True,
     )
-    for version in versions:
-        if version.startswith("pypy"):
-            exe = version.split("-")[0]
-        else:
-            major, minor = version.split(".")[:2]
-            exe = f"python{major}.{minor}"
-        exe_path = PYENV_ROOT / "versions" / version / "bin" / exe
-        if not exe_path.is_file() or not os.access(exe_path, os.R_OK | os.X_OK):
+    for pyenv in pyenvs:
+        if not pyenv.exe_path.is_file() or not os.access(pyenv.exe_path, os.R_OK | os.X_OK):
             raise InstallError(
-                f"For pyenv version {version}, expected Python exe path does not exist:\n"
-                f"  {exe_path}"
+                f"For pyenv version {pyenv.version}, expected Python exe path does not exist:\n"
+                f"  {pyenv.exe_path}"
             )
-        os.symlink(exe_path, f"/usr/bin/{exe}")
+        os.symlink(pyenv.exe_path, f"/usr/bin/{pyenv.exe}")
 
 
-def install_pythons(new: bool = True) -> None:
-    uninstall: list[str] = []
-    versions: Iterable[DeadSnake | str]
-    if new:
-        # N.B.: Ubuntu 24.04 which ships its own (older) CPython 3.12.
-        uninstall.append("python3.12")
-        versions = NEW_VERSIONS
-        default_python_exe_name = NEW_DEFAULT_PYTHON
-    else:
-        # N.B.: Ubuntu 20.04 which ships its own (older) CPython 3.8.
-        uninstall.append("python3.8")
-        versions = OLD_VERSIONS
-        default_python_exe_name = OLD_DEFAULT_PYTHON
+@dataclass(frozen=True)
+class Versions:
+    @classmethod
+    def parse(cls, versions_file: Path) -> Versions:
+        with versions_file.open(mode="rb") as fp:
+            data = tomllib.load(fp)
 
-    install_deadsnakes_versions(
-        versions=[version for version in versions if isinstance(version, DeadSnake)],
-        uninstall=uninstall,
-    )
-    install_pyenv_versions(versions=[version for version in versions if isinstance(version, str)])
+        subject = "Versions config file"
+        default_python_exe_name = parse_str_field(
+            subject=subject, name="default-version", data=data
+        )
+        pyenv_versions: list[Pyenv] = []
+        deadsnakes_versions: list[DeadSnake] = []
+        for index, version in enumerate(
+            parse_list_field(subject=subject, name="versions", data=data)
+        ):
+            if not isinstance(version, dict):
+                raise InstallError(
+                    f"The `versions` field must be a list of tables; "
+                    f"item {index} is {version} of type {type(version)}."
+                )
+            match parse_str_field(
+                subject=f"{subject} `versions` field item {index}", name="source", data=version
+            ):
+                case "dead-snakes":
+                    try:
+                        deadsnakes_versions.append(DeadSnake.from_dict(version))
+                    except InstallError as e:
+                        raise InstallError(
+                            f"Invalid `versions` field dead-snakes item {index}: {e}"
+                        )
+                case "pyenv":
+                    try:
+                        pyenv_versions.append(Pyenv.from_dict(version))
+                    except InstallError as e:
+                        raise InstallError(f"Invalid `versions` field pyenv item {index}: {e}")
+                case other:
+                    raise InstallError(
+                        f"The `versions` field item {index} has unrecognized source of '{other}'; "
+                        f"must be either 'dead-snakes' or 'pyenv'."
+                    )
+        uninstall_packages = parse_str_list_field(
+            subject=subject, name="uninstall-packages", data=data
+        )
+        return cls(
+            default_python_exe_name=default_python_exe_name,
+            deadsnakes_versions=tuple(deadsnakes_versions),
+            pyenv_versions=tuple(pyenv_versions),
+            uninstall_packages=tuple(uninstall_packages),
+        )
 
-    default_python = shutil.which(default_python_exe_name)
+    default_python_exe_name: str
+    deadsnakes_versions: tuple[DeadSnake, ...]
+    pyenv_versions: tuple[Pyenv, ...]
+    uninstall_packages: tuple[str, ...]
+
+
+def install_pythons(versions: Versions) -> None:
+    install_deadsnakes_versions(versions.deadsnakes_versions, uninstall=versions.uninstall_packages)
+    install_pyenv_versions(versions.pyenv_versions)
+
+    default_python = shutil.which(versions.default_python_exe_name)
     if default_python is None:
-        raise InstallError(f"Expected default Python {default_python_exe_name} does not exist")
+        raise InstallError(
+            f"Expected default Python {versions.default_python_exe_name} does not exist"
+        )
     os.symlink(default_python, "/usr/bin/python")
 
 
@@ -169,11 +233,10 @@ class InstallError(Exception):
 
 
 def main() -> Any:
-    args_parser = ArgumentParser()
-    args_parser.add_argument("--pythons", choices=["old", "new"], default="new")
-    args = args_parser.parse_args()
-
-    install_pythons(new=args.pythons == "new")
+    if len(sys.argv) != 2:
+        raise InstallError(f"Usage: {sys.argv[0]} <versions config file>")
+    versions = Versions.parse(Path(sys.argv[1]))
+    install_pythons(versions)
 
 
 if __name__ == "__main__":

--- a/docker/base/new-versions.toml
+++ b/docker/base/new-versions.toml
@@ -1,0 +1,23 @@
+# N.B.: 2.7, 3.9 and 3.11 are needed in both version sets to run certain dev-cmd commands.
+
+default-version = "python3.14"
+versions = [
+    # N.B.: Old, but needed for some dev-cmd commands.
+    { source = "pyenv", version = "2.7.18" },
+    { source = "dead-snakes", version = "3.9.25", packages = ["dev", "venv", "distutils"] },
+
+    # New:
+    { source = "dead-snakes", version = "3.10.20", packages = ["dev", "venv", "distutils"] },
+    { source = "dead-snakes", version = "3.11.15", packages = ["dev", "venv"] },
+    { source = "pyenv", version = "3.12.13" },
+    { source = "dead-snakes", version = "3.13.14", packages = ["dev", "venv"] },
+    { source = "dead-snakes", version = "3.14.6", packages = ["dev", "venv"] },
+    { source = "dead-snakes", version = "3.15.0~b2", packages = ["dev", "venv"] },
+    { source = "pyenv", version = "pypy3.10-7.3.19" },
+    { source = "pyenv", version = "pypy3.11-7.3.22" },
+]
+
+# N.B.: These versions are installed on Ubuntu 24.04 which ships its own (older) CPython 3.12.
+uninstall-packages = [
+    "python3.12"
+]

--- a/docker/base/old-versions.toml
+++ b/docker/base/old-versions.toml
@@ -1,0 +1,34 @@
+# N.B.: 2.7, 3.9 and 3.11 are needed in both version sets to run certain dev-cmd commands.
+
+# N.B.: These versions are installed on Ubuntu 20.04 and Dead Snakes only supports 22.04 and higher;
+# so we stick to pyenv.
+
+default-version = "python3.9"
+versions = [
+    # N.B.: New, but needed for some dev-cmd commands.
+    { source = "pyenv", version = "3.11.15" },
+
+    # Old:
+    { source = "pyenv", version = "2.7.18" },
+    { source = "pyenv", version = "3.5.10" },
+    { source = "pyenv", version = "3.6.15" },
+    { source = "pyenv", version = "3.7.17" },
+    { source = "pyenv", version = "3.8.20" },
+    { source = "pyenv", version = "3.9.25" },
+    { source = "pyenv", version = "pypy2.7-7.3.22" },
+    # This is served from:
+    #   https://bitbucket-archive.softwareheritage.org/static/14/140b7b14-aa94-424e-b191-9cd3438381f7/attachments/pypy3.5-7.0.0-linux_x86_64-portable.tar.bz2
+    # which has begun to prove flaky; so we comment out for now and perhaps need to drop or
+    # self-host:
+    # { source = "pyenv", version = "pypy3.5-7.0.0" },
+    # This is failing install for unknown reasons:
+    # { source = "pyenv", version = "pypy3.6-7.3.3" },
+    { source = "pyenv", version = "pypy3.7-7.3.9" },
+    { source = "pyenv", version = "pypy3.8-7.3.11" },
+    { source = "pyenv", version = "pypy3.9-7.3.16" },
+]
+
+# N.B.: These versions are installed on Ubuntu 20.04 which ships its own (older) CPython 3.8.
+uninstall-packages = [
+    "python3.8"
+]

--- a/duvrc.sh
+++ b/duvrc.sh
@@ -30,6 +30,15 @@ BASE_INPUT=(
   "${ROOT}/docker/base/Dockerfile"
   "${ROOT}/docker/base/install-pythons.py"
 )
+if [[ "${BASE_PYTHONS}" == "new" ]]; then
+  BASE_INPUT+=(
+    "${ROOT}/docker/base/new-versions.toml"
+  )
+else
+  BASE_INPUT+=(
+    "${ROOT}/docker/base/old-versions.toml"
+  )
+fi
 base_hash=$(cat "${BASE_INPUT[@]}" | git hash-object -t blob --stdin)
 
 function base_image_id() {

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -40,7 +40,6 @@ def run_black(*args: str) -> None:
                 "--color",
                 *args,
                 "build-backend",
-                "docker",
                 "docs",
                 "package",
                 "pex",
@@ -48,6 +47,20 @@ def run_black(*args: str) -> None:
                 "setup.py",
                 "testing",
                 "tests",
+            ],
+            stdout=out_fd,
+            stderr=subprocess.STDOUT,
+            encoding="utf-8",
+            check=True,
+        )
+        subprocess.run(
+            args=[
+                "black",
+                "--color",
+                "--target-version",
+                "py310",
+                *args,
+                "docker",
             ],
             stdout=out_fd,
             stderr=subprocess.STDOUT,

--- a/scripts/typecheck.py
+++ b/scripts/typecheck.py
@@ -75,7 +75,7 @@ def main() -> None:
         subject="scripts",
     )
     run_mypy(
-        "3.9",
+        "3.11",
         files=sorted(find_files_to_check(include=["docker"])),
         subject="docker scripts",
     )


### PR DESCRIPTION
This allows the new versions image to evolve without re-building the
old versions image.