### PR TITLE
Add explicit grouping to ensure `and` / `or` precedence.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## 2.98.1
+
+This release fixes marker processing in `--style universal` locks to respect `and` binding more
+tightly than `or` in the spec. Previously `and` and `or` were processed left to right without
+regard for precedence rules. Thanks to @notatallshaw for a pre-emptive report of this when surveying
+the ecosystem.
+
+* Add explicit grouping to ensure `and` / `or` precedence. (#3219)
+
 ## 2.98.0
 
 This release adds proper support for windowed PEX scies targeting Windows. When you specify at least

--- a/pex/resolve/target_system.py
+++ b/pex/resolve/target_system.py
@@ -140,6 +140,41 @@ class MarkerVisitor(Generic["_C"]):
 if TYPE_CHECKING:
     _C = TypeVar("_C")
 
+    Expression = Tuple[Any, str, Any]
+    ComplexExpression = List[Union[str, Expression, List]]
+
+
+class _ParenthesizedAnd(list):
+    pass
+
+
+def _canonicalize_expression(
+    expression,  # type: ComplexExpression
+    marker,  # type: Marker
+):
+    # type: (...) -> ComplexExpression
+
+    # N.B.: Instead of shunting yard or Pratt, this is in the spirit of Fortran:
+    #   https://en.wikipedia.org/wiki/Operator-precedence_parser#Full_parenthesization
+    # Since we only have 1 precedence rule to respect (`and` binds more tightly than `or`), this
+    # seems simple and direct, just add explicit parenthesization around all `and`s.
+
+    canonicalized_expression = []  # type: ComplexExpression
+    for item in expression:
+        if item == "and":
+            if len(canonicalized_expression) == 0:
+                raise ValueError("Marker is invalid: {marker}".format(marker=marker))
+            canonicalized_expression[-1] = _ParenthesizedAnd([canonicalized_expression[-1], "and"])
+        else:
+            item = _canonicalize_expression(item, marker) if isinstance(item, list) else item
+            if len(canonicalized_expression) > 1 and isinstance(
+                canonicalized_expression[-1], _ParenthesizedAnd
+            ):
+                cast(_ParenthesizedAnd, canonicalized_expression[-1]).append(item)
+            else:
+                canonicalized_expression.append(item)
+    return canonicalized_expression
+
 
 class MarkerParser(Generic["_C"]):
     def __init__(self, visitor):
@@ -177,7 +212,11 @@ class MarkerParser(Generic["_C"]):
     ):
         # type: (...) -> _C
 
-        for item in _marker_items(marker):
+        # 1. Ensure precedence is respected for unparenthesized `and` and `or` operators.
+        items = _canonicalize_expression(list(_marker_items(marker)), marker)
+
+        # 2. perform walk:
+        for item in items:
             self._parse_marker_item(item, marker, context)
         return context
 

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.98.0"
+__version__ = "2.98.1"

--- a/testing/lock.py
+++ b/testing/lock.py
@@ -10,11 +10,11 @@ from pex.resolve.lockfile.model import Lockfile
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import List, Mapping, Union
+    from typing import Dict, List, Union
 
 
 def index_lock_artifacts(lock_file):
-    # type: (Union[str, Lockfile]) -> Mapping[ProjectName, LockedRequirement]
+    # type: (Union[str, Lockfile]) -> Dict[ProjectName, LockedRequirement]
 
     lock = lock_file if isinstance(lock_file, Lockfile) else json_codec.load(lock_file)
     assert 1 == len(lock.locked_resolves)

--- a/tests/integration/cli/commands/test_issue_3206.py
+++ b/tests/integration/cli/commands/test_issue_3206.py
@@ -1,0 +1,37 @@
+# Copyright 2026 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+from pex.pep_440 import Version
+from pex.pep_503 import ProjectName
+from testing.cli import run_pex3
+from testing.lock import index_lock_artifacts
+from testing.pytest_utils.tmp import Tempdir
+
+
+def test_marker_conjunction_precedence(tmpdir):
+    # type: (Tempdir) -> None
+
+    lock_file = tmpdir.join("lock.json")
+    run_pex3(
+        "lock",
+        "create",
+        "--style",
+        "universal",
+        "--target-system",
+        "linux",
+        (
+            "ansicolors==1.1.8; "
+            'sys_platform == "linux" or sys_platform == "win32" and sys_platform == "aix"'
+        ),
+        "--indent",
+        "2",
+        "-o",
+        lock_file,
+    ).assert_success()
+
+    lock_artifacts = index_lock_artifacts(lock_file)
+    locked_artifact = lock_artifacts.pop(ProjectName("ansicolors"))
+    assert not lock_artifacts, "Should have locked just 1 project."
+    assert Version("1.1.8") == locked_artifact.pin.version

--- a/tests/resolve/test_marker_env_conjunction_precedence.py
+++ b/tests/resolve/test_marker_env_conjunction_precedence.py
@@ -1,0 +1,66 @@
+# Copyright 2026 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import print_function
+
+from pex.interpreter_implementation import InterpreterImplementation
+from pex.resolve.target_system import MarkerEnv, TargetSystem, UniversalTarget
+from pex.third_party.packaging.markers import Marker
+
+
+def test_issue_3206():
+    # type: () -> None
+
+    marker_env = MarkerEnv.create(
+        extras=(),
+        universal_target=UniversalTarget(
+            implementation=InterpreterImplementation.PYPY, systems=(TargetSystem.LINUX,)
+        ),
+    )
+
+    # N.B.: This works both on a simple LR scan and with proper precedence logic.
+    assert marker_env.evaluate(
+        Marker("sys_platform == 'win32' and sys_platform == 'aix' or sys_platform == 'linux'")
+    )
+
+    # No precedence left implicit.
+    assert marker_env.evaluate(
+        Marker("sys_platform == 'linux' or (sys_platform == 'win32' and sys_platform == 'aix')")
+    )
+
+    # Implicit precedence to respect:
+    assert marker_env.evaluate(
+        Marker("sys_platform == 'linux' or sys_platform == 'win32' and sys_platform == 'aix'")
+    ), (
+        "The `and` operator should bind more tightly than the `or` operator per the PEP-508 "
+        "grammar: "
+        "https://packaging.python.org/en/latest/specifications/dependency-specifiers/#complete-grammar"
+    )
+
+    assert marker_env.evaluate(
+        Marker(
+            "sys_platform == 'darwin' "
+            "or sys_platform == 'win32' and sys_platform == 'aix' "
+            "or sys_platform == 'linux'"
+        )
+    )
+
+    assert marker_env.evaluate(
+        Marker(
+            "sys_platform == 'darwin' "
+            "or sys_platform == 'linux' and platform_python_implementation == 'PyPy'"
+        )
+    )
+    assert not marker_env.evaluate(
+        Marker(
+            "sys_platform == 'darwin' "
+            "or sys_platform == 'linux' and platform_python_implementation == 'CPython'"
+        )
+    )
+    assert marker_env.evaluate(
+        Marker(
+            "sys_platform == 'darwin' "
+            "or sys_platform == 'linux' and platform_python_implementation == 'CPython'"
+            "or sys_platform != 'aix' and platform_python_implementation == 'PyPy'"
+        )
+    )


### PR DESCRIPTION
Fixes #3206