### PR TITLE
All scies honor platform cache conventions & are re-packable.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,23 @@
 # Release Notes
 
+## 2.98.2
+
+This release fixes generation of foreign platform PEX scies to respect the foreign platform cache
+directory standards.
+
+In addition `--scie only -o <name that does not end in ".pex">` PEX scies can now be split and
+re-packed with:
+```console
+:; SCIE=split <PEX scie> split-dir
+:; cd split-dir
+:; ./scie-jump
+```
+
+Previously splitting always worked, but the scie boot-pack would fail due to a name clash between
+the final scie and the application PEX file.
+
+* All scies honor platform cache conventions & are re-packable. (#3220)
+
 ## 2.98.1
 
 This release fixes marker processing in `--style universal` locks to respect `and` binding more

--- a/pex/scie/science.py
+++ b/pex/scie/science.py
@@ -416,7 +416,18 @@ def create_manifests(
             lift["base"] = configuration.options.base
         elif pex_info.pex_root_set:
             lift["base"] = CacheDir.SCIES.path(
-                "base", os=interpreter.platform.os, pex_root=pex_info.raw_pex_root
+                "base",
+                os=interpreter.platform.os,
+                pex_root=(
+                    pex_info.raw_pex_root
+                    if interpreter.platform.os is Os.CURRENT
+                    else interpreter.platform.os.path_join(
+                        "{{scie.user.cache_dir={fallback}}}".format(
+                            fallback=interpreter.platform.os.path_join("~", ".cache")
+                        ),
+                        "pex",
+                    )
+                ),
             )
 
         manifest_path = os.path.join(

--- a/pex/scie/science.py
+++ b/pex/scie/science.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import
 
+import itertools
 import os.path
 import re
 import shutil
@@ -324,7 +325,9 @@ def create_manifests(
     # Try to give the PEX the extracted filename expected by the user. This should work in almost
     # all cases save for the Pex PEX.
     pex_name = os.path.basename(pex.path())
-    if pex_name not in frozenset(filename.value for filename in Filenames.values()):
+    if pex_name not in frozenset(
+        itertools.chain([app_name], (filename.value for filename in Filenames.values()))
+    ):
         pex_key = Filenames.PEX.name  # type: Optional[str]
     else:
         pex_name = Filenames.PEX.name

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.98.1"
+__version__ = "2.98.2"

--- a/tests/integration/scie/test_issue_3195.py
+++ b/tests/integration/scie/test_issue_3195.py
@@ -8,13 +8,9 @@ import json
 
 from pex.os import Os
 from pex.platforms import Platform
-from pex.typing import TYPE_CHECKING
 from testing import run_pex_command
 from testing.pytest_utils.tmp import Tempdir
 from testing.scie import skip_if_no_provider
-
-if TYPE_CHECKING:
-    pass
 
 
 @skip_if_no_provider

--- a/tests/integration/scie/test_issue_3217.py
+++ b/tests/integration/scie/test_issue_3217.py
@@ -1,0 +1,32 @@
+# Copyright 2026 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import filecmp
+import os.path
+import subprocess
+
+from pex.sysconfig import SysPlatform
+from testing import make_env, run_pex_command
+from testing.pytest_utils.tmp import Tempdir
+from testing.scie import skip_if_no_provider
+
+
+@skip_if_no_provider
+def test_scie_only_split_pack(tmpdir):
+    # type: (Tempdir) -> None
+
+    scie = tmpdir.join("scie")
+    run_pex_command(
+        args=["cowsay<6", "-c", "cowsay", "--scie", "eager", "--scie-only", "-o", scie]
+    ).assert_success()
+
+    split_dir = tmpdir.join("split")
+    subprocess.check_call(args=[scie, split_dir], env=make_env(SCIE="split"))
+    subprocess.check_call(
+        args=[os.path.join(".", SysPlatform.CURRENT.binary_name("scie-jump"))], cwd=split_dir
+    )
+    re_packed_scie = os.path.join(split_dir, "scie")
+    assert b"| Scie-Moo! |" in subprocess.check_output(args=[re_packed_scie, "Scie-Moo!"])
+    assert filecmp.cmp(scie, re_packed_scie, shallow=False)


### PR DESCRIPTION
Fix `scie.lift.base` for foreign platform scies by respecting the
foreign system's conventions for cache dirs by using the
`{scie.user.cache_dir=<fallback>}` scie-jump placeholder.

Also fix `--scie only` for `-o` not ending in `.pex`. Previously the
scies generated in this situation could not be split and re-packed
using scie-jump command line tooling.

Fixes #3216
Fixes #3217