### PR TITLE
Fix download cache coherence

### DIFF
--- a/pex/resolve/downloads.py
+++ b/pex/resolve/downloads.py
@@ -11,6 +11,7 @@ from pex.artifact_url import ArtifactURL, Fingerprint
 from pex.atomic_directory import atomic_directory
 from pex.cache.dirs import CacheDir, DownloadDir
 from pex.common import safe_mkdir, safe_mkdtemp
+from pex.fs.lock import FileLockStyle
 from pex.hashing import Sha256
 from pex.jobs import Job, Raise, SpawnedJob, execute_parallel
 from pex.pip import foreign_platform
@@ -63,7 +64,9 @@ class ArtifactDownloader(object):
         hashing.file_hash(path, digest)
         fingerprint = digest.hexdigest()
         target_dir = DownloadDir.create(file_hash=fingerprint)
-        with atomic_directory(target_dir) as atomic_dir:
+        # All writers to the fingerprint-addressed DownloadDir cache must use the same lock domain.
+        # POSIX record locks and BSD flock locks do not exclude one another on Linux.
+        with atomic_directory(target_dir, lock_style=FileLockStyle.BSD) as atomic_dir:
             if not atomic_dir.is_finalized():
                 shutil.move(path, os.path.join(atomic_dir.work_dir, os.path.basename(path)))
         return Fingerprint.from_hashing_fingerprint(fingerprint)

--- a/pex/resolve/lockfile/download_manager.py
+++ b/pex/resolve/lockfile/download_manager.py
@@ -8,7 +8,7 @@ import json
 import os
 
 from pex import hashing
-from pex.atomic_directory import atomic_directory
+from pex.atomic_directory import AtomicDirectory, atomic_directory
 from pex.cache.dirs import DownloadDir
 from pex.common import safe_mkdtemp, safe_rmtree
 from pex.fs.lock import FileLockStyle
@@ -173,10 +173,30 @@ class DownloadManager(Generic["_A"]):
             if not retry:
                 raise ResultError(Error(str(e)))
 
