### PR TITLE
Fix PEP-691 fingerprinting against authenticated indexes.

### DIFF
--- a/pex/auth.py
+++ b/pex/auth.py
@@ -165,3 +165,21 @@ class PasswordDatabase(object):
     def append(self, entries):
         # type: (Iterable[PasswordEntry]) -> PasswordDatabase
         return PasswordDatabase(entries=self.entries + tuple(entries))
+
+    def lookup(self, url):
+        # type: (Text) -> Optional[PasswordEntry]
+        """Finds the password entry for the machine serving the given URL, if any.
+
+        N.B.: Only machine-scoped entries are considered; the credentials of a machine-less
+        `default` netrc entry are only safe to present in response to a challenge, not
+        preemptively to arbitrary hosts.
+        """
+        try:
+            machine = Machine.from_url(url)
+        except ValueError:
+            return None
+
+        for entry in self.entries:
+            if entry.machine == machine:
+                return entry
+        return None

--- a/pex/auth.py
+++ b/pex/auth.py
@@ -179,7 +179,9 @@ class PasswordDatabase(object):
         except ValueError:
             return None
 
-        for entry in self.entries:
+        # Later entries are appended from more explicit configuration sources and should take
+        # precedence over earlier entries (e.g. an index URL credential over a netrc credential).
+        for entry in reversed(self.entries):
             if entry.machine == machine:
                 return entry
         return None

--- a/pex/fetcher.py
+++ b/pex/fetcher.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import
 
+import base64
 import contextlib
 import os
 import socket
@@ -214,6 +215,71 @@ class UnixHTTPHandler(AbstractHTTPHandler):
         )
 
 
+def _basic_auth_header(
+    username,  # type: Text
+    password,  # type: Optional[Text]
+):
+    # type: (...) -> str
+    credentials = (
+        "{username}:{password}".format(username=username, password=password)
+        if password is not None
+        else username
+    )
+    return "Basic {credentials}".format(
+        credentials=base64.b64encode(credentials.encode("utf-8")).decode("ascii")
+    )
+
+
+class SchemeGuardedHTTPBasicAuthHandler(HTTPBasicAuthHandler):
+    """A drop-in HTTPBasicAuthHandler that tolerates unsupported challenge schemes.
+
+    The stdlib auth handlers raise `ValueError` when a 401 response carries a `WWW-Authenticate`
+    challenge scheme they do not implement (e.g.: the `Bearer` challenges sent by AWS
+    CodeArtifact), which turns a garden variety auth failure into an opaque crash. Ignoring the
+    challenge instead allows the original 401 `HTTPError` to propagate to the caller.
+
+    N.B.: Under Python 3 both the basic and digest handlers raise; under Python 2.7 only the
+    digest handler does. See the `http_error_auth_reqed` implementations in `urllib.request`
+    (`AbstractBasicAuthHandler` and `AbstractDigestAuthHandler`) and their `urllib2`
+    counterparts.
+    """
+
+    def http_error_401(
+        self,
+        req,  # type: Any
+        fp,  # type: Any
+        code,  # type: Any
+        msg,  # type: Any
+        headers,  # type: Any
+    ):
+        # type: (...) -> Any
+        try:
+            return HTTPBasicAuthHandler.http_error_401(self, req, fp, code, msg, headers)
+        except ValueError:
+            return None
+
+
+class SchemeGuardedHTTPDigestAuthHandler(HTTPDigestAuthHandler):
+    """A drop-in HTTPDigestAuthHandler that tolerates unsupported challenge schemes.
+
+    See `SchemeGuardedHTTPBasicAuthHandler`.
+    """
+
+    def http_error_401(
+        self,
+        req,  # type: Any
+        fp,  # type: Any
+        code,  # type: Any
+        msg,  # type: Any
+        headers,  # type: Any
+    ):
+        # type: (...) -> Any
+        try:
+            return HTTPDigestAuthHandler.http_error_401(self, req, fp, code, msg, headers)
+        except ValueError:
+            return None
+
+
 class URLFetcher(object):
     USER_AGENT = "pex/{version}".format(version=__version__)
 
@@ -270,6 +336,44 @@ class URLFetcher(object):
         # type: (...) -> Iterator[BinaryIO]
 
         handlers = list(self._handlers)
