### PR TITLE
Use BSD locks for all DownloadDir writers

### DIFF
--- a/pex/resolve/downloads.py
+++ b/pex/resolve/downloads.py
@@ -11,6 +11,7 @@ from pex.artifact_url import ArtifactURL, Fingerprint
 from pex.atomic_directory import atomic_directory
 from pex.cache.dirs import CacheDir, DownloadDir
 from pex.common import safe_mkdir, safe_mkdtemp
+from pex.fs.lock import FileLockStyle
 from pex.hashing import Sha256
 from pex.jobs import Job, Raise, SpawnedJob, execute_parallel
 from pex.pip import foreign_platform
@@ -63,7 +64,9 @@ class ArtifactDownloader(object):
         hashing.file_hash(path, digest)
         fingerprint = digest.hexdigest()
         target_dir = DownloadDir.create(file_hash=fingerprint)
-        with atomic_directory(target_dir) as atomic_dir:
+        # All writers to the fingerprint-addressed DownloadDir cache must use the same lock domain.
+        # POSIX record locks and BSD flock locks do not exclude one another on Linux.
+        with atomic_directory(target_dir, lock_style=FileLockStyle.BSD) as atomic_dir:
             if not atomic_dir.is_finalized():
                 shutil.move(path, os.path.join(atomic_dir.work_dir, os.path.basename(path)))
         return Fingerprint.from_hashing_fingerprint(fingerprint)

--- a/pex/resolve/lockfile/download_manager.py
+++ b/pex/resolve/lockfile/download_manager.py
@@ -129,7 +129,7 @@ class DownloadManager(Generic["_A"]):
     def __init__(
         self,
         pex_root=ENV,  # type: Union[str, Variables]
-        file_lock_style=FileLockStyle.POSIX,  # type: FileLockStyle.Value
+        file_lock_style=FileLockStyle.BSD,  # type: FileLockStyle.Value
     ):
         # type: (...) -> None
         self._pex_root = pex_root

--- a/tests/resolve/lockfile/test_download_manager.py
+++ b/tests/resolve/lockfile/test_download_manager.py
@@ -10,6 +10,7 @@ import pytest
 from pex import hashing
 from pex.artifact_url import ArtifactURL, Fingerprint
 from pex.cache.dirs import CacheDir
+from pex.fs.lock import FileLockStyle
 from pex.hashing import Sha1Fingerprint, Sha256Fingerprint
 from pex.pep_503 import ProjectName
 from pex.resolve.locked_resolve import FileArtifact
@@ -106,6 +107,12 @@ def test_storage_cache(
     downloaded_artifact2 = download_manager.store(artifact, project_name)
     assert downloaded_artifact1 == downloaded_artifact2
     assert 1 == len(download_manager.save_calls)
+
+
+def test_download_cache_uses_bsd_locks(download_manager):
+    # type: (FakeDownloadManager) -> None
+
+    assert FileLockStyle.BSD is download_manager._file_lock_style
 
 
 def test_storage_version_upgrade(

--- a/tests/resolve/test_downloads.py
+++ b/tests/resolve/test_downloads.py
@@ -1,0 +1,39 @@
+# Copyright 2026 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from contextlib import contextmanager
+
+from pex.fs.lock import FileLockStyle
+from pex.resolve import downloads
+from pex.resolve.downloads import ArtifactDownloader
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Any, Iterator
+
+
+def test_fingerprint_download_uses_bsd_lock(tmpdir, monkeypatch):
+    # type: (Any, Any) -> None
+
+    artifact = tmpdir.join("artifact.whl")
+    with open(artifact, "wb") as fp:
+        fp.write(b"content")
+    lock_styles = []
+
+    @contextmanager
+    def observe_atomic_directory(_target_dir, lock_style=None):
+        # type: (str, Any) -> Iterator[Any]
+        lock_styles.append(lock_style)
+
+        class Finalized(object):
+            @staticmethod
+            def is_finalized():
+                # type: () -> bool
+                return True
+
+        yield Finalized()
+
+    monkeypatch.setattr(downloads, "atomic_directory", observe_atomic_directory)
+
+    ArtifactDownloader._fingerprint_and_move(artifact)
+    assert [FileLockStyle.BSD] == lock_styles


### PR DESCRIPTION
## Summary

Use BSD file locks for every writer to the fingerprint-addressed `DownloadDir` cache.

`LockDownloader` already uses BSD locks because it writes from a thread pool. `ArtifactDownloader._fingerprint_and_move` and `DownloadManager` previously used POSIX locks on the same lockfiles. On Linux, `flock` and `lockf` use independent lock domains, so two processes could both enter the same `atomic_directory` critical section and operate on the shared `.lck.work` directory.

This changes the remaining writers to BSD locks. It is independent of the invalid-cache `rmtree` fix in #3204.

## Reproduction

A two-process Linux amd64 reproducer used a BSD owner and a POSIX owner on the same atomic directory. Both acquired their locks. The second owner found the existing `.lck.work` directory and forcibly recreated it, deleting the first owner's wheel. The first owner then failed with the same error shape observed in Pants CI:

```text
[Errno 2] No such file or directory: .../fingerprint.lck.work/demo-1.0-py3-none-any.whl
```

## Validation

- `uv run dev-cmd format lint typecheck`
- `uv run dev-cmd test-py312 -- tests/resolve/lockfile/test_download_manager.py tests/resolve/test_downloads.py`
- 6 focused tests passed
