### PR TITLE
Handle foreign too-long Python script shebangs.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 2.100.5
+
+This release fixes handling of `#!/bin/sh` too-long script shebang re-directors created by other
+tools like pip and uv for data scripts when round-tripping installed wheels from venvs.
+
+* Handle foreign too-long Python script shebangs. (#3249)
+
 ## 2.100.4
 
 This release fixes `pex --venv-repository ...` to respect the `--[no-]system-time` option and its

--- a/pex/cache/dirs.py
+++ b/pex/cache/dirs.py
@@ -180,7 +180,7 @@ class CacheDir(Enum["CacheDir.Value"]):
 
     PACKED_WHEELS = Value(
         "packed_wheels",
-        version=1,
+        version=2,
         name="Packed Wheels",
         description=(
             "The same content as {installed_wheels!r}, but zipped up for `--layout packed` "
@@ -207,7 +207,7 @@ class CacheDir(Enum["CacheDir.Value"]):
 
     REPACKED_WHEELS = Value(
         "repacked_wheels",
-        version=1,
+        version=2,
         name="Reconstituted Wheels",
         description=(
             "Wheels that have been reconstituted from {installed_wheels!r}, as well as from wheels "

--- a/pex/cache/dirs.py
+++ b/pex/cache/dirs.py
@@ -156,7 +156,7 @@ class CacheDir(Enum["CacheDir.Value"]):
 
     INSTALLED_WHEELS = Value(
         "installed_wheels",
-        version=2,
+        version=3,
         name="Pre-installed Wheels",
         description=(
             "Pre-installed wheel chroots used to both build PEXes and serve as runtime `sys.path` "

--- a/pex/executables.py
+++ b/pex/executables.py
@@ -146,11 +146,25 @@ def is_python_script(
     # type: (...) -> bool
 
     path = os.path.realpath(path)
+
+    def extra_check(
+        shebang,  # type: bytes
+        fp,  # type: BinaryIO
+    ):
+        # type: (...) -> bool
+        if shebang != b"/bin/sh":
+            return False
+
+        next_line = fp.readline()
+        if b"'''': pshprs\n" == next_line:
+            # A Pex too-long-shebang exec re-director.
+            return True
+
+        # A pip, uv, etc. too-long-shebang exec re-director.
+        return re.match(br"'''.*exec.+", next_line) is not None and next_line.count(b"'") >= 4
+
     if is_script(
-        path,
-        pattern=_PYTHON_SHEBANG_RE,
-        check_executable=check_executable,
-        extra_check=lambda shebang, fp: shebang == b"/bin/sh" and fp.read(13) == b"'''': pshprs\n",
+        path, pattern=_PYTHON_SHEBANG_RE, check_executable=check_executable, extra_check=extra_check
     ):
         return True
 

--- a/pex/pep_427.py
+++ b/pex/pep_427.py
@@ -1037,10 +1037,7 @@ def install_wheel(
                     if is_entry_point_script(src_path):
                         # This entry point script will be installed afresh below as needed.
                         break
-                    rewrite_script = interpreter is not None and is_python_script(
-                        src_path, check_executable=False
-                    )
-
+                    rewrite_script = is_python_script(src_path, check_executable=False)
                 dst_rel_path = os.path.relpath(src_path, installed_path)
                 dst_components = path_name, dst_rel_path, rewrite_script
                 break
@@ -1090,6 +1087,24 @@ def install_wheel(
                             out_fp.write(next_line)
                     shutil.copyfileobj(in_fp, out_fp)
                 chmod_plus_x(out_fp.name)
+
+                # We modified the script shebang; so we need to re-hash / re-size.
+                dst_installed_file = create_dst_installed_file(regenerate_hash=True)
+            elif rewrite_script and interpreter is None:
+                with open(src_file, mode="rb") as in_fp, safe_open(dst_file, "wb") as out_fp:
+                    first_line = in_fp.readline()
+                    if re.match(br"#!/bin/sh", first_line):
+                        # This is a too-long-shebang re-director script as identified by
+                        # `is_python_script` above; so we need to discard all lines that make up
+                        # that script - which are enclosed in a python `'''` string also consumable
+                        # by `sh`.
+                        in_fp.readline()  # Initial `'''` line
+                        while True:
+                            next_line = in_fp.readline()
+                            if not next_line or next_line.endswith(b"'''\n"):
+                                break
+                    out_fp.write(b"#!python\n")
+                    shutil.copyfileobj(in_fp, out_fp)
 
                 # We modified the script shebang; so we need to re-hash / re-size.
                 dst_installed_file = create_dst_installed_file(regenerate_hash=True)

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.100.4"
+__version__ = "2.100.5"

--- a/tests/integration/test_issue_3248.py
+++ b/tests/integration/test_issue_3248.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Pex project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import absolute_import
+
+import shutil
+import subprocess
+import sys
+from textwrap import dedent
+
+import pytest
+
+from pex.venv.virtualenv import Virtualenv
+from testing import IS_PYPY
+from testing.cli import run_pex3
+from testing.pytest_utils.tmp import Tempdir
+
+
+@pytest.mark.skipif(
+    IS_PYPY or sys.version_info < (3, 8),
+    reason=(
+        "Use of uv is required and uv only supports Python >= 3.8 and the `undill` script does not "
+        "work with PyPy."
+    ),
+)
+def test_uv_too_long_data_scripts_shebang(tmpdir):
+    # type: (Tempdir) -> None
+
+    uv_venv_dir = tmpdir.join("uv-venv", "too-long", "x" * max(1, 128 - len(tmpdir.path)))
+    subprocess.check_call(
+        args=[
+            "uv",
+            "venv",
+            "--python",
+            "{major}.{minor}".format(major=sys.version_info[0], minor=sys.version_info[1]),
+            uv_venv_dir,
+        ]
+    )
+
+    uv_venv = Virtualenv(uv_venv_dir)
+    subprocess.check_call(
+        args=["uv", "pip", "install", "--python", uv_venv.interpreter.binary, "dill"]
+    )
+
+    pickled = tmpdir.join("hello.pkl")
+    uv_venv.interpreter.execute(
+        args=[
+            "-c",
+            dedent(
+                """\
+                import dill
+
+
+                with open({pickled!r}, "wb") as fp:
+                    dill.dump(["hello", "world"], fp)
+                """
+            ).format(pickled=pickled),
+        ]
+    )
+
+    pex_root = tmpdir.join("pex-root")
+    pex_venv_dir = tmpdir.join("pex-venv")
+    run_pex3(
+        "venv",
+        "create",
+        "--pex-root",
+        pex_root,
+        "--dest-dir",
+        pex_venv_dir,
+        "--venv-repository",
+        uv_venv_dir,
+        "--pre",
+        "dill",
+    ).assert_success()
+
+    pex_venv = Virtualenv(pex_venv_dir)
+
+    def assert_undill_works():
+        assert b"['hello', 'world']\n" == subprocess.check_output(
+            args=[pex_venv.bin_path("undill"), pickled]
+        )
+
+    assert_undill_works()
+    shutil.rmtree(uv_venv_dir)
+    assert_undill_works()


### PR DESCRIPTION
Detect `#!/bin/sh` too-long script shebang re-directors created by other
tools like pip and uv for data scripts when round-tripping installed
wheels from venvs.

Fixes #3248