+
+        preemptive_authorization = None  # type: Optional[str]
+        url_info = urlparse.urlparse(url)
+        if url_info.username:
+            # The stdlib openers cannot handle credentials in a URL netloc (the netloc fails to
+            # parse as a valid host); so we strip the credentials from the URL and send them
+            # preemptively via a basic auth header instead.
+            preemptive_authorization = _basic_auth_header(url_info.username, url_info.password)
+            host = url_info.hostname or ""
+            if ":" in host:
+                # N.B.: The `hostname` accessor strips IPv6 brackets; restore them.
+                host = "[{host}]".format(host=host)
+            netloc = (
+                "{host}:{port}".format(host=host, port=url_info.port)
+                if url_info.port is not None
+                else host
+            )
+            url = urlparse.urlunparse(
+                (
+                    url_info.scheme,
+                    netloc,
+                    url_info.path,
+                    url_info.params,
+                    url_info.query,
+                    url_info.fragment,
+                )
+            )
+        else:
+            password_entry = self._password_database.lookup(url)
+            if password_entry:
+                # Some servers accept basic auth but respond to unauthenticated requests with a
+                # challenge scheme the stdlib auth handlers cannot process (e.g.: the
+                # `WWW-Authenticate: Bearer ...` challenges sent by AWS CodeArtifact); sending
+                # known credentials preemptively side-steps the challenge round trip altogether.
+                preemptive_authorization = _basic_auth_header(
+                    password_entry.username, password_entry.password
+                )
+
         if self._password_database.entries:
             password_manager = HTTPPasswordMgrWithDefaultRealm()
             for password_entry in self._password_database.entries:
@@ -282,7 +386,10 @@ class URLFetcher(object):
                     passwd=password_entry.password,
                 )
             handlers.extend(
-                (HTTPBasicAuthHandler(password_manager), HTTPDigestAuthHandler(password_manager))
+                (
+                    SchemeGuardedHTTPBasicAuthHandler(password_manager),
+                    SchemeGuardedHTTPDigestAuthHandler(password_manager),
+                )
             )
 
         retries = 0
@@ -295,6 +402,10 @@ class URLFetcher(object):
 
             opener = build_opener(*handlers)
             headers = dict(extra_headers) if extra_headers else {}
+            if preemptive_authorization and not any(
+                "authorization" == header_name.lower() for header_name in headers
+            ):
+                headers["Authorization"] = preemptive_authorization
             headers["User-Agent"] = self.USER_AGENT
             request = Request(
                 # N.B.: MyPy incorrectly thinks url must be a str in Python 2 where a unicode url

--- a/pex/fetcher.py
+++ b/pex/fetcher.py
@@ -230,56 +230,6 @@ def _basic_auth_header(
     )
 
 
-class SchemeGuardedHTTPBasicAuthHandler(HTTPBasicAuthHandler):
-    """A drop-in HTTPBasicAuthHandler that tolerates unsupported challenge schemes.
-
-    The stdlib auth handlers raise `ValueError` when a 401 response carries a `WWW-Authenticate`
-    challenge scheme they do not implement (e.g.: the `Bearer` challenges sent by AWS
-    CodeArtifact), which turns a garden variety auth failure into an opaque crash. Ignoring the
-    challenge instead allows the original 401 `HTTPError` to propagate to the caller.
-
-    N.B.: Under Python 3 both the basic and digest handlers raise; under Python 2.7 only the
-    digest handler does. See the `http_error_auth_reqed` implementations in `urllib.request`
-    (`AbstractBasicAuthHandler` and `AbstractDigestAuthHandler`) and their `urllib2`
-    counterparts.
-    """
-
-    def http_error_401(
-        self,
-        req,  # type: Any
-        fp,  # type: Any
-        code,  # type: Any
-        msg,  # type: Any
-        headers,  # type: Any
-    ):
-        # type: (...) -> Any
-        try:
-            return HTTPBasicAuthHandler.http_error_401(self, req, fp, code, msg, headers)
-        except ValueError:
-            return None
-
-
-class SchemeGuardedHTTPDigestAuthHandler(HTTPDigestAuthHandler):
-    """A drop-in HTTPDigestAuthHandler that tolerates unsupported challenge schemes.
-
-    See `SchemeGuardedHTTPBasicAuthHandler`.
-    """
-
-    def http_error_401(
-        self,
-        req,  # type: Any
-        fp,  # type: Any
-        code,  # type: Any
-        msg,  # type: Any
-        headers,  # type: Any
-    ):
-        # type: (...) -> Any
-        try:
-            return HTTPDigestAuthHandler.http_error_401(self, req, fp, code, msg, headers)
-        except ValueError:
-            return None
-
-
 class URLFetcher(object):
     USER_AGENT = "pex/{version}".format(version=__version__)
 
@@ -386,10 +336,7 @@ class URLFetcher(object):
                     passwd=password_entry.password,
                 )
             handlers.extend(
-                (
-                    SchemeGuardedHTTPBasicAuthHandler(password_manager),
-                    SchemeGuardedHTTPDigestAuthHandler(password_manager),
-                )
+                (HTTPBasicAuthHandler(password_manager), HTTPDigestAuthHandler(password_manager))
             )
 
         retries = 0