-            TRACER.log(
-                "Found outdated downloaded artifact metadata, upgrading: {err}".format(err=e)
-            )
-            safe_rmtree(download_dir)
+            if hasattr(artifact, "fingerprint"):
+                # `atomic_directory` deliberately takes a lock only when its target does not
+                # exist. Re-check invalid metadata under the artifact lock: another process may
+                # have repaired it after our failed load but before we acquired the lock.
+                cached_download = AtomicDirectory(target_dir=download_dir, locked=True)
+                with cached_download.locked(lock_style=self._file_lock_style):
+                    try:
+                        return DownloadedArtifact.load(download_dir)
+                    except DownloadedArtifact.LoadError as locked_error:
+                        TRACER.log(
+                            "Found outdated downloaded artifact metadata, upgrading: "
+                            "{err}".format(err=locked_error)
+                        )
+                        safe_rmtree(download_dir)
+            else:
+                # Unfingerprinted artifacts use a private temporary directory, not the shared
+                # download cache, so there is no artifact lock to acquire for cleanup.
+                TRACER.log(
+                    "Found outdated downloaded artifact metadata, upgrading: {err}".format(err=e)
+                )
+                safe_rmtree(download_dir)
+
+            # Do not rebuild while holding the artifact lock: Pex's in-process file lock is
+            # intentionally non-reentrant. `atomic_directory` will re-check after acquiring it.
             return self.store(artifact, project_name, retry=False)
 
     def _download(

--- a/pex/resolve/lockfile/download_manager.py
+++ b/pex/resolve/lockfile/download_manager.py
@@ -129,7 +129,7 @@ class DownloadManager(Generic["_A"]):
     def __init__(
         self,
         pex_root=ENV,  # type: Union[str, Variables]
-        file_lock_style=FileLockStyle.POSIX,  # type: FileLockStyle.Value
+        file_lock_style=FileLockStyle.BSD,  # type: FileLockStyle.Value
     ):
         # type: (...) -> None
         self._pex_root = pex_root

--- a/tests/resolve/lockfile/test_download_manager.py
+++ b/tests/resolve/lockfile/test_download_manager.py
@@ -10,6 +10,7 @@ import pytest
 from pex import hashing
 from pex.artifact_url import ArtifactURL, Fingerprint
 from pex.cache.dirs import CacheDir
+from pex.fs.lock import FileLockStyle
 from pex.hashing import Sha1Fingerprint, Sha256Fingerprint
 from pex.pep_503 import ProjectName
 from pex.resolve.locked_resolve import FileArtifact
@@ -106,6 +107,12 @@ def test_storage_cache(
     downloaded_artifact2 = download_manager.store(artifact, project_name)
     assert downloaded_artifact1 == downloaded_artifact2
     assert 1 == len(download_manager.save_calls)
+
+
+def test_download_cache_uses_bsd_locks(download_manager):
+    # type: (FakeDownloadManager) -> None
+
+    assert FileLockStyle.BSD is download_manager._file_lock_style
 
 
 def test_storage_version_upgrade(

--- a/tests/resolve/test_downloads.py
+++ b/tests/resolve/test_downloads.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from contextlib import contextmanager
+
+from pex.fs.lock import FileLockStyle
+from pex.resolve import downloads
+from pex.resolve.downloads import ArtifactDownloader
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Iterator
+
+
+def test_fingerprint_download_uses_bsd_lock(tmpdir, monkeypatch):
+    # type: (Any, Any) -> None
+
+    artifact = tmpdir.join("artifact.whl")
+    with open(artifact, "wb") as fp:
+        fp.write(b"content")
+    lock_styles = []
+
+    @contextmanager
+    def observe_atomic_directory(_target_dir, lock_style=None):
+        # type: (str, Any) -> Iterator[Any]
+        lock_styles.append(lock_style)
+
+        class Finalized(object):
+            @staticmethod
+            def is_finalized():
+                # type: () -> bool
+                return True
+
+        yield Finalized()
+
+    monkeypatch.setattr(downloads, "atomic_directory", observe_atomic_directory)
+
+    ArtifactDownloader._fingerprint_and_move(artifact)
+    assert [FileLockStyle.BSD] == lock_styles


### PR DESCRIPTION
## Summary

This PR previously made locked `AtomicDirectory` work directories owner-specific. After digging further, that change addressed a symptom rather than the cause of the failures we were seeing, so this PR has been re-pointed at the root cause. It is now three commits, each independently reviewable:

1. **Accept legacy v2 downloaded artifact metadata.** The metadata version was bumped 2 → 3 in 826ef8e3 (#3112, first released in 2.91.0) to record local-project editability. Since then, a download cache populated by an older Pex fails every `DownloadedArtifact.load` with a `LoadError`, mass-invalidating the entire cache on first use. v2 metadata predates editable support entirely, so it is now read in place as `editable=False`. To preserve v3 semantics, `store()` also cross-checks the requested artifact's editability against the cached metadata and rebuilds on mismatch (previously, since `DownloadDir` is keyed only by file hash, an entry stored with one editability was silently returned for requests wanting the other).

2. **Remove invalid download cache entries under the artifact lock.** On `LoadError`, `DownloadManager.store` called `safe_rmtree(download_dir)` on the shared, finalized cache directory *with no lock held*. Readers are lock-free by design (`atomic_directory` only locks when its target does not exist), so under concurrent resolves one process could delete a directory another process had just repaired or was actively reading. Combined with a metadata version bump, this cascades: every process that observed the old metadata queues up a deletion of the freshly repaired directory. The invalid entry is now re-checked under the artifact lock before removal; the rebuild happens after the lock is released because Pex's in-process file lock is intentionally non-reentrant (`atomic_directory` re-checks after re-acquiring).

3. **Use BSD file locks for all `DownloadDir` writers.** On Linux, POSIX record locks (`fcntl`/`lockf`) and BSD locks (`flock`) live in independent lock tables and do not exclude one another. The fingerprint-addressed download cache had writers in both domains: `LockDownloader` uses BSD locks, while `ArtifactDownloader._fingerprint_and_move` and the `DownloadManager` default used POSIX locks on the same lockfile — so a lock creation running concurrently with a lock resolve could have two writers inside the critical section for the same artifact. Pex already requires working `flock` for cache access (`pex/cache/access.py`), so this adds no new platform requirements.

## The failure we observed

After upgrading Pants (and with it Pex ~2.81 → 2.95) with the Pex cache restored across the upgrade, CI began failing nondeterministically with downloaded wheels disappearing during concurrent resolution. The mechanism is the interaction of commits 1 and 2: the restored cache was all v2 metadata, so every concurrent Pex process hit `LoadError` on the same shared directories and issued unlocked `safe_rmtree` calls — deleting entries that sibling processes had just repaired or were reading.

## Why the work-directory approach was replaced

The earlier change here gave each locked owner a unique work directory to protect against a "cancelled owner cleaning up under a new owner". Two problems with that:

- Pants preemption (dynamic concurrency restarts) SIGKILLs the entire process group with no graceful phase, so a cancelled owner never runs late cleanup, and no descendant survives to write into an adopted work directory. In the `atomic_directory` context manager, `cleanup()` also always precedes `unlock()`, so a live owner cannot clean up after losing the lock unless lock exclusion is already broken — which commit 3 addresses at the source.
- With unique names, a SIGKILLed owner's work directory (holding a partial download) is never adopted or cleaned by the next owner, and nothing prunes it, so preemption-heavy CI would leak cache space unboundedly.

If owner-specific work directories are still wanted as insurance against exclusion failures (e.g. NFS), I'm happy to follow up separately with a stale work-directory cleanup to accompany them.

## Validation

- `tests/resolve/lockfile/test_download_manager.py` — v2 read-in-place, editable-mismatch rebuild, removal-under-lock ordering, and re-check-after-locking (a concurrently repaired entry is not deleted).
- `tests/resolve/test_downloads.py` — `_fingerprint_and_move` uses the BSD lock domain.

All 10 focused tests pass.
