### PR TITLE
Fix PEP-691 fingerprinting for authenticated indexes.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 2.98.5
+
+This release fixes `pex3 lock create` to better handle authenticated PEP-691 endpoints.
+
+* Fix PEP-691 fingerprinting for authenticated indexes. (#3230)
+
 ## 2.98.4
 
 This release updates vendored Pip's vendored certifi's cacert.pem to that from certifi 2026.7.22.

--- a/pex/fetcher.py
+++ b/pex/fetcher.py
@@ -214,6 +214,22 @@ class UnixHTTPHandler(AbstractHTTPHandler):
         )
 
 
+def scheme_guard(auth_handler):
+    # type: (Any) -> Any
+    http_error_401 = getattr(auth_handler, "http_error_401", None)
+    if not http_error_401:
+        return auth_handler
+
+    def guard(*args, **kwargs):
+        try:
+            return http_error_401(*args, **kwargs)
+        except ValueError:
+            return None
+
+    setattr(auth_handler, "http_error_401", guard)
+    return auth_handler
+
+
 class URLFetcher(object):
     USER_AGENT = "pex/{version}".format(version=__version__)
 
@@ -282,7 +298,20 @@ class URLFetcher(object):
                     passwd=password_entry.password,
                 )
             handlers.extend(
-                (HTTPBasicAuthHandler(password_manager), HTTPDigestAuthHandler(password_manager))
+                (
+                    HTTPBasicAuthHandler(password_manager),
+                    # N.B.: Python stdlib HTTPDigestAuthHandler docs note:
+                    # > Changed in version 3.3: Raise ValueError on unsupported Authentication
+                    # > Scheme.
+                    # We saw this in the wild in https://github.com/pex-tool/pex/issues/3224; so we
+                    # hack around this by guarding against the ValueError raise here.
+                    #
+                    # Likely, it would be better to just remove this auth handler altogether -
+                    # Digest auth would seem to be rarely used in the contexts Pex runs in. That
+                    # said, this would be a backward compatibility break for anyone that happened to
+                    # rely on it.
+                    scheme_guard(HTTPDigestAuthHandler(password_manager)),
+                )
             )
 
         retries = 0

--- a/pex/resolve/locker.py
+++ b/pex/resolve/locker.py
@@ -539,8 +539,20 @@ class Locker(LogAnalyzer):
             line,
         )
         if match:
+            # N.B.: Pip redacts credentials in the URLs it logs (e.g.:
+            # https://user:****@example.com/simple/); so the scraped URL cannot be used to
+            # authenticate as-is. We strip the credentials here as needed and the `URLFetcher` used
+            # to make PEP-691 API requests re-attaches the real credentials for the endpoint's
+            # machine from its `PasswordDatabase`.
+            index_url = match.group("index_url")
+            maybe_credentialed_url = CredentialedURL.parse(index_url)
             self._pep_691_endpoints.add(
-                Endpoint(url=match.group("index_url"), content_type=match.group("content_type"))
+                Endpoint(
+                    url=str(maybe_credentialed_url.strip_credentials())
+                    if maybe_credentialed_url.has_redacted_credentials
+                    else index_url,
+                    content_type=match.group("content_type"),
+                )
             )
             return self.Continue()
 

--- a/pex/resolve/locker.py
+++ b/pex/resolve/locker.py
@@ -548,9 +548,11 @@ class Locker(LogAnalyzer):
             maybe_credentialed_url = CredentialedURL.parse(index_url)
             self._pep_691_endpoints.add(
                 Endpoint(
-                    url=str(maybe_credentialed_url.strip_credentials())
-                    if maybe_credentialed_url.has_redacted_credentials
-                    else index_url,
+                    url=(
+                        str(maybe_credentialed_url.strip_credentials())
+                        if maybe_credentialed_url.has_redacted_credentials
+                        else index_url
+                    ),
                     content_type=match.group("content_type"),
                 )
             )

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.98.4"
+__version__ = "2.98.5"


### PR DESCRIPTION
Previously, PEP-691 endpoint URLs with credentials were not properly 
normalized before use and if the endpoint responded with multiple
challenge types, any of which were not "Basic" or "Digest", the locking
process would error.

The initial investigation came from @jasonwbarnett and narrowed down the
issue to the general vicinity of the fixes above.

Supercedes #3225
Fixes #3224