--- a/pex/resolve/locker.py
+++ b/pex/resolve/locker.py
@@ -539,8 +539,16 @@ class Locker(LogAnalyzer):
             line,
         )
         if match:
+            # N.B.: Pip redacts credentials in the URLs it logs (e.g.:
+            # https://user:****@example.com/simple/); so the scraped URL cannot be used to
+            # authenticate as-is. We strip the credentials here and the `URLFetcher` used to
+            # make PEP-691 API requests re-attaches the real credentials for the endpoint's
+            # machine from its `PasswordDatabase`.
             self._pep_691_endpoints.add(
-                Endpoint(url=match.group("index_url"), content_type=match.group("content_type"))
+                Endpoint(
+                    url=str(CredentialedURL.parse(match.group("index_url")).strip_credentials()),
+                    content_type=match.group("content_type"),
+                )
             )
             return self.Continue()
 

--- a/tests/resolve/test_locker.py
+++ b/tests/resolve/test_locker.py
@@ -1,8 +1,32 @@
 # Copyright 2022 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pex.resolve.locker import CredentialedURL, Credentials, Netloc
+import base64
+import json
+import os.path
+from threading import Thread
+
+from pex.artifact_url import Fingerprint
+from pex.auth import Machine, PasswordEntry
+from pex.compatibility import PY2
+from pex.fetcher import URLFetcher
+from pex.requirements import parse_requirement_string
+from pex.resolve.configured_resolver import ConfiguredResolver
+from pex.resolve.locked_resolve import LockStyle
+from pex.resolve.locker import CredentialedURL, Credentials, Locker, Netloc
+from pex.resolve.pep_691.api import Client
+from pex.resolve.pep_691.fingerprint_service import FingerprintService
+from pex.resolve.pep_691.model import Endpoint
+from pex.resolve.resolved_requirement import PartialArtifact
+from pex.targets import LocalInterpreter
 from pex.typing import TYPE_CHECKING
+
+if PY2:
+    from BaseHTTPServer import BaseHTTPRequestHandler
+    from SocketServer import TCPServer
+else:
+    from http.server import BaseHTTPRequestHandler
+    from socketserver import TCPServer
 
 if TYPE_CHECKING:
     from typing import Any, Optional
@@ -85,37 +109,95 @@ def test_inject_credentials():
     )
 
 
-def test_pep_691_endpoints_strip_redacted_credentials(tmpdir):
+def test_pep_691_endpoint_authentication_and_fingerprinting(tmpdir):
     # type: (Any) -> None
 
