### PR TITLE
Beef up `#!/bin/sh` re-director script handling.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 2.100.6
+
+Further improve handling of `#!/bin/sh` re-director scripts.
+
+* Beef up `#!/bin/sh` re-director script handling. (#3252)
+
 ## 2.100.5
 
 This release fixes handling of `#!/bin/sh` too-long script shebang re-directors created by other

--- a/pex/executables.py
+++ b/pex/executables.py
@@ -112,6 +112,15 @@ def create_sh_python_redirector_shebang(sh_script_content):
     )
 
 
+def maybe_read_encoding_line(line):
+    # type: (bytes) -> str
+    """Returns the PEP-263 file encoding if the given line declares one; otherwise ""."""
+    # See: https://peps.python.org/pep-0263/
+    if re.match(br"^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)", line):
+        return str(line.decode("ascii"))
+    return ""
+
+
 _PYTHON_SHEBANG_RE = br"""(?ix)
 # The aim is to admit the common shebang forms:
 # + python
@@ -156,6 +165,9 @@ def is_python_script(
             return False
 
         next_line = fp.readline()
+        if maybe_read_encoding_line(next_line):
+            next_line = fp.readline()
+
         if b"'''': pshprs\n" == next_line:
             # A Pex too-long-shebang exec re-director.
             return True

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -19,6 +19,7 @@ from pex import third_party
 from pex.cache.dirs import InterpreterDir
 from pex.common import safe_mkdtemp, safe_rmtree
 from pex.exceptions import production_assert
+from pex.executables import create_sh_python_redirector_shebang
 from pex.executor import Executor
 from pex.interpreter_implementation import InterpreterImplementation
 from pex.jobs import Job, Retain, SpawnedJob, execute_parallel
@@ -1745,30 +1746,12 @@ def create_shebang(
     if WINDOWS or len(shebang) + 1 <= max_shebang_length:
         return shebang
 
-    # This trick relies on /bin/sh being ubiquitous and the concordance of:
-    # 1. Python: triple quoted strings plus allowance for free-floating string values in
-    #    python files.
-    # 2. sh: Any number of pairs of `'` evaluating away when followed immediately by a
-    #    command string (`''command` -> `command`) and lazy parsing allowing for invalid sh
-    #    content immediately following an exec line.
-    # The end result is a file that is both a valid sh script with a short shebang and a
-    # valid Python program.
-    return (
-        dedent(
-            """\
-            #!/bin/sh
-            {encoding_line}
-            # N.B.: This python script executes via a /bin/sh re-exec as a hack to work around a
-            # potential maximum shebang length of {max_shebang_length} bytes on this system which
-            # the python interpreter `exec`ed below would violate.
-            ''''exec {python} "$0" "$@"
-            '''
-            """
-        )
-        .format(
-            encoding_line=encoding_line.rstrip(),
-            max_shebang_length=max_shebang_length,
-            python=python,
-        )
-        .strip()
+    lines = []
+    shebang, body = create_sh_python_redirector_shebang(
+        'exec {python} "$0" "$@"'.format(python=python)
     )
+    lines.append(shebang)
+    if encoding_line:
+        lines.append(encoding_line)
+    lines.append(body)
+    return "\n".join(lines)

--- a/pex/pep_427.py
+++ b/pex/pep_427.py
@@ -33,7 +33,7 @@ from pex.dist_metadata import DistMetadata, Distribution, MetadataFiles
 from pex.entry_points_txt import install_scripts
 from pex.enum import Enum
 from pex.exceptions import production_assert, reportable_unexpected_error_msg
-from pex.executables import chmod_plus_x, is_python_script
+from pex.executables import chmod_plus_x, is_python_script, maybe_read_encoding_line
 from pex.installed_wheel import InstalledWheel
 from pex.interpreter import PythonInterpreter
 from pex.pep_376 import InstalledDirectory, InstalledFile, Record, create_installed_file
@@ -1069,13 +1069,8 @@ def install_wheel(
                         _, _, shebang_args = first_line.partition(b" ")
                         if hermetic_scripts and not shebang_args:
                             shebang_args = interpreter.hermetic_args.encode("utf-8")
-                        encoding_line = ""
                         next_line = in_fp.readline()
-                        # See: https://peps.python.org/pep-0263/
-                        if next_line and re.match(
-                            br"^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)", next_line
-                        ):
-                            encoding_line = str(next_line.decode("ascii"))
+                        encoding_line = maybe_read_encoding_line(next_line)
                         out_fp.write(
                             "{shebang}\n".format(
                                 shebang=interpreter.shebang(
@@ -1098,7 +1093,9 @@ def install_wheel(
                         # `is_python_script` above; so we need to discard all lines that make up
                         # that script - which are enclosed in a python `'''` string also consumable
                         # by `sh`.
-                        in_fp.readline()  # Initial `'''` line
+                        next_line = in_fp.readline()  # Initial `'''` line or encoding line
+                        if maybe_read_encoding_line(next_line):
+                            in_fp.readline()  # Initial `'''` line
                         while True:
                             next_line = in_fp.readline()
                             if not next_line or next_line.endswith(b"'''\n"):

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.100.5"
+__version__ = "2.100.6"

--- a/tests/integration/test_issue_3248.py
+++ b/tests/integration/test_issue_3248.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import
 
+import os.path
 import shutil
 import subprocess
 import sys
@@ -10,40 +11,25 @@ from textwrap import dedent
 
 import pytest
 
-from pex.venv.virtualenv import Virtualenv
+from pex.typing import cast
+from pex.venv.virtualenv import InstallationChoice, Virtualenv
 from testing import IS_PYPY
 from testing.cli import run_pex3
 from testing.pytest_utils.tmp import Tempdir
 
 
-@pytest.mark.skipif(
-    IS_PYPY or sys.version_info < (3, 8),
-    reason=(
-        "Use of uv is required and uv only supports Python >= 3.8 and the `undill` script does not "
-        "work with PyPy."
-    ),
-)
-def test_uv_too_long_data_scripts_shebang(tmpdir):
-    # type: (Tempdir) -> None
+def assert_bin_sh_shebang(venv):
+    # type: (Virtualenv) -> None
+    with open(venv.bin_path("undill")) as fp:
+        assert "#!/bin/sh\n" == fp.readline()
 
-    uv_venv_dir = tmpdir.join("uv-venv", "too-long", "x" * max(1, 128 - len(tmpdir.path)))
-    subprocess.check_call(
-        args=[
-            "uv",
-            "venv",
-            "--python",
-            "{major}.{minor}".format(major=sys.version_info[0], minor=sys.version_info[1]),
-            uv_venv_dir,
-        ]
-    )
 
-    uv_venv = Virtualenv(uv_venv_dir)
-    subprocess.check_call(
-        args=["uv", "pip", "install", "--python", uv_venv.interpreter.binary, "dill"]
-    )
-
+def assert_venv_repository_from(
+    tmpdir,  # type: Tempdir
+    venv,  # type: Virtualenv
+):
     pickled = tmpdir.join("hello.pkl")
-    uv_venv.interpreter.execute(
+    venv.interpreter.execute(
         args=[
             "-c",
             dedent(
@@ -68,7 +54,7 @@ def test_uv_too_long_data_scripts_shebang(tmpdir):
         "--dest-dir",
         pex_venv_dir,
         "--venv-repository",
-        uv_venv_dir,
+        venv.venv_dir,
         "--pre",
         "dill",
     ).assert_success()
@@ -77,9 +63,69 @@ def test_uv_too_long_data_scripts_shebang(tmpdir):
 
     def assert_undill_works():
         assert b"['hello', 'world']\n" == subprocess.check_output(
-            args=[pex_venv.bin_path("undill"), pickled]
+            args=[(pex_venv.bin_path("undill")), pickled]
         )
 
     assert_undill_works()
-    shutil.rmtree(uv_venv_dir)
+    shutil.rmtree(venv.venv_dir)
     assert_undill_works()
+
+
+def create_too_long_venv_dir(tmpdir):
+    # type: (...) -> str
+    venv_dir = tmpdir.join("venv", "too-long")
+    venv_dir = os.path.join(venv_dir, "x" * max(1, 256 - len(venv_dir)))
+    assert len(venv_dir) > 256
+    return cast(str, venv_dir)
+
+
+skip_for_pypy = pytest.mark.skipif(IS_PYPY, reason="The `undill` script does not work with PyPy.")
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 8), reason="Use of uv is required and uv only supports Python >= 3.8."
+)
+@skip_for_pypy
+def test_uv_too_long_data_scripts_shebang(tmpdir):
+    # type: (Tempdir) -> None
+
+    uv_venv_dir = create_too_long_venv_dir(tmpdir)
+    subprocess.check_call(
+        args=[
+            "uv",
+            "venv",
+            "--python",
+            "{major}.{minor}".format(major=sys.version_info[0], minor=sys.version_info[1]),
+            uv_venv_dir,
+        ]
+    )
+
+    uv_venv = Virtualenv(uv_venv_dir)
+    subprocess.check_call(
+        args=["uv", "pip", "install", "--python", uv_venv.interpreter.binary, "dill"]
+    )
+
+    assert_bin_sh_shebang(uv_venv)
+    assert_venv_repository_from(tmpdir, uv_venv)
+
+
+@skip_for_pypy
+def test_pip_too_long_data_scripts_shebang(tmpdir):
+    pip_venv_dir = create_too_long_venv_dir(tmpdir)
+    pip_venv = Virtualenv.create(venv_dir=pip_venv_dir, install_pip=InstallationChoice.YES)
+    pip_venv.interpreter.execute(args=["-m", "pip", "install", "dill"])
+
+    # N.B.: As of this writing no version of Pip re-writes #!python in data scripts using a
+    # `#!/bin/sh` re-director script: https://github.com/pypa/pip/issues/13389
+    # As such, we do not `assert_bin_sh_shebang`.
+    assert_venv_repository_from(tmpdir, pip_venv)
+
+
+@skip_for_pypy
+def test_pex_too_long_data_scripts_shebang(tmpdir):
+    pex_root = tmpdir.join("pex-root")
+    pex_venv_dir = create_too_long_venv_dir(tmpdir)
+    run_pex3("venv", "create", "--pex-root", pex_root, "-d", pex_venv_dir, "dill").assert_success()
+
+    pex_venv = Virtualenv(pex_venv_dir)
+    assert_bin_sh_shebang(pex_venv)
+    assert_venv_repository_from(tmpdir, pex_venv)

--- a/tests/integration/test_issue_3248.py
+++ b/tests/integration/test_issue_3248.py
@@ -11,6 +11,7 @@ from textwrap import dedent
 
 import pytest
 
+from pex.interpreter import MAX_SHEBANG_LENGTH
 from pex.typing import cast
 from pex.venv.virtualenv import InstallationChoice, Virtualenv
 from testing import IS_PYPY
@@ -74,8 +75,8 @@ def assert_venv_repository_from(
 def create_too_long_venv_dir(tmpdir):
     # type: (...) -> str
     venv_dir = tmpdir.join("venv", "too-long")
-    venv_dir = os.path.join(venv_dir, "x" * max(1, 256 - len(venv_dir)))
-    assert len(venv_dir) > 256
+    venv_dir = os.path.join(venv_dir, "x" * max(1, MAX_SHEBANG_LENGTH - len(venv_dir)))
+    assert len(venv_dir) > MAX_SHEBANG_LENGTH
     return cast(str, venv_dir)
 
 

--- a/tests/integration/test_issue_3248.py
+++ b/tests/integration/test_issue_3248.py
@@ -75,7 +75,13 @@ def assert_venv_repository_from(
 def create_too_long_venv_dir(tmpdir):
     # type: (...) -> str
     venv_dir = tmpdir.join("venv", "too-long")
-    venv_dir = os.path.join(venv_dir, "x" * max(1, MAX_SHEBANG_LENGTH - len(venv_dir)))
+    while len(venv_dir) < MAX_SHEBANG_LENGTH:
+        # N.B.: Instead of adding one extra directory to make up the remaining length needed to
+        # break MAX_SHEBANG_LENGTH, we limit directory names to 127 characters to not run afoul of
+        # max filename lengths in the process. The 127 is chosen at ~1/2 255 which is the expected
+        # real limit on both Linux and macOS.
+        extra = min(127, max(1, MAX_SHEBANG_LENGTH - len(venv_dir)))
+        venv_dir = os.path.join(venv_dir, "x" * extra)
     assert len(venv_dir) > MAX_SHEBANG_LENGTH
     return cast(str, venv_dir)
 

--- a/tests/integration/test_issue_3248.py
+++ b/tests/integration/test_issue_3248.py
@@ -81,6 +81,7 @@ def create_too_long_venv_dir(tmpdir):
 
 skip_for_pypy = pytest.mark.skipif(IS_PYPY, reason="The `undill` script does not work with PyPy.")
 
+
 @pytest.mark.skipif(
     sys.version_info < (3, 8), reason="Use of uv is required and uv only supports Python >= 3.8."
 )


### PR DESCRIPTION
This follows up on #3249 with improved test coverage including Pip and
Pex venvs as well as handling for Python script encoding lines.