### PR TITLE
Preserve file encoding for `#!/bin/sh` re-director scripts.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 2.100.7
+
+Finalize improvements of `#!/bin/sh` re-director scripts by ensuring custom script file encodings
+are preserved round trip.
+
+* Preserve file encoding for `#!/bin/sh` re-director scripts. (#3254)
+
 ## 2.100.6
 
 Further improve handling of `#!/bin/sh` re-director scripts.

--- a/pex/interpreter.py
+++ b/pex/interpreter.py
@@ -1741,17 +1741,18 @@ def create_shebang(
     """
     python = "{exe} {args}".format(exe=python_exe, args=python_args) if python_args else python_exe
     shebang = "#!{python}".format(python=python)
+    stripped_encoding_line = encoding_line.rstrip()
 
     # N.B.: We add 1 to be conservative and account for the EOL character.
     if WINDOWS or len(shebang) + 1 <= max_shebang_length:
-        return shebang
+        return "\n".join((shebang, stripped_encoding_line)) if stripped_encoding_line else shebang
 
     lines = []
     shebang, body = create_sh_python_redirector_shebang(
         'exec {python} "$0" "$@"'.format(python=python)
     )
     lines.append(shebang)
-    if encoding_line:
-        lines.append(encoding_line)
+    if stripped_encoding_line:
+        lines.append(stripped_encoding_line)
     lines.append(body)
     return "\n".join(lines)

--- a/pex/pep_427.py
+++ b/pex/pep_427.py
@@ -1087,20 +1087,24 @@ def install_wheel(
                 dst_installed_file = create_dst_installed_file(regenerate_hash=True)
             elif rewrite_script and interpreter is None:
                 with open(src_file, mode="rb") as in_fp, safe_open(dst_file, "wb") as out_fp:
-                    first_line = in_fp.readline()
-                    if re.match(br"#!/bin/sh", first_line):
+                    encoding_line = ""
+                    if b"#!/bin/sh" == in_fp.readline().rstrip():
                         # This is a too-long-shebang re-director script as identified by
                         # `is_python_script` above; so we need to discard all lines that make up
                         # that script - which are enclosed in a python `'''` string also consumable
                         # by `sh`.
-                        next_line = in_fp.readline()  # Initial `'''` line or encoding line
-                        if maybe_read_encoding_line(next_line):
+                        encoding_line = maybe_read_encoding_line(
+                            in_fp.readline()
+                        )  # Initial `'''` line or encoding line
+                        if encoding_line:
                             in_fp.readline()  # Initial `'''` line
                         while True:
                             next_line = in_fp.readline()
                             if not next_line or next_line.endswith(b"'''\n"):
                                 break
                     out_fp.write(b"#!python\n")
+                    if encoding_line:
+                        out_fp.write(encoding_line.encode("ascii"))
                     shutil.copyfileobj(in_fp, out_fp)
 
                 # We modified the script shebang; so we need to re-hash / re-size.

--- a/pex/version.py
+++ b/pex/version.py
@@ -1,4 +1,4 @@
 # Copyright 2015 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-__version__ = "2.100.6"
+__version__ = "2.100.7"

--- a/tests/integration/test_issue_3248.py
+++ b/tests/integration/test_issue_3248.py
@@ -13,6 +13,7 @@ from textwrap import dedent
 import pytest
 
 from pex.common import safe_open
+from pex.compatibility import to_unicode
 from pex.dist_metadata import ProjectNameAndVersion
 from pex.interpreter import MAX_SHEBANG_LENGTH
 from pex.typing import TYPE_CHECKING, cast
@@ -155,18 +156,15 @@ def custom_script_wheel(tmpdir):
 
     project_dir = tmpdir.join("project")
     with safe_open(os.path.join(project_dir, "script"), "wb") as fp:
-        # These bytes are:
-        # ---
-        # #!python
-        # coding=windows-1252
-        # print("��")
-        # ---
-        # Where the printed chars are <euro><trademark>; i.e.: €™
-        fp.write(
-            b"\x23\x21\x70\x79\x74\x68\x6f\x6e\n"
-            b"\x23\x20\x63\x6f\x64\x69\x6e\x67\x3d\x77\x69\x6e\x64\x6f\x77\x73\x2d\x31\x32\x35\x32\n"
-            b"\x70\x72\x69\x6e\x74\x28\x22\x80\x99\x22\x29\n"
-        )
+        # The \x80\x99 in windows-1252 are <euro><trademark>; i.e.: €™
+        # These bytes are picked since they differ in UTF-8 and are <PAD><SGCI> there; i.e.:
+        # non-printing characters.
+        fp.write(b"#!python\n" b"# coding=windows-1252\n")
+        fp.write(b'print("\x80\x99"')
+        if sys.version_info[0] == 2:
+            fp.write(b'.decode("windows-1252").encode("utf-8")')
+        fp.write(b")\n")
+
     with safe_open(os.path.join(project_dir, "setup.py"), "w") as fp:
         fp.write(
             dedent(
@@ -212,7 +210,9 @@ def custom_script_requirement(custom_script_wheel):
 
 def assert_custom_script_works(venv):
     # type: (Virtualenv) -> None
-    assert "€™\n" == subprocess.check_output(args=[(venv.bin_path("script"))]).decode("utf-8")
+    assert to_unicode("€™\n") == subprocess.check_output(args=[(venv.bin_path("script"))]).decode(
+        "utf-8"
+    )
 
 
 def assert_custom_script_repository_from(

--- a/tests/integration/test_issue_3248.py
+++ b/tests/integration/test_issue_3248.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # Copyright 2026 Pex project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
@@ -11,21 +12,29 @@ from textwrap import dedent
 
 import pytest
 
+from pex.common import safe_open
+from pex.dist_metadata import ProjectNameAndVersion
 from pex.interpreter import MAX_SHEBANG_LENGTH
-from pex.typing import cast
+from pex.typing import TYPE_CHECKING, cast
 from pex.venv.virtualenv import InstallationChoice, Virtualenv
-from testing import IS_PYPY
+from testing import IS_PYPY, WheelBuilder
 from testing.cli import run_pex3
 from testing.pytest_utils.tmp import Tempdir
 
-
-def assert_bin_sh_shebang(venv):
-    # type: (Virtualenv) -> None
-    with open(venv.bin_path("undill")) as fp:
-        assert "#!/bin/sh\n" == fp.readline()
+if TYPE_CHECKING:
+    from typing import Text
 
 
-def assert_venv_repository_from(
+def assert_bin_sh_shebang(
+    venv,  # type: Virtualenv
+    script,  # type: str
+):
+    # type: (...) -> None
+    with open(venv.bin_path(script), "rb") as fp:
+        assert b"#!/bin/sh\n" == fp.readline()
+
+
+def assert_undill_venv_repository_from(
     tmpdir,  # type: Tempdir
     venv,  # type: Virtualenv
 ):
@@ -86,12 +95,13 @@ def create_too_long_venv_dir(tmpdir):
     return cast(str, venv_dir)
 
 
+skip_if_uv_not_supported = pytest.mark.skipif(
+    sys.version_info < (3, 8), reason="Use of uv is required and uv only supports Python >= 3.8."
+)
 skip_for_pypy = pytest.mark.skipif(IS_PYPY, reason="The `undill` script does not work with PyPy.")
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 8), reason="Use of uv is required and uv only supports Python >= 3.8."
-)
+@skip_if_uv_not_supported
 @skip_for_pypy
 def test_uv_too_long_data_scripts_shebang(tmpdir):
     # type: (Tempdir) -> None
@@ -112,8 +122,8 @@ def test_uv_too_long_data_scripts_shebang(tmpdir):
         args=["uv", "pip", "install", "--python", uv_venv.interpreter.binary, "dill"]
     )
 
-    assert_bin_sh_shebang(uv_venv)
-    assert_venv_repository_from(tmpdir, uv_venv)
+    assert_bin_sh_shebang(uv_venv, script="undill")
+    assert_undill_venv_repository_from(tmpdir, uv_venv)
 
 
 @skip_for_pypy
@@ -125,7 +135,7 @@ def test_pip_too_long_data_scripts_shebang(tmpdir):
     # N.B.: As of this writing no version of Pip re-writes #!python in data scripts using a
     # `#!/bin/sh` re-director script: https://github.com/pypa/pip/issues/13389
     # As such, we do not `assert_bin_sh_shebang`.
-    assert_venv_repository_from(tmpdir, pip_venv)
+    assert_undill_venv_repository_from(tmpdir, pip_venv)
 
 
 @skip_for_pypy
@@ -135,5 +145,178 @@ def test_pex_too_long_data_scripts_shebang(tmpdir):
     run_pex3("venv", "create", "--pex-root", pex_root, "-d", pex_venv_dir, "dill").assert_success()
 
     pex_venv = Virtualenv(pex_venv_dir)
-    assert_bin_sh_shebang(pex_venv)
-    assert_venv_repository_from(tmpdir, pex_venv)
+    assert_bin_sh_shebang(pex_venv, script="undill")
+    assert_undill_venv_repository_from(tmpdir, pex_venv)
+
+
+@pytest.fixture
+def custom_script_wheel(tmpdir):
+    # type: (Tempdir) -> str
+
+    project_dir = tmpdir.join("project")
+    with safe_open(os.path.join(project_dir, "script"), "wb") as fp:
+        # These bytes are:
+        # ---
+        # #!python
+        # coding=windows-1252
+        # print("��")
+        # ---
+        # Where the printed chars are <euro><trademark>; i.e.: €™
+        fp.write(
+            b"\x23\x21\x70\x79\x74\x68\x6f\x6e\n"
+            b"\x23\x20\x63\x6f\x64\x69\x6e\x67\x3d\x77\x69\x6e\x64\x6f\x77\x73\x2d\x31\x32\x35\x32\n"
+            b"\x70\x72\x69\x6e\x74\x28\x22\x80\x99\x22\x29\n"
+        )
+    with safe_open(os.path.join(project_dir, "setup.py"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                from setuptools import setup
+
+
+                setup()
+                """
+            )
+        )
+    with safe_open(os.path.join(project_dir, "setup.cfg"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                [metadata]
+                name = custom_encoding_data_script
+                version = 0.1.0
+
+                [options]
+                scripts = script
+                """
+            )
+        )
+    with safe_open(os.path.join(project_dir, "pyproject.toml"), "w") as fp:
+        fp.write(
+            dedent(
+                """\
+                [build-system]
+                build-backend = "setuptools.build_meta"
+                requires = ["setuptools"]
+                """
+            )
+        )
+    return WheelBuilder(project_dir).bdist()
+
+
+@pytest.fixture
+def custom_script_requirement(custom_script_wheel):
+    # type: (str) -> Text
+    return ProjectNameAndVersion.from_filename(custom_script_wheel).project_name
+
+
+def assert_custom_script_works(venv):
+    # type: (Virtualenv) -> None
+    assert "€™\n" == subprocess.check_output(args=[(venv.bin_path("script"))]).decode("utf-8")
+
+
+def assert_custom_script_repository_from(
+    tmpdir,  # type: Tempdir
+    venv,  # type: Virtualenv
+    custom_script_requirement,  # type: str
+):
+    # type: (...) -> None
+
+    pex_root = tmpdir.join("pex-root")
+    pex_venv_dir = tmpdir.join("pex-venv")
+    run_pex3(
+        "venv",
+        "create",
+        "--pex-root",
+        pex_root,
+        "--dest-dir",
+        pex_venv_dir,
+        "--venv-repository",
+        venv.venv_dir,
+        custom_script_requirement,
+    ).assert_success()
+
+    pex_venv = Virtualenv(pex_venv_dir)
+    assert_custom_script_works(pex_venv)
+    shutil.rmtree(venv.venv_dir)
+    assert_custom_script_works(pex_venv)
+
+
+@skip_if_uv_not_supported
+def test_uv_too_long_data_scripts_shebang_custom_script_encoding(
+    tmpdir,  # type: Tempdir
+    custom_script_wheel,  # type: str
+    custom_script_requirement,  # type: str
+):
+    # type: (...) -> None
+
+    uv_venv_dir = create_too_long_venv_dir(tmpdir)
+    subprocess.check_call(
+        args=[
+            "uv",
+            "venv",
+            "--python",
+            "{major}.{minor}".format(major=sys.version_info[0], minor=sys.version_info[1]),
+            uv_venv_dir,
+        ]
+    )
+
+    uv_venv = Virtualenv(uv_venv_dir)
+    subprocess.check_call(
+        args=["uv", "pip", "install", "--python", uv_venv.interpreter.binary, custom_script_wheel]
+    )
+
+    assert_bin_sh_shebang(uv_venv, script="script")
+
+    # N.B.: We do not `assert_custom_script_works(uv_venv) because uv incorrectly maps:
+    # ---
+    # #!python
+    # # coding=XXX
+    # ---
+    # To:
+    # ---
+    # #!/bin/sh
+    # '''exec' ...
+    # '''
+    # # coding=XXX
+    # ---
+    # In other words - it does not put the `# coding=XXX` line 2nd after the shebang - which is required for Python to
+    # read it and interpret the script Python code using the XXX encoding.
+
+    assert_custom_script_repository_from(tmpdir, uv_venv, custom_script_requirement)
+
+
+def test_pip_too_long_data_scripts_shebang_custom_script_encoding(
+    tmpdir,  # type: Tempdir
+    custom_script_wheel,  # type: str
+    custom_script_requirement,  # type: str
+):
+    pip_venv_dir = create_too_long_venv_dir(tmpdir)
+    pip_venv = Virtualenv.create(venv_dir=pip_venv_dir, install_pip=InstallationChoice.YES)
+    pip_venv.interpreter.execute(args=["-m", "pip", "install", custom_script_wheel])
+
+    # N.B.: As of this writing no version of Pip re-writes #!python in data scripts using a
+    # `#!/bin/sh` re-director script: https://github.com/pypa/pip/issues/13389
+    # As such, we do not `assert_bin_sh_shebang`.
+
+    assert_custom_script_works(pip_venv)
+    assert_custom_script_repository_from(tmpdir, pip_venv, custom_script_requirement)
+
+
+def test_pex_too_long_data_scripts_shebang_custom_script_encoding(
+    tmpdir,  # type: Tempdir
+    custom_script_wheel,  # type: str
+    custom_script_requirement,  # type: str
+):
+    # type: (...) -> None
+
+    pex_root = tmpdir.join("pex-root")
+    pex_venv_repository_dir = create_too_long_venv_dir(tmpdir)
+    run_pex3(
+        "venv", "create", "--pex-root", pex_root, "-d", pex_venv_repository_dir, custom_script_wheel
+    ).assert_success()
+
+    pex_venv_repository = Virtualenv(pex_venv_repository_dir)
+    assert_bin_sh_shebang(pex_venv_repository, script="script")
+    assert_custom_script_works(pex_venv_repository)
+    assert_custom_script_repository_from(tmpdir, pex_venv_repository, custom_script_requirement)

--- a/tests/integration/test_issue_3248.py
+++ b/tests/integration/test_issue_3248.py
@@ -18,7 +18,7 @@ from pex.dist_metadata import ProjectNameAndVersion
 from pex.interpreter import MAX_SHEBANG_LENGTH
 from pex.typing import TYPE_CHECKING, cast
 from pex.venv.virtualenv import InstallationChoice, Virtualenv
-from testing import IS_PYPY, WheelBuilder
+from testing import IS_LINUX, IS_PYPY, WheelBuilder
 from testing.cli import run_pex3
 from testing.pytest_utils.tmp import Tempdir
 
@@ -210,7 +210,7 @@ def custom_script_requirement(custom_script_wheel):
 
 def assert_custom_script_works(venv):
     # type: (Virtualenv) -> None
-    assert to_unicode("€™\n") == subprocess.check_output(args=[(venv.bin_path("script"))]).decode(
+    assert to_unicode("€™\n") == subprocess.check_output(args=[venv.bin_path("script")]).decode(
         "utf-8"
     )
 
@@ -299,7 +299,13 @@ def test_pip_too_long_data_scripts_shebang_custom_script_encoding(
     # `#!/bin/sh` re-director script: https://github.com/pypa/pip/issues/13389
     # As such, we do not `assert_bin_sh_shebang`.
 
-    assert_custom_script_works(pip_venv)
+    if IS_LINUX:
+        # This does not work on macOS for unknown reasons at this time. Looks like:
+        # OSError: [Errno 8] Exec format error: '/private/var/folders/_5/zjnzxgh147qcg3bb5cg2wvqw0000gn/T/pytest-of-runner/pytest-0/popen-gw0/test_pip_too_long_data_s-104740/venv/too-long/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/bin/script'
+        assert_custom_script_works(pip_venv)
+    else:
+        with open(pip_venv.bin_path("script")) as fp:
+            sys.stderr.write(fp.read())
     assert_custom_script_repository_from(tmpdir, pip_venv, custom_script_requirement)
 
 

--- a/tests/integration/test_issue_3248.py
+++ b/tests/integration/test_issue_3248.py
@@ -15,10 +15,9 @@ import pytest
 from pex.common import safe_open
 from pex.compatibility import to_unicode
 from pex.dist_metadata import ProjectNameAndVersion
-from pex.interpreter import MAX_SHEBANG_LENGTH
 from pex.typing import TYPE_CHECKING, cast
 from pex.venv.virtualenv import InstallationChoice, Virtualenv
-from testing import IS_LINUX, IS_PYPY, WheelBuilder
+from testing import IS_PYPY, WheelBuilder
 from testing.cli import run_pex3
 from testing.pytest_utils.tmp import Tempdir
 
@@ -80,6 +79,10 @@ def assert_undill_venv_repository_from(
     assert_undill_works()
     shutil.rmtree(venv.venv_dir)
     assert_undill_works()
+
+
+# N.B.: This covers Linux in standard configurations (generally 255) as well as macOS (511).
+MAX_SHEBANG_LENGTH = 512
 
 
 def create_too_long_venv_dir(tmpdir):
@@ -280,8 +283,8 @@ def test_uv_too_long_data_scripts_shebang_custom_script_encoding(
     # '''
     # # coding=XXX
     # ---
-    # In other words - it does not put the `# coding=XXX` line 2nd after the shebang - which is required for Python to
-    # read it and interpret the script Python code using the XXX encoding.
+    # In other words - it does not put the `# coding=XXX` line 2nd after the shebang - which is
+    # required for Python to read it and interpret the script Python code using the XXX encoding.
 
     assert_custom_script_repository_from(tmpdir, uv_venv, custom_script_requirement)
 
@@ -297,15 +300,9 @@ def test_pip_too_long_data_scripts_shebang_custom_script_encoding(
 
     # N.B.: As of this writing no version of Pip re-writes #!python in data scripts using a
     # `#!/bin/sh` re-director script: https://github.com/pypa/pip/issues/13389
-    # As such, we do not `assert_bin_sh_shebang`.
+    # As such, we do not `assert_bin_sh_shebang(pip_venv)` or
+    # `assert_custom_script_works(pip_venv)`.
 
-    if IS_LINUX:
-        # This does not work on macOS for unknown reasons at this time. Looks like:
-        # OSError: [Errno 8] Exec format error: '/private/var/folders/_5/zjnzxgh147qcg3bb5cg2wvqw0000gn/T/pytest-of-runner/pytest-0/popen-gw0/test_pip_too_long_data_s-104740/venv/too-long/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/bin/script'
-        assert_custom_script_works(pip_venv)
-    else:
-        with open(pip_venv.bin_path("script")) as fp:
-            sys.stderr.write(fp.read())
     assert_custom_script_repository_from(tmpdir, pip_venv, custom_script_requirement)
 
 


### PR DESCRIPTION
This is the final follow-up to #3249 and #3252; ensuring data scripts
with a declared custom file encoding keep that declaration when
round-tripped.