### PR TITLE
Add support for Pip 26.2.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,8 @@ jobs:
           - test-cmd: test-py27-pip20.3.4--patched
             base-pythons: old
 
-          - test-cmd: test-py314-pip26.1.2
-          - test-cmd: test-py315-pip26.1.2
+          - test-cmd: test-py314-pip26.2
+          - test-cmd: test-py315-pip26.2
           - test-cmd: test-pypy311-pip24.3.1
 
           # Integration tests, split most into two shards:
@@ -117,11 +117,11 @@ jobs:
           - test-cmd: test-py38-pip22.3.1-integration-shard2@2
             base-pythons: old
 
-          - test-cmd: test-py314-pip26.1.2-integration-shard1@2
-          - test-cmd: test-py314-pip26.1.2-integration-shard2@2
+          - test-cmd: test-py314-pip26.2-integration-shard1@2
+          - test-cmd: test-py314-pip26.2-integration-shard2@2
 
-          - test-cmd: test-py315-pip26.1.2-integration-shard1@2
-          - test-cmd: test-py315-pip26.1.2-integration-shard2@2
+          - test-cmd: test-py315-pip26.2-integration-shard1@2
+          - test-cmd: test-py315-pip26.2-integration-shard2@2
 
           # PyPy is slow enough to require extra sharding.
           - test-cmd: test-pypy311-pip24.3.1-integration-shard1@4
@@ -177,11 +177,11 @@ jobs:
       matrix:
         include:
           - python-version: "3.14"
-            test-cmd: test-py314-pip26.1.2
+            test-cmd: test-py314-pip26.2
           - python-version: "3.14"
-            test-cmd: test-py314-pip26.1.2-integration-shard:1/2
+            test-cmd: test-py314-pip26.2-integration-shard:1/2
           - python-version: "3.14"
-            test-cmd: test-py314-pip26.1.2-integration-shard:2/2
+            test-cmd: test-py314-pip26.2-integration-shard:2/2
     steps:
       - name: Checkout Pex
         uses: actions/checkout@v6
@@ -266,15 +266,15 @@ jobs:
           - python-version: "3.11"
             test-cmd: typecheck package docs
           - python-version: "3.14"
-            test-cmd: test-py314-pip26.1.2
+            test-cmd: test-py314-pip26.2
             artifact-name: unit
             pex-test-pos-args: --junit-report ../dist/test-results/unit.xml
           - python-version: "3.14"
-            test-cmd: test-py314-pip26.1.2-integration
+            test-cmd: test-py314-pip26.2-integration
             artifact-name: integration-1
             pex-test-pos-args: --shard 1/2 --junit-report ../dist/test-results/integration-1.xml
           - python-version: "3.14"
-            test-cmd: test-py314-pip26.1.2-integration
+            test-cmd: test-py314-pip26.2-integration
             artifact-name: integration-2
             pex-test-pos-args: --shard 2/2 --junit-report ../dist/test-results/integration-2.xml
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 2.99.0
+
+This release adds support for Pip 26.2.
+
+* Add support for Pip 26.2. (#3231)
+
 ## 2.98.5
 
 This release fixes `pex3 lock create` to better handle authenticated PEP-691 endpoints.

--- a/pex/pip/version.py
+++ b/pex/pip/version.py
@@ -501,6 +501,13 @@ class PipVersion(Enum["PipVersionValue"]):
         requires_python=">=3.10,<3.16",
     )
 
+    v26_2 = PipVersionValue(
+        version="26.2",
+        setuptools_version="83.0.0",
+        wheel_version="0.47.0",
+        requires_python=">=3.10,<3.16",
+    )
+
     ADHOC = Adhoc()
 
     VENDORED = v20_3_4_patched

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.98.5"
+__version__ = "2.99.0"


### PR DESCRIPTION
This is minimal support - no new Pip options are plumbed. Those can
wait for someone to request and / or implement them.