### PR TITLE
Fix marker envs generated from abbreviated platforms.

### DIFF
--- a/pex/interpreter_implementation.py
+++ b/pex/interpreter_implementation.py
@@ -16,6 +16,7 @@ class _InterpreterImplementationValue(Enum.Value):
         value,  # type: str
         abbr,  # type: str
         binary_name,  # type: str
+        platform_python_implementation=None,  # type: Optional[str]
         alias=None,  # type: Optional[str]
         free_threaded=None,  # type: Optional[bool]
         initial_version=None,  # type: Optional[Tuple[int, ...]]
@@ -23,6 +24,7 @@ class _InterpreterImplementationValue(Enum.Value):
         # type: (...) -> None
         super(_InterpreterImplementationValue, self).__init__(value)
         self.abbr = abbr
+        self.platform_python_implementation = platform_python_implementation or value
         self.binary_name = binary_name
         self.alias = alias
         self.free_threaded = free_threaded
@@ -86,11 +88,19 @@ class InterpreterImplementation(Enum["InterpreterImplementation.Value"]):
         "CPython+t",
         "cp",
         "python",
+        platform_python_implementation="CPython",
         alias="CPython[free-threaded]",
         free_threaded=True,
         initial_version=(3, 13),
     )
-    CPYTHON_GIL = Value("CPython-t", "cp", "python", alias="CPython[gil]", free_threaded=False)
+    CPYTHON_GIL = Value(
+        "CPython-t",
+        "cp",
+        "python",
+        platform_python_implementation="CPython",
+        alias="CPython[gil]",
+        free_threaded=False,
+    )
     PYPY = Value("PyPy", "pp", "pypy")
 
 

--- a/pex/pep_508.py
+++ b/pex/pep_508.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import
 
 from pex.interpreter_implementation import InterpreterImplementation
-from pex.platforms import Platform
+from pex.platforms import PlatformSpec
 from pex.third_party.packaging import markers
 from pex.typing import TYPE_CHECKING
 
@@ -49,7 +49,7 @@ class MarkerEnvironment(object):
 
     @classmethod
     def from_platform(cls, platform):
-        # type: (Platform) -> MarkerEnvironment
+        # type: (PlatformSpec) -> MarkerEnvironment
         """Populate a partial marker environment given what we know from platform information.
 
         Since Pex support is (currently) restricted to:
@@ -117,10 +117,10 @@ class MarkerEnvironment(object):
             platform_system = "Windows"
             sys_platform = "win32"
 
-        platform_python_implementation = None
         for implementation in InterpreterImplementation.values():
             if implementation.abbr == platform.impl:
-                platform_python_implementation = implementation.value
+                platform_python_implementation = implementation.platform_python_implementation
+                break
 
         python_version = ".".join(map(str, platform.version_info[:2]))
 

--- a/tests/test_issue_3208.py
+++ b/tests/test_issue_3208.py
@@ -1,0 +1,48 @@
+# Copyright 2026 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from pex.pep_508 import MarkerEnvironment
+from pex.platforms import PlatformSpec
+from pex.typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Tuple, Union
+
+
+def test_marker_env_from_platform():
+    # type: () -> None
+
+    def assert_marker_env(
+        platform_spec,  # type: str
+        python_version,  # type: Union[Tuple[int, int], Tuple[int, int, int]]
+        implementation_name="cpython",  # type: str
+        platform_python_implementation="CPython",  # type: str
+    ):
+        # type: (...) -> None
+
+        marker_env = MarkerEnvironment.from_platform(PlatformSpec.parse(platform_spec))
+        assert marker_env.implementation_name == implementation_name
+        assert marker_env.implementation_version is None
+        assert marker_env.os_name == "posix"
+        assert marker_env.platform_machine == "x86_64"
+        assert marker_env.platform_python_implementation == platform_python_implementation
+        assert marker_env.platform_release is None
+        assert marker_env.platform_system == "Linux"
+        assert marker_env.platform_version is None
+        assert marker_env.python_full_version == (
+            ".".join(map(str, python_version)) if len(python_version) == 3 else None
+        )
+        assert marker_env.python_version == ".".join(map(str, python_version[:2]))
+        assert marker_env.sys_platform == "linux"
+
+    assert_marker_env("linux_x86_64-cp-39-cp39", (3, 9))
+    assert_marker_env("linux_x86_64-cp-3.9.25-cp39", (3, 9, 25))
+    assert_marker_env("linux_x86_64-cp-3.14.15-cp314t", (3, 14, 15))
+    assert_marker_env(
+        "linux-x86_64-pp-311-pypy311_pp73",
+        (3, 11),
+        implementation_name="pypy",
+        platform_python_implementation="PyPy",
+    )


### PR DESCRIPTION
The introduction of free-threaded support to interpreter selection broke
this.

Fixes #3208