-    import os.path
-
-    from pex.requirements import parse_requirement_string
-    from pex.resolve.configured_resolver import ConfiguredResolver
-    from pex.resolve.locked_resolve import LockStyle
-    from pex.resolve.locker import Locker
-    from pex.resolve.pep_691.model import Endpoint
-    from pex.targets import LocalInterpreter
-
-    locker = Locker(
-        target=LocalInterpreter.create(),
-        root_requirements=[parse_requirement_string("foo")],
-        resolver=ConfiguredResolver.default(),
-        lock_style=LockStyle.UNIVERSAL,
-        download_dir=os.path.join(str(tmpdir), "downloads"),
+    expected_authorization = "Basic {credentials}".format(
+        credentials=base64.b64encode(b"joe:bob").decode("ascii")
     )
-    locker.analyze(
-        "2026-07-21T00:00:00,000 Fetched page https://user:****@example.com/simple/foo/ as "
-        "application/vnd.pypi.simple.v1+json"
-    )
+    unauthorized_requests = []
 
-    assert {
-        Endpoint(
-            url="https://example.com/simple/foo/",
+    class PEP691RequestHandler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.headers.get("Authorization") != expected_authorization:
+                unauthorized_requests.append(self.path)
+                self.send_response(401)
+                self.send_header("WWW-Authenticate", 'Bearer realm="example"')
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+
+            body = json.dumps(
+                {
+                    "name": "foo",
+                    "files": [
+                        {
+                            "filename": "foo-1.0.tar.gz",
+                            "url": "../../files/foo-1.0.tar.gz",
+                            "hashes": {"sha256": "strong"},
+                        }
+                    ],
+                    "meta": {"api-version": "1.0"},
+                }
+            ).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/vnd.pypi.simple.v1+json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format, *args):
+            pass
+
+    server = TCPServer(("127.0.0.1", 0), PEP691RequestHandler)
+    host, port = server.server_address
+    endpoint_url = "http://{host}:{port}/simple/foo/".format(host=host, port=port)
+    artifact_url = "http://{host}:{port}/files/foo-1.0.tar.gz".format(host=host, port=port)
+    server_thread = Thread(target=server.serve_forever)
+    server_thread.daemon = True
+    server_thread.start()
+    try:
+        password_entry = PasswordEntry(
+            machine=Machine.from_url(endpoint_url), username="joe", password="bob"
+        )
+        fingerprint_service = FingerprintService(
+            api=Client(url_fetcher=URLFetcher(password_entries=[password_entry], netrc_file=None)),
+            db_dir=os.path.join(str(tmpdir), "fingerprints"),
+        )
+        locker = Locker(
+            target=LocalInterpreter.create(),
+            root_requirements=[parse_requirement_string("foo")],
+            resolver=ConfiguredResolver.default(),
+            lock_style=LockStyle.UNIVERSAL,
+            download_dir=os.path.join(str(tmpdir), "downloads"),
+            fingerprint_service=fingerprint_service,
+        )
+        locker.analyze(
+            "2026-07-21T00:00:00,000 Fetched page "
+            "http://user:****@{host}:{port}/simple/foo/ as "
+            "application/vnd.pypi.simple.v1+json".format(host=host, port=port)
+        )
+
+        endpoint = Endpoint(
+            url=endpoint_url,
             content_type="application/vnd.pypi.simple.v1+json",
         )
-    } == locker._pep_691_endpoints, (
-        "Pip redacts credentials in the URLs it logs; so the recorded endpoint should have "
-        "credentials stripped for the URLFetcher to re-attach real credentials from its "
-        "PasswordDatabase."
-    )
+        assert {endpoint} == locker._pep_691_endpoints
+        assert [
+            PartialArtifact(
+                url=artifact_url,
+                fingerprint=Fingerprint(algorithm="sha256", hash="strong"),
+            )
+        ] == list(
+            fingerprint_service.fingerprint(
+                endpoints=locker._pep_691_endpoints,
+                artifacts=[PartialArtifact(url=artifact_url)],
+            )
+        )
+        assert not unauthorized_requests, (
+            "The real machine-scoped credentials should be sent preemptively after the credentials "
+            "redacted by Pip are stripped from the logged endpoint."
+        )
+    finally:
+        server.shutdown()
+        server_thread.join()

--- a/tests/resolve/test_locker.py
+++ b/tests/resolve/test_locker.py
@@ -5,7 +5,7 @@ from pex.resolve.locker import CredentialedURL, Credentials, Netloc
 from pex.typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Optional
+    from typing import Any, Optional
 
 
 def test_credentials_redacted():
@@ -82,4 +82,40 @@ def test_inject_credentials():
     )
     assert "http://joe:bob@example.org" == inject_credentials(
         "http://joe:****@example.org", Credentials("joe", "bob")
+    )
+
+
+def test_pep_691_endpoints_strip_redacted_credentials(tmpdir):
+    # type: (Any) -> None
+
+    import os.path
+
+    from pex.requirements import parse_requirement_string
+    from pex.resolve.configured_resolver import ConfiguredResolver
+    from pex.resolve.locked_resolve import LockStyle
+    from pex.resolve.locker import Locker
+    from pex.resolve.pep_691.model import Endpoint
+    from pex.targets import LocalInterpreter
+
+    locker = Locker(
+        target=LocalInterpreter.create(),
+        root_requirements=[parse_requirement_string("foo")],
+        resolver=ConfiguredResolver.default(),
+        lock_style=LockStyle.UNIVERSAL,
+        download_dir=os.path.join(str(tmpdir), "downloads"),
+    )
+    locker.analyze(
+        "2026-07-21T00:00:00,000 Fetched page https://user:****@example.com/simple/foo/ as "
+        "application/vnd.pypi.simple.v1+json"
+    )
+
+    assert {
+        Endpoint(
+            url="https://example.com/simple/foo/",
+            content_type="application/vnd.pypi.simple.v1+json",
+        )
+    } == locker._pep_691_endpoints, (
+        "Pip redacts credentials in the URLs it logs; so the recorded endpoint should have "
+        "credentials stripped for the URLFetcher to re-attach real credentials from its "
+        "PasswordDatabase."
     )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pex.auth import Machine, PasswordDatabase, PasswordEntry
