### PR TITLE
Simplify lock creation download caching.

### DIFF
--- a/pex/resolve/lockfile/create.py
+++ b/pex/resolve/lockfile/create.py
@@ -9,11 +9,13 @@ from collections import OrderedDict, defaultdict
 from multiprocessing.pool import ThreadPool
 
 from pex import hashing
+from pex.atomic_directory import atomic_directory
 from pex.auth import PasswordDatabase
 from pex.build_system import pep_517
+from pex.cache.dirs import DownloadDir
 from pex.common import pluralize, safe_mkdtemp
 from pex.dependency_configuration import DependencyConfiguration
-from pex.dist_metadata import DistMetadata, ProjectNameAndVersion, Requirement, is_sdist, is_wheel
+from pex.dist_metadata import DistMetadata, ProjectNameAndVersion, Requirement
 from pex.exceptions import production_assert
 from pex.fetcher import URLFetcher
 from pex.jobs import Job, Retain, SpawnedJob, execute_parallel
@@ -29,7 +31,6 @@ from pex.resolve.configured_resolver import ConfiguredResolver
 from pex.resolve.downloads import ArtifactDownloader
 from pex.resolve.lock_downloader import LockDownloader
 from pex.resolve.locked_resolve import (
-    Artifact,
     DownloadableArtifact,
     FileArtifact,
     LocalProjectArtifact,
@@ -39,7 +40,7 @@ from pex.resolve.locked_resolve import (
     VCSArtifact,
 )
 from pex.resolve.locker import Locker
-from pex.resolve.lockfile.download_manager import DownloadManager
+from pex.resolve.lockfile.download_manager import DownloadedArtifact
 from pex.resolve.lockfile.model import Lockfile
 from pex.resolve.lockfile.targets import DownloadInput, calculate_download_input
 from pex.resolve.package_repository import ReposConfiguration
@@ -58,7 +59,7 @@ from pex.resolver import (
 )
 from pex.resolver import download_requests as pip_download_requests
 from pex.resolver import reports as pip_reports
-from pex.result import Error, ResultError, try_
+from pex.result import Error, try_
 from pex.targets import Target, Targets
 from pex.tracer import TRACER
 from pex.typing import TYPE_CHECKING, cast
@@ -70,7 +71,6 @@ if TYPE_CHECKING:
 
     import attr  # vendor:skip
 
-    from pex.hashing import HintedDigest
     from pex.requirements import ParsedRequirement
 
     AnyArtifact = Union[FileArtifact, LocalProjectArtifact, VCSArtifact]
@@ -78,7 +78,7 @@ else:
     from pex.third_party import attr
 
 
-class CreateLockDownloadManager(DownloadManager[Artifact]):
+class DownloadCacheManager(object):
     @classmethod
     def create(
         cls,
@@ -86,7 +86,7 @@ class CreateLockDownloadManager(DownloadManager[Artifact]):
         locked_resolves,  # type: Iterable[LockedResolve]
         pex_root=ENV,  # type: Union[str, Variables]
     ):
-        # type: (...) -> CreateLockDownloadManager
+        # type: (...) -> DownloadCacheManager
 
         file_artifacts_by_filename = defaultdict(
             list
@@ -161,10 +161,10 @@ class CreateLockDownloadManager(DownloadManager[Artifact]):
         pex_root=ENV,  # type: Union[str, Variables]
     ):
         # type: (...) -> None
-        super(CreateLockDownloadManager, self).__init__(pex_root=pex_root)
         self._path_and_version_by_artifact_and_project_name = dict(
             path_and_version_by_artifact_and_project_name
         )
+        self._pex_root = pex_root
 
     def store_all(
         self,
@@ -183,14 +183,26 @@ class CreateLockDownloadManager(DownloadManager[Artifact]):
     ):
         # type: (...) -> None
 
-        downloadable_artifacts = [
-            DownloadableArtifact(project_name=project_name, artifact=artifact, version=version)
-            for (artifact, project_name), (
-                path,
-                version,
-            ) in self._path_and_version_by_artifact_and_project_name.items()
-            if path is None
-        ]
+        path_and_version_by_artifact_and_project_name = (
+            {}
+        )  # type: Dict[Tuple[AnyArtifact, ProjectName], Tuple[str, Optional[Version]]]
+        downloadable_artifacts = []  # type: List[DownloadableArtifact]
+        for (artifact, project_name), (
+            path,
+            version,
+        ) in self._path_and_version_by_artifact_and_project_name.items():
+            if path:
+                path_and_version_by_artifact_and_project_name[(artifact, project_name)] = (
+                    path,
+                    version,
+                )
+            else:
+                downloadable_artifacts.append(
+                    DownloadableArtifact(
+                        project_name=project_name, artifact=artifact, version=version
+                    )
+                )
+
         downloader = LockDownloader.create(
             targets=targets,
             lock_configuration=lock_configuration,
@@ -222,80 +234,44 @@ class CreateLockDownloadManager(DownloadManager[Artifact]):
                 isinstance(artifact, (FileArtifact, LocalProjectArtifact, VCSArtifact))
             )
 
-            self._path_and_version_by_artifact_and_project_name[
+            path_and_version_by_artifact_and_project_name[
                 (artifact, downloadable_artifact.project_name)
             ] = (downloaded_artifact.path, downloadable_artifact.version)
 
-        for artifact, project_name in self._path_and_version_by_artifact_and_project_name:
-            self.store(artifact, project_name)
-
-    def digest(
-        self,
-        artifact,  # type: Artifact
-        project_name,  # type: ProjectName
-        download_dir,  # type: str
-        digest,  # type: HintedDigest
-    ):
-        # type: (...) -> str
-
-        archives = [path for path in os.listdir(download_dir) if is_sdist(path) or is_wheel(path)]
-        if not archives:
-            raise ResultError(
-                Error(
-                    "Found no artifact for {project_name} in download directory "
-                    "{download_dir}.".format(project_name=project_name, download_dir=download_dir)
-                )
-            )
-        if len(archives) > 1:
-            raise ResultError(
-                Error(
-                    "Found more than one artifact for {project_name} in download directory "
-                    "{download_dir}:\n"
-                    "{artifacts}".format(
-                        project_name=project_name,
-                        download_dir=download_dir,
-                        artifacts="\n".join(
-                            "{idx}. {artifact}".format(idx=idx, artifact=artifact)
-                            for idx, artifact in enumerate(archives, start=1)
+        for (artifact, project_name), (
+            artifact_path,
+            version,
+        ) in path_and_version_by_artifact_and_project_name.items():
+            download_dir = DownloadDir.create(
+                file_hash=artifact.fingerprint.hash, pex_root=self._pex_root
+            )  # type: str
+            with atomic_directory(download_dir) as atomic_dir:
+                if not atomic_dir.is_finalized():
+                    TRACER.log(
+                        "Caching download of {project_name_and_version} by Pip at {artifact_path} "
+                        "to {download_dir}".format(
+                            project_name_and_version=(
+                                "{project_name} {version}".format(
+                                    project_name=project_name, version=version
+                                )
+                                if version
+                                else project_name
+                            ),
+                            artifact_path=artifact_path,
+                            download_dir=download_dir,
+                        )
+                    )
+                    filename = os.path.basename(artifact_path)
+                    shutil.move(artifact_path, os.path.join(atomic_dir.work_dir, filename))
+                    DownloadedArtifact.store(
+                        artifact=artifact,
+                        artifact_dir=atomic_dir.work_dir,
+                        filename=filename,
+                        fingerprint=hashing.new_fingerprint(
+                            algorithm=artifact.fingerprint.algorithm,
+                            hexdigest=artifact.fingerprint.hash,
                         ),
                     )
-                )
-            )
-        filename = archives[0]
-        archive = os.path.join(download_dir, filename)
-        hashing.file_hash(archive, digest=digest)
-        return filename
-
-    def save(
-        self,
-        artifact,  # type: Artifact
-        project_name,  # type: ProjectName
-        dest_dir,  # type: str
-        digest,  # type: HintedDigest
-    ):
-        # type: (...) -> Union[str, Error]
-
-        # N.B.: The input to save comes from self.store in self.store_all above and these inputs
-        # are all AnyArtifacts.
-        artifact_to_store = cast("AnyArtifact", artifact)
-        production_assert(
-            isinstance(artifact_to_store, (FileArtifact, LocalProjectArtifact, VCSArtifact))
-        )
-
-        path, _ = self._path_and_version_by_artifact_and_project_name[
-            (artifact_to_store, project_name)
-        ]
-        # N.B.: We filled out all None paths above in store_all or else failed if downloads failed
-        # there.
-        src = cast(str, path)
-        production_assert(isinstance(src, str))
-
-        filename = os.path.basename(src)
-        dest = os.path.join(dest_dir, filename)
-        shutil.move(src, dest)
-
-        hashing.file_hash(dest, digest=digest)
-        return filename
 
 
 @attr.s(frozen=True)
@@ -726,11 +702,11 @@ def create(
         )
     )
 
-    with TRACER.timed("Indexing downloads"):
-        create_lock_download_manager = CreateLockDownloadManager.create(
+    with TRACER.timed("Caching Pip downloads"):
+        download_cache_manager = DownloadCacheManager.create(
             download_dir=download_dir, locked_resolves=locked_resolves
         )
-        create_lock_download_manager.store_all(
+        download_cache_manager.store_all(
             targets=OrderedSet(
                 download_request.target for download_request in download_input.download_requests
             ),

--- a/pex/resolve/lockfile/download_manager.py
+++ b/pex/resolve/lockfile/download_manager.py
@@ -52,7 +52,7 @@ class DownloadedArtifact(object):
         return os.path.join(artifact_dir, "metadata.json")
 
     @classmethod
-    def store(
+    def store_with_legacy(
         cls,
         artifact,  # type: _A
         artifact_dir,  # type: str
@@ -66,6 +66,17 @@ class DownloadedArtifact(object):
         with atomic_text_file(os.path.join(artifact_dir, "sha1")) as fp:
             fp.write(artifact_digests.legacy_internal_hasher.hexdigest())
 
+        return cls.store(artifact, artifact_dir, filename, artifact_digests.fingerprint())
+
+    @classmethod
+    def store(
+        cls,
+        artifact,  # type: _A
+        artifact_dir,  # type: str
+        filename,  # type: str
+        fingerprint,  # type: hashing.Fingerprint
+    ):
+        # type: (...) -> DownloadedArtifact
         # N.B.: Pip already accounts for subdirectory when it creates source zips from VCS
         # requirements; so we elide unless the archive was a directly downloaded file artifact.
         subdirectory = artifact.subdirectory if isinstance(artifact, FileArtifact) else None
@@ -76,12 +87,10 @@ class DownloadedArtifact(object):
             else False
         )
 
-        fingerprint = artifact_digests.fingerprint()
-
         with atomic_text_file(cls.metadata_filename(artifact_dir)) as fp:
             json.dump(
                 dict(
-                    algorithm=artifact_digests.algorithm,
+                    algorithm=fingerprint.algorithm,
                     hexdigest=fingerprint,
                     filename=filename,
                     subdirectory=subdirectory,
@@ -262,7 +271,7 @@ class DownloadManager(Generic["_A"]):
                 digest=artifact_digests.digest,
             )
             artifact_digests.check(project_name)
-            return DownloadedArtifact.store(
+            return DownloadedArtifact.store_with_legacy(
                 artifact=artifact,
                 artifact_dir=download_dir,
                 filename=filename,
@@ -292,7 +301,7 @@ class DownloadManager(Generic["_A"]):
                 )
             )
         artifact_digests.check(project_name=project_name)
-        return DownloadedArtifact.store(
+        return DownloadedArtifact.store_with_legacy(
             artifact=artifact,
             artifact_dir=dest_dir,
             filename=filename,

--- a/tests/resolve/lockfile/test_download_manager.py
+++ b/tests/resolve/lockfile/test_download_manager.py
@@ -172,7 +172,7 @@ def test_storage_version_downgrade_v0(tmpdir):
     )
 
     artifact_digests = ArtifactDigests(artifact)
-    DownloadedArtifact.store(
+    DownloadedArtifact.store_with_legacy(
         artifact=artifact,
         artifact_dir=str(tmpdir),
         filename="foo",


### PR DESCRIPTION
This worked previously, but it was not at all obvious. In particular,
it looked like digests calculated in the caching phase would not match
those calculated when locking. Simplification reveals download caching
only deals with artifacts that already have a fingerprint, and that
fingerprint can be re-used.

Prompted by @tobni's review of #3207.

C.F.: #1650 whose functionality this preserves.