+
+
+def test_password_database_lookup_matches_machine():
+    # type: () -> None
+
+    example = PasswordEntry(
+        machine=Machine.from_url("https://example.com"), username="joe", password="bob"
+    )
+    example_alt_port = PasswordEntry(
+        machine=Machine.from_url("https://example.com:8443"), username="jane", password="bib"
+    )
+    database = PasswordDatabase(entries=(example, example_alt_port))
+
+    assert example == database.lookup("https://example.com/simple/foo/")
+    assert example_alt_port == database.lookup("https://example.com:8443/simple/foo/")
+    assert database.lookup("https://other.example.com/simple/foo/") is None
+
+
+def test_password_database_lookup_ignores_default_entries():
+    # type: () -> None
+
+    default = PasswordEntry(username="joe", password="bob")
+    database = PasswordDatabase(entries=(default,))
+
+    assert database.lookup("https://example.com/simple/foo/") is None, (
+        "The credentials of a machine-less `default` netrc entry should not be offered for "
+        "preemptive use against arbitrary hosts."
+    )
+
+
+def test_password_database_lookup_unparseable_url():
+    # type: () -> None
+
+    database = PasswordDatabase(
+        entries=(
+            PasswordEntry(
+                machine=Machine.from_url("https://example.com"), username="joe", password="bob"
+            ),
+        )
+    )
+
+    assert database.lookup("not-a-url") is None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -20,6 +20,21 @@ def test_password_database_lookup_matches_machine():
     assert database.lookup("https://other.example.com/simple/foo/") is None
 
 
+def test_password_database_lookup_prefers_later_entries():
+    # type: () -> None
+
+    machine = Machine.from_url("https://example.com")
+    netrc = PasswordEntry(machine=machine, username="joe", password="stale")
+    configured = PasswordEntry(machine=machine, username="joe", password="current")
+
+    database = PasswordDatabase(entries=(netrc,)).append((configured,))
+
+    assert configured == database.lookup("https://example.com/simple/foo/"), (
+        "Credentials from explicit configuration appended to the password database should take "
+        "precedence over earlier netrc credentials for the same machine."
+    )
+
+
 def test_password_database_lookup_ignores_default_entries():
     # type: () -> None
 

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -3,11 +3,13 @@
 
 from __future__ import print_function
 
+import base64
 from threading import Thread
 
 import pytest
 
-from pex.compatibility import PY2
+from pex.auth import Machine, PasswordEntry
+from pex.compatibility import PY2, HTTPError
 from pex.fetcher import URLFetcher
 from pex.typing import TYPE_CHECKING
 from pex.version import __version__
@@ -20,7 +22,7 @@ else:
     from socketserver import TCPServer
 
 if TYPE_CHECKING:
-    from typing import Tuple
+    from typing import Iterator, Tuple
 
 
 @pytest.fixture
@@ -55,3 +57,100 @@ def test_user_agent(server_address):
     url_fetcher = URLFetcher()
     with url_fetcher.get_body_stream(url) as fp:
         assert "pex/{version}".format(version=__version__) == fp.read().decode("utf-8")
+
+
+EXPECTED_AUTHORIZATION = "Basic {credentials}".format(
+    credentials=base64.b64encode(b"joe:bob").decode("ascii")
+)
+
+
+@pytest.fixture
+def bearer_challenge_server_address():
+    # type: () -> Iterator[Tuple[str, int]]
+
+    class BearerChallengeRequestHandler(BaseHTTPRequestHandler):
+        """Accepts basic auth but challenges with a scheme the stdlib cannot process.
+
+        This mimics AWS CodeArtifact, which accepts basic auth credentials but answers
+        unauthenticated requests with a 401 bearing `WWW-Authenticate: Bearer ...`.
+        """
+
+        def do_GET(self):
+            if self.headers.get("Authorization") != EXPECTED_AUTHORIZATION:
+                self.send_response(401)
+                self.send_header("WWW-Authenticate", 'Bearer realm="example"')
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+
+            body = b"authorized"
+            self.send_response(200)
+            self.send_header("Content-Type", "application/octet-stream")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    server = TCPServer(("127.0.0.1", 0), BearerChallengeRequestHandler)
+    host, port = server.server_address
+
+    server_thread = Thread(target=server.serve_forever)
+    server_thread.daemon = True
+    server_thread.start()
+    try:
+        yield host, port
+    finally:
+        server.shutdown()
+        server_thread.join()
+
+
+def test_preemptive_basic_auth_from_password_entries(bearer_challenge_server_address):
+    # type: (Tuple[str, int]) -> None
+
+    host, port = bearer_challenge_server_address
+    url = "http://{host}:{port}/simple/foo/".format(host=host, port=port)
+    url_fetcher = URLFetcher(
+        password_entries=[
+            PasswordEntry(
+                machine=Machine.from_url(url),
+                username="joe",
+                password="bob",
+            )
+        ],
+        netrc_file=None,
+    )
+    with url_fetcher.get_body_stream(url) as fp:
+        assert b"authorized" == fp.read()
+
+
+def test_preemptive_basic_auth_from_url_credentials(bearer_challenge_server_address):
+    # type: (Tuple[str, int]) -> None
+
+    host, port = bearer_challenge_server_address
+    url = "http://joe:bob@{host}:{port}/simple/foo/".format(host=host, port=port)
+    url_fetcher = URLFetcher(netrc_file=None)
+    with url_fetcher.get_body_stream(url) as fp:
+        assert b"authorized" == fp.read()
+
+
+def test_unsupported_challenge_scheme_yields_http_error(bearer_challenge_server_address):
+    # type: (Tuple[str, int]) -> None
+
+    host, port = bearer_challenge_server_address
+    url = "http://{host}:{port}/simple/foo/".format(host=host, port=port)
+    url_fetcher = URLFetcher(
+        password_entries=[
+            # N.B.: These credentials are for another machine; so no preemptive auth applies and
+            # the server's `WWW-Authenticate: Bearer` challenge is processed by the stdlib auth
+            # handlers, which do not support the scheme.
+            PasswordEntry(
+                machine=Machine.from_url("https://other.example.com"),
+                username="joe",
+                password="bob",
+            )
+        ],
+        netrc_file=None,
+    )
+    with pytest.raises(HTTPError) as exc_info:
+        with url_fetcher.get_body_stream(url) as fp:
+            fp.read()
+    assert 401 == exc_info.value.code

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -9,7 +9,7 @@ from threading import Thread
 import pytest
 
 from pex.auth import Machine, PasswordEntry
-from pex.compatibility import PY2, HTTPError
+from pex.compatibility import PY2
 from pex.fetcher import URLFetcher
 from pex.typing import TYPE_CHECKING
 from pex.version import __version__
@@ -130,27 +130,3 @@ def test_preemptive_basic_auth_from_url_credentials(bearer_challenge_server_addr
     url_fetcher = URLFetcher(netrc_file=None)
     with url_fetcher.get_body_stream(url) as fp:
         assert b"authorized" == fp.read()
-
-
-def test_unsupported_challenge_scheme_yields_http_error(bearer_challenge_server_address):
-    # type: (Tuple[str, int]) -> None
-
-    host, port = bearer_challenge_server_address
-    url = "http://{host}:{port}/simple/foo/".format(host=host, port=port)
-    url_fetcher = URLFetcher(
-        password_entries=[
-            # N.B.: These credentials are for another machine; so no preemptive auth applies and
-            # the server's `WWW-Authenticate: Bearer` challenge is processed by the stdlib auth
-            # handlers, which do not support the scheme.
-            PasswordEntry(
-                machine=Machine.from_url("https://other.example.com"),
-                username="joe",
-                password="bob",
-            )
-        ],
-        netrc_file=None,
-    )
-    with pytest.raises(HTTPError) as exc_info:
-        with url_fetcher.get_body_stream(url) as fp:
-            fp.read()
-    assert 401 == exc_info.value.code


### PR DESCRIPTION
Fixes #3224.

Two changes, both required for `pex3 lock create` to fingerprint artifacts from an authenticated PEP-691 index (AWS CodeArtifact) instead of downloading every one of them:

1. `Locker` strips credentials from the PEP-691 endpoints it scrapes from the Pip log. Pip redacts credentials in the URLs it logs (`https://user:****@...`), so the scraped values can never authenticate and do not even parse as a netloc in the stdlib openers (`nonnumeric port: '****@...'`). The `URLFetcher` making the PEP-691 requests re-attaches real credentials for the endpoint's machine from its `PasswordDatabase`.
2. `URLFetcher.get_body_stream` sends known credentials preemptively via a Basic `Authorization` header — from the machine-scoped `PasswordDatabase` entry matching the URL, or from credentials embedded in the URL itself (which are moved out of the netloc, since the stdlib openers cannot parse a credentialed netloc). This is what makes authentication succeed: CodeArtifact accepts Basic auth but answers unauthenticated requests with `401 WWW-Authenticate: Bearer`, which the stdlib challenge handlers cannot process, so a challenge/response round trip never authenticates. Sending credentials up front avoids provoking a challenge at all.

Machine-less `default` netrc entries are deliberately never sent preemptively — they remain challenge-only, so credentials are not offered to arbitrary hosts.

Which mechanisms are load-bearing was verified by instrumenting each one during a real lock against a CodeArtifact index: the endpoint strip fires (`has_redacted_credentials=True`) and the preemptive Basic header fires. An earlier revision of this PR also guarded the stdlib auth handlers against challenge schemes they do not implement; that code never executed on the success path and only changed the error surfaced when credentials are unknown, so it has been dropped (see #3224 for the detail).

Validated against the CodeArtifact repository that surfaced #3224:

- before (`main` @ bea9c2e2): `pex3 lock create --pip-version 24.2 --style universal --no-pypi --index https://aws:<token>@<host>/pypi/<repo>/simple psycopg2-binary==2.9.12` exits 1 (`pg_config` sdist metadata build failure) after downloading the release's 11 other artifacts to fingerprint them;
- after: exits 0 with zero fingerprint downloads, and the resulting lock's artifact set and sha256s are byte-identical to those produced when the same index serves PEP 503 HTML (`#sha256=` fragments), including the sdist hash, which matches the index's advertised `hashes.sha256` exactly. Same result for other previously-failing projects (`ddtrace` et al).
- With only the endpoint strip and no preemptive auth, the `Bearer` challenge is reached, `AbstractDigestAuthHandler does not support the following scheme: 'Bearer'` is raised and swallowed to a warning, and the lock fails as before — confirming (2) is what fixes this.

`format`, `lint-check`, `typecheck` and the touched tests (`tests/test_auth.py`, `tests/test_fetcher.py`, `tests/resolve/test_locker.py`, `tests/resolve/pep_691/`) pass locally; the fetcher tests exercise a local HTTP server that mimics CodeArtifact's Bearer-challenge behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ftLY926gkJA6yMbu